### PR TITLE
Consume spaces + enable footnotes

### DIFF
--- a/corpus/text_mode.txt
+++ b/corpus/text_mode.txt
@@ -34,6 +34,34 @@ fubar\quux[opt]{bar} wibble
     (text_group (begin_group) (text) (end_group))
     (text)))
 
+==================
+Single command with spaces
+==================
+fubar\quux  {bar} wibble
+---
+
+(document
+  (text_mode
+    (text)
+    (token)
+    (text_group (begin_group) (text) (end_group))
+    (text)))
+
+
+==================
+Single command with arguments and spaces (TODO: Resolve design choice)
+==================
+fubar\quux  [opt]  {bar} wibble
+---
+
+(document
+  (text_mode
+    (text)
+    (token)
+    (opt_text_group (begin_opt) (text) (end_opt)) (text)
+    (text_group (begin_group) (text) (end_group))
+    (text)))
+
 =============
 Active char
 =============
@@ -221,4 +249,19 @@ foo\texttt{bar}wibble
   (text_mode
     (text)
     (texttt (texttt_token) (text_group (begin_group) (text) (end_group)))
+    (text)))
+
+=====================
+footnote
+=====================
+foo\footnote{bar}wibble
+foo\footnote[10]{bar}wibble
+---------------------
+(document
+  (text_mode
+    (text)
+    (footnote (footnote_token) (text_group (begin_group) (text) (end_group))) (text)
+    (footnote (footnote_token)
+      (opt_text_group (begin_opt) (text) (end_opt))
+      (text_group (begin_group) (text) (end_group)))
     (text)))

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,11 @@
+const named_command = ($, name) => seq($._escape, name, optional($._whitespace))
+
+const command_options = ($) => optional(seq($.opt_text_group, optional($._whitespace)))
+const command_options_at = ($) => optional(seq($.opt_text_group_at, optional($._whitespace)))
+
+const env_options = ($) => command_options($)
+const env_options_at = ($) => command_options_at($)
+
 module.exports = grammar({
   name: 'latex',
 
@@ -46,7 +54,8 @@ module.exports = grammar({
       $.section,
       $.storage,
       $.usepackage,
-      $.token
+      $.token,
+      $.footnote
     ),
 
     text_mode: $ => repeat1($._text_mode),
@@ -67,7 +76,8 @@ module.exports = grammar({
       $.section_at,
       $.storage,
       $.usepackage,
-      $.token_at
+      $.token_at,
+      $.footnote_at
     ),
 
     text_mode_at: $ => prec.left(2, repeat1($._text_mode_at)),
@@ -162,13 +172,13 @@ module.exports = grammar({
       $.end_display_math
     ),
 
-    begin_display_math: $ => seq($._escape, '['),
+    begin_display_math: $ => named_command($, '['),
 
-    end_display_math: $ => seq($._escape, ']'),
+    end_display_math: $ => named_command($, ']'),
 
-    begin_inline_math: $ => seq($._escape, '('),
+    begin_inline_math: $ => named_command($, '('),
 
-    end_inline_math: $ => seq($._escape, ')'),
+    end_inline_math: $ => named_command($, ')'),
 
     display_math_env: $ => seq(
       $.display_math_begin,
@@ -185,7 +195,7 @@ module.exports = grammar({
     display_math_begin: $ => seq(
       $.begin_token,
       $.display_math_env_group,
-      optional($.opt_text_group),
+      env_options($),
       optional($.text_group),
       $._end_of_line
     ),
@@ -193,7 +203,7 @@ module.exports = grammar({
     display_math_begin_at: $ => seq(
       $.begin_token,
       $.display_math_env_group,
-      optional($.opt_text_group_at),
+      env_options_at($),
       optional($.text_group_at),
       $._end_of_line
     ),
@@ -273,7 +283,7 @@ module.exports = grammar({
 
     tag_at: $ => seq($.tag_token, $.math_text_group_at),
 
-    tag_token: $ => seq($._escape, 'tag'),
+    tag_token: $ => named_command($, 'tag'),
 
     verbatim_env: $ => seq(
       $.verbatim_begin,
@@ -284,7 +294,7 @@ module.exports = grammar({
     verbatim_begin: $ => seq(
       $.begin_token,
       $.verbatim_env_group,
-      optional($.opt_text_group),
+      env_options($),
       optional($.text_group),
       $._end_of_line
     ),
@@ -308,27 +318,27 @@ module.exports = grammar({
 
     begin: $ => seq($.begin_token, alias($.simple_text_group, 'env_name')),
 
-    begin_token: $ => seq($._escape, 'begin'),
+    begin_token: $ => named_command($, 'begin'),
 
     end: $ => seq($.end_token, alias($.simple_text_group, 'env_name')),
 
-    end_token: $ => seq($._escape, 'end'),
+    end_token: $ => named_command($, 'end'),
 
     documentclass: $ => seq(
       $.documentclass_token,
-      optional($.opt_text_group),
+      command_options($),
       alias($.simple_text_group, 'class_name')
     ),
 
-    documentclass_token: $ => seq($._escape, 'documentclass'),
+    documentclass_token: $ => named_command($, 'documentclass'),
 
     usepackage: $ => seq(
       $.usepackage_token,
-      optional($.opt_text_group),
+      command_options($),
       alias($.simple_text_group, 'package_name')
     ),
 
-    usepackage_token: $ => seq($._escape, 'usepackage'),
+    usepackage_token: $ => named_command($, 'usepackage'),
 
     include: $ => seq($.include_token, $.text_group),
 
@@ -336,9 +346,9 @@ module.exports = grammar({
 
     include_token: $ => seq($._escape, /include|input/),
 
-    section: $ => seq($.section_token, optional($.opt_text_group), $.text_group),
+    section: $ => seq($.section_token, command_options($), $.text_group),
 
-    section_at: $ => seq($.section_token, optional($.opt_text_group_at), $.text_group_at),
+    section_at: $ => seq($.section_token, command_options_at($), $.text_group_at),
 
     section_token: $ => seq(
       $._escape,
@@ -359,39 +369,39 @@ module.exports = grammar({
 
     emph_at: $ => seq($.emph_token, $.text_group_at),
 
-    emph_token: $ => seq($._escape, 'emph'),
+    emph_token: $ => named_command($, 'emph'),
 
-    footnote: $ => seq($.footnote_token, $.opt_text_group, $.text_group),
+    footnote: $ => seq($.footnote_token, command_options($), $.text_group),
 
-    footnote_at: $ => seq($.footnote_token, $.opt_text_group_at, $.text_group_at),
+    footnote_at: $ => seq($.footnote_token, command_options_at($), $.text_group_at),
 
-    footnote_token: $ => seq($._escape, 'footnote'),
+    footnote_token: $ => named_command($, 'footnote'),
 
     textbf: $ => seq($.textbf_token, $.text_group),
 
     textbf_at: $ => seq($.textbf_token, $.text_group_at),
 
-    textbf_token: $ => seq($._escape, 'textbf'),
+    textbf_token: $ => named_command($, 'textbf'),
 
     textit: $ => seq($.textit_token, $.text_group),
 
     textit_at: $ => seq($.textit_token, $.text_group_at),
 
-    textit_token: $ => seq($._escape, 'textit'),
+    textit_token: $ => named_command($, 'textit'),
 
     texttt: $ => seq($.texttt_token, $.text_group),
 
     texttt_at: $ => seq($.texttt_token, $.text_group_at),
 
-    texttt_token: $ => seq($._escape, 'texttt'),
+    texttt_token: $ => named_command($, 'texttt'),
 
     makeatletter: $ => $.makeatletter_token,
 
-    makeatletter_token: $ => seq($._escape, 'makeatletter'),
+    makeatletter_token: $ => named_command($, 'makeatletter'),
 
     makeatother: $ => $.makeatother_token,
 
-    makeatother_token: $ => seq($._escape, 'makeatother'),
+    makeatother_token: $ => named_command($, 'makeatother'),
 
     text_group: $ => seq(
       $.begin_group, repeat($._text_mode), $.end_group
@@ -437,9 +447,9 @@ module.exports = grammar({
       $.begin_group, optional($.text_mode_at), $.end_group
     ),
 
-    token: $ => seq($._escape, $._name),
+    token: $ => seq($._escape, $._name, optional($._whitespace)),
 
-    token_at: $ => seq($._escape, $._name_at),
+    token_at: $ => seq($._escape, $._name_at, optional($._whitespace)),
 
     magic_comment: $ => /%\s*!T[eE]X\s+.*/,
 
@@ -459,7 +469,7 @@ module.exports = grammar({
     superscript: $ => '^',
     subscript: $ => '_',
     //ignored_character: //,
-    // space: $ => /[ \t]/,
+    _whitespace: $ => /[ \t]+/,
     // letter: $ => /[a-zA-Z]/,
     _name: $ => /[a-zA-Z]+/,
     _name_at: $ => /[a-zA-Z@]+/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -143,6 +143,10 @@
         {
           "type": "SYMBOL",
           "name": "token"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "footnote"
         }
       ]
     },
@@ -219,6 +223,10 @@
         {
           "type": "SYMBOL",
           "name": "token_at"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "footnote_at"
         }
       ]
     },
@@ -592,6 +600,18 @@
         {
           "type": "STRING",
           "value": "["
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -605,6 +625,18 @@
         {
           "type": "STRING",
           "value": "]"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -618,6 +650,18 @@
         {
           "type": "STRING",
           "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -631,6 +675,18 @@
         {
           "type": "STRING",
           "value": ")"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -688,8 +744,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -729,8 +802,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group_at"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group_at"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1008,6 +1098,18 @@
         {
           "type": "STRING",
           "value": "tag"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1051,8 +1153,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1171,6 +1290,18 @@
         {
           "type": "STRING",
           "value": "begin"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1202,6 +1333,18 @@
         {
           "type": "STRING",
           "value": "end"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1216,8 +1359,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1245,6 +1405,18 @@
         {
           "type": "STRING",
           "value": "documentclass"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1259,8 +1431,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1288,6 +1477,18 @@
         {
           "type": "STRING",
           "value": "usepackage"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1341,8 +1542,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1366,8 +1584,25 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "opt_text_group_at"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group_at"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
               "type": "BLANK"
@@ -1480,6 +1715,18 @@
         {
           "type": "STRING",
           "value": "emph"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1491,8 +1738,33 @@
           "name": "footnote_token"
         },
         {
-          "type": "SYMBOL",
-          "name": "opt_text_group"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -1508,8 +1780,33 @@
           "name": "footnote_token"
         },
         {
-          "type": "SYMBOL",
-          "name": "opt_text_group_at"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "opt_text_group_at"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -1527,6 +1824,18 @@
         {
           "type": "STRING",
           "value": "footnote"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1566,6 +1875,18 @@
         {
           "type": "STRING",
           "value": "textbf"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1605,6 +1926,18 @@
         {
           "type": "STRING",
           "value": "textit"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1644,6 +1977,18 @@
         {
           "type": "STRING",
           "value": "texttt"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1661,6 +2006,18 @@
         {
           "type": "STRING",
           "value": "makeatletter"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1678,6 +2035,18 @@
         {
           "type": "STRING",
           "value": "makeatother"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1918,6 +2287,18 @@
         {
           "type": "SYMBOL",
           "name": "_name"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1931,6 +2312,18 @@
         {
           "type": "SYMBOL",
           "name": "_name_at"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },
@@ -1985,6 +2378,10 @@
     "subscript": {
       "type": "STRING",
       "value": "_"
+    },
+    "_whitespace": {
+      "type": "PATTERN",
+      "value": "[ \\t]+"
     },
     "_name": {
       "type": "PATTERN",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -124,11 +124,8 @@
       ]
     },
     "_whitespace": {
-      "type": "REPEAT1",
-      "content": {
-        "type": "PATTERN",
-        "value": "[\\s\\t]"
-      }
+      "type": "PATTERN",
+      "value": "[ \\t]+"
     },
     "_text_mode": {
       "type": "CHOICE",
@@ -2438,10 +2435,6 @@
     "subscript": {
       "type": "STRING",
       "value": "_"
-    },
-    "_whitespace": {
-      "type": "PATTERN",
-      "value": "[ \\t]+"
     },
     "_name": {
       "type": "PATTERN",

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,12 +6,12 @@
 #endif
 
 #define LANGUAGE_VERSION 9
-#define STATE_COUNT 291
-#define SYMBOL_COUNT 151
+#define STATE_COUNT 339
+#define SYMBOL_COUNT 156
 #define ALIAS_COUNT 4
-#define TOKEN_COUNT 42
+#define TOKEN_COUNT 44
 #define EXTERNAL_TOKEN_COUNT 0
-#define MAX_ALIAS_SEQUENCE_LENGTH 3
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
 
 enum {
   anon_sym_LBRACK = 1,
@@ -34,140 +34,145 @@ enum {
   anon_sym_EQ = 18,
   aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH = 19,
   anon_sym_emph = 20,
-  anon_sym_textbf = 21,
-  anon_sym_textit = 22,
-  anon_sym_texttt = 23,
-  anon_sym_makeatletter = 24,
-  anon_sym_makeatother = 25,
-  sym_magic_comment = 26,
-  sym_comment = 27,
-  sym__escape = 28,
-  sym_begin_group = 29,
-  sym_end_group = 30,
-  sym_math_shift = 31,
-  sym_alignment_tab = 32,
-  sym__end_of_line = 33,
-  sym_parameter_char = 34,
-  sym_superscript = 35,
-  sym_subscript = 36,
-  sym__name = 37,
-  sym__name_at = 38,
-  sym_active_char = 39,
-  sym_text = 40,
-  sym_number = 41,
-  sym_document = 42,
-  sym__common = 43,
-  sym__text_mode_common = 44,
-  sym__text_mode = 45,
-  sym_text_mode = 46,
-  sym__text_mode_at = 47,
-  sym_text_mode_at = 48,
-  sym_text_mode_at_region = 49,
-  sym__math_mode_common = 50,
-  sym__math_mode = 51,
-  sym_math_mode = 52,
-  sym__math_mode_at = 53,
-  sym_math_mode_at = 54,
-  sym_parameter = 55,
-  sym_text_env = 56,
-  sym_text_env_at = 57,
-  sym_math_env = 58,
-  sym_math_env_at = 59,
-  sym__display_math = 60,
-  sym__display_math_at = 61,
-  sym_tex_display_math = 62,
-  sym_tex_display_math_at = 63,
-  sym_latex_display_math = 64,
-  sym_latex_display_math_at = 65,
-  sym_begin_display_math = 66,
-  sym_end_display_math = 67,
-  sym_begin_inline_math = 68,
-  sym_end_inline_math = 69,
-  sym_display_math_env = 70,
-  sym_display_math_env_at = 71,
-  sym_display_math_begin = 72,
-  sym_display_math_begin_at = 73,
-  sym_display_math_end = 74,
-  sym_display_math_env_group = 75,
-  sym__inline_math = 76,
-  sym__inline_math_at = 77,
-  sym_tex_inline_math = 78,
-  sym_tex_inline_math_at = 79,
-  sym_latex_inline_math = 80,
-  sym_latex_inline_math_at = 81,
-  sym_inline_math_env = 82,
-  sym_inline_math_env_at = 83,
-  sym_inline_math_begin = 84,
-  sym_inline_math_end = 85,
-  sym_inline_math_env_group = 86,
-  sym_tag = 87,
-  sym_tag_at = 88,
-  sym_tag_token = 89,
-  sym_verbatim_env = 90,
-  sym_verbatim_begin = 91,
-  sym_verbatim_end = 92,
-  sym_verbatim_text = 93,
-  sym_verbatim_env_group = 94,
-  sym_escaped = 95,
-  sym_begin = 96,
-  sym_begin_token = 97,
-  sym_end = 98,
-  sym_end_token = 99,
-  sym_documentclass = 100,
-  sym_documentclass_token = 101,
-  sym_usepackage = 102,
-  sym_usepackage_token = 103,
-  sym_include = 104,
-  sym_include_at = 105,
-  sym_include_token = 106,
-  sym_section = 107,
-  sym_section_at = 108,
-  sym_section_token = 109,
-  sym_storage = 110,
-  sym_storage_token = 111,
-  sym_catcode = 112,
-  sym_catcode_token = 113,
-  sym_emph = 114,
-  sym_emph_at = 115,
-  sym_emph_token = 116,
-  sym_textbf = 117,
-  sym_textbf_at = 118,
-  sym_textbf_token = 119,
-  sym_textit = 120,
-  sym_textit_at = 121,
-  sym_textit_token = 122,
-  sym_texttt = 123,
-  sym_texttt_at = 124,
-  sym_texttt_token = 125,
-  sym_makeatletter = 126,
-  sym_makeatletter_token = 127,
-  sym_makeatother = 128,
-  sym_makeatother_token = 129,
-  sym_text_group = 130,
-  sym_text_group_at = 131,
-  sym_simple_text_group = 132,
-  sym_opt_text_group = 133,
-  sym_opt_text_group_at = 134,
-  sym_math_group = 135,
-  sym_math_group_at = 136,
-  sym_opt_math_group = 137,
-  sym_opt_math_group_at = 138,
-  sym_math_text_group = 139,
-  sym_math_text_group_at = 140,
-  sym_token = 141,
-  sym_token_at = 142,
-  sym_begin_opt = 143,
-  sym_end_opt = 144,
-  aux_sym_text_mode_repeat1 = 145,
-  aux_sym_text_mode_at_repeat1 = 146,
-  aux_sym_math_mode_repeat1 = 147,
-  aux_sym_math_mode_at_repeat1 = 148,
-  aux_sym_verbatim_text_repeat1 = 149,
-  aux_sym_verbatim_text_repeat2 = 150,
-  anon_alias_sym_class_name = 151,
-  anon_alias_sym_env_name = 152,
-  anon_alias_sym_package_name = 153,
-  anon_alias_sym_text = 154,
+  anon_sym_footnote = 21,
+  anon_sym_textbf = 22,
+  anon_sym_textit = 23,
+  anon_sym_texttt = 24,
+  anon_sym_makeatletter = 25,
+  anon_sym_makeatother = 26,
+  sym_magic_comment = 27,
+  sym_comment = 28,
+  sym__escape = 29,
+  sym_begin_group = 30,
+  sym_end_group = 31,
+  sym_math_shift = 32,
+  sym_alignment_tab = 33,
+  sym__end_of_line = 34,
+  sym_parameter_char = 35,
+  sym_superscript = 36,
+  sym_subscript = 37,
+  sym__whitespace = 38,
+  sym__name = 39,
+  sym__name_at = 40,
+  sym_active_char = 41,
+  sym_text = 42,
+  sym_number = 43,
+  sym_document = 44,
+  sym__common = 45,
+  sym__text_mode_common = 46,
+  sym__text_mode = 47,
+  sym_text_mode = 48,
+  sym__text_mode_at = 49,
+  sym_text_mode_at = 50,
+  sym_text_mode_at_region = 51,
+  sym__math_mode_common = 52,
+  sym__math_mode = 53,
+  sym_math_mode = 54,
+  sym__math_mode_at = 55,
+  sym_math_mode_at = 56,
+  sym_parameter = 57,
+  sym_text_env = 58,
+  sym_text_env_at = 59,
+  sym_math_env = 60,
+  sym_math_env_at = 61,
+  sym__display_math = 62,
+  sym__display_math_at = 63,
+  sym_tex_display_math = 64,
+  sym_tex_display_math_at = 65,
+  sym_latex_display_math = 66,
+  sym_latex_display_math_at = 67,
+  sym_begin_display_math = 68,
+  sym_end_display_math = 69,
+  sym_begin_inline_math = 70,
+  sym_end_inline_math = 71,
+  sym_display_math_env = 72,
+  sym_display_math_env_at = 73,
+  sym_display_math_begin = 74,
+  sym_display_math_begin_at = 75,
+  sym_display_math_end = 76,
+  sym_display_math_env_group = 77,
+  sym__inline_math = 78,
+  sym__inline_math_at = 79,
+  sym_tex_inline_math = 80,
+  sym_tex_inline_math_at = 81,
+  sym_latex_inline_math = 82,
+  sym_latex_inline_math_at = 83,
+  sym_inline_math_env = 84,
+  sym_inline_math_env_at = 85,
+  sym_inline_math_begin = 86,
+  sym_inline_math_end = 87,
+  sym_inline_math_env_group = 88,
+  sym_tag = 89,
+  sym_tag_at = 90,
+  sym_tag_token = 91,
+  sym_verbatim_env = 92,
+  sym_verbatim_begin = 93,
+  sym_verbatim_end = 94,
+  sym_verbatim_text = 95,
+  sym_verbatim_env_group = 96,
+  sym_escaped = 97,
+  sym_begin = 98,
+  sym_begin_token = 99,
+  sym_end = 100,
+  sym_end_token = 101,
+  sym_documentclass = 102,
+  sym_documentclass_token = 103,
+  sym_usepackage = 104,
+  sym_usepackage_token = 105,
+  sym_include = 106,
+  sym_include_at = 107,
+  sym_include_token = 108,
+  sym_section = 109,
+  sym_section_at = 110,
+  sym_section_token = 111,
+  sym_storage = 112,
+  sym_storage_token = 113,
+  sym_catcode = 114,
+  sym_catcode_token = 115,
+  sym_emph = 116,
+  sym_emph_at = 117,
+  sym_emph_token = 118,
+  sym_footnote = 119,
+  sym_footnote_at = 120,
+  sym_footnote_token = 121,
+  sym_textbf = 122,
+  sym_textbf_at = 123,
+  sym_textbf_token = 124,
+  sym_textit = 125,
+  sym_textit_at = 126,
+  sym_textit_token = 127,
+  sym_texttt = 128,
+  sym_texttt_at = 129,
+  sym_texttt_token = 130,
+  sym_makeatletter = 131,
+  sym_makeatletter_token = 132,
+  sym_makeatother = 133,
+  sym_makeatother_token = 134,
+  sym_text_group = 135,
+  sym_text_group_at = 136,
+  sym_simple_text_group = 137,
+  sym_opt_text_group = 138,
+  sym_opt_text_group_at = 139,
+  sym_math_group = 140,
+  sym_math_group_at = 141,
+  sym_opt_math_group = 142,
+  sym_opt_math_group_at = 143,
+  sym_math_text_group = 144,
+  sym_math_text_group_at = 145,
+  sym_token = 146,
+  sym_token_at = 147,
+  sym_begin_opt = 148,
+  sym_end_opt = 149,
+  aux_sym_text_mode_repeat1 = 150,
+  aux_sym_text_mode_at_repeat1 = 151,
+  aux_sym_math_mode_repeat1 = 152,
+  aux_sym_math_mode_at_repeat1 = 153,
+  aux_sym_verbatim_text_repeat1 = 154,
+  aux_sym_verbatim_text_repeat2 = 155,
+  anon_alias_sym_class_name = 156,
+  anon_alias_sym_env_name = 157,
+  anon_alias_sym_package_name = 158,
+  anon_alias_sym_text = 159,
 };
 
 static const char *ts_symbol_names[] = {
@@ -192,6 +197,7 @@ static const char *ts_symbol_names[] = {
   [anon_sym_EQ] = "=",
   [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = "/k?catcode`/",
   [anon_sym_emph] = "emph",
+  [anon_sym_footnote] = "footnote",
   [anon_sym_textbf] = "textbf",
   [anon_sym_textit] = "textit",
   [anon_sym_texttt] = "texttt",
@@ -208,6 +214,7 @@ static const char *ts_symbol_names[] = {
   [sym_parameter_char] = "parameter_char",
   [sym_superscript] = "superscript",
   [sym_subscript] = "subscript",
+  [sym__whitespace] = "_whitespace",
   [sym__name] = "_name",
   [sym__name_at] = "_name_at",
   [sym_active_char] = "active_char",
@@ -288,6 +295,9 @@ static const char *ts_symbol_names[] = {
   [sym_emph] = "emph",
   [sym_emph_at] = "emph_at",
   [sym_emph_token] = "emph_token",
+  [sym_footnote] = "footnote",
+  [sym_footnote_at] = "footnote_at",
+  [sym_footnote_token] = "footnote_token",
   [sym_textbf] = "textbf",
   [sym_textbf_at] = "textbf_at",
   [sym_textbf_token] = "textbf_token",
@@ -413,6 +423,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
+  [anon_sym_footnote] = {
+    .visible = true,
+    .named = false,
+  },
   [anon_sym_textbf] = {
     .visible = true,
     .named = false,
@@ -475,6 +489,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym_subscript] = {
     .visible = true,
+    .named = true,
+  },
+  [sym__whitespace] = {
+    .visible = false,
     .named = true,
   },
   [sym__name] = {
@@ -797,6 +815,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_footnote] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_footnote_at] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_footnote_token] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_textbf] = {
     .visible = true,
     .named = true,
@@ -951,7 +981,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-static TSSymbol ts_alias_sequences[7][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static TSSymbol ts_alias_sequences[9][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [1] = {
     [0] = anon_alias_sym_text,
   },
@@ -969,6 +999,12 @@ static TSSymbol ts_alias_sequences[7][MAX_ALIAS_SEQUENCE_LENGTH] = {
   },
   [6] = {
     [2] = anon_alias_sym_package_name,
+  },
+  [7] = {
+    [3] = anon_alias_sym_class_name,
+  },
+  [8] = {
+    [3] = anon_alias_sym_package_name,
   },
 };
 
@@ -1277,31 +1313,33 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(70);
       if (lookahead == 'e')
         ADVANCE(85);
-      if (lookahead == 'i')
+      if (lookahead == 'f')
         ADVANCE(90);
+      if (lookahead == 'i')
+        ADVANCE(98);
       if (lookahead == 'k')
-        ADVANCE(99);
+        ADVANCE(107);
       if (lookahead == 'm')
-        ADVANCE(101);
+        ADVANCE(109);
       if (lookahead == 'p')
-        ADVANCE(116);
-      if (lookahead == 's')
         ADVANCE(124);
+      if (lookahead == 's')
+        ADVANCE(132);
       if (lookahead == 't')
-        ADVANCE(139);
+        ADVANCE(147);
       if (lookahead == 'u')
-        ADVANCE(149);
+        ADVANCE(157);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(159);
+        ADVANCE(167);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(160);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(168);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
     case 38:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
@@ -1719,7 +1757,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 90:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'n')
+      if (lookahead == 'o')
         ADVANCE(91);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1727,17 +1765,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 91:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 'o')
         ADVANCE(92);
-      if (lookahead == 'p')
-        ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'l')
+      if (lookahead == 't')
         ADVANCE(93);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1745,7 +1781,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'u')
+      if (lookahead == 'n')
         ADVANCE(94);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1753,7 +1789,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'd')
+      if (lookahead == 'o')
         ADVANCE(95);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1761,63 +1797,63 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(96);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(46);
-      END_STATE();
-    case 96:
-      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(46);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'u')
-        ADVANCE(98);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(46);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(sym__name);
       if (lookahead == 't')
         ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 99:
+    case 96:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(97);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 97:
+      ACCEPT_TOKEN(anon_sym_footnote);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 98:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'n')
+        ADVANCE(99);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 99:
+      ACCEPT_TOKEN(sym__name);
       if (lookahead == 'c')
         ADVANCE(100);
+      if (lookahead == 'p')
+        ADVANCE(105);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 100:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(58);
+      if (lookahead == 'l')
+        ADVANCE(101);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 101:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'u')
         ADVANCE(102);
-      if (lookahead == 'i')
-        ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 102:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'k')
+      if (lookahead == 'd')
         ADVANCE(103);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1832,16 +1868,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(46);
       END_STATE();
     case 104:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(105);
+      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 105:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'u')
         ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1849,15 +1883,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'l')
-        ADVANCE(107);
+      if (lookahead == 't')
+        ADVANCE(104);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 107:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'c')
         ADVANCE(108);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1865,23 +1899,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 108:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
-        ADVANCE(109);
+      if (lookahead == 'a')
+        ADVANCE(58);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 109:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
         ADVANCE(110);
+      if (lookahead == 'i')
+        ADVANCE(121);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 110:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      if (lookahead == 'k')
         ADVANCE(111);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1889,21 +1925,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 'e')
         ADVANCE(112);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 112:
-      ACCEPT_TOKEN(anon_sym_makeatletter);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'a')
+        ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 113:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'n')
+      if (lookahead == 't')
         ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1911,7 +1949,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'i')
+      if (lookahead == 'l')
         ADVANCE(115);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1919,23 +1957,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 's')
-        ADVANCE(50);
+      if (lookahead == 'e')
+        ADVANCE(116);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 116:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 't')
         ADVANCE(117);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 117:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 't')
         ADVANCE(118);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1943,41 +1981,37 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 'e')
         ADVANCE(119);
-      if (lookahead == 't')
-        ADVANCE(45);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'g')
+      if (lookahead == 'r')
         ADVANCE(120);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 120:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
-        ADVANCE(121);
+      ACCEPT_TOKEN(anon_sym_makeatletter);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 121:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 'n')
         ADVANCE(122);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
+      if (lookahead == 'i')
         ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1985,25 +2019,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'h')
-        ADVANCE(45);
+      if (lookahead == 's')
+        ADVANCE(50);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 124:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      if (lookahead == 'a')
         ADVANCE(125);
-      if (lookahead == 'u')
-        ADVANCE(130);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 'r')
         ADVANCE(126);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2011,15 +2043,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(127);
+      if (lookahead == 't')
+        ADVANCE(45);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'i')
+      if (lookahead == 'g')
         ADVANCE(128);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2027,7 +2061,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'o')
+      if (lookahead == 'r')
         ADVANCE(129);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2035,15 +2069,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'n')
-        ADVANCE(45);
+      if (lookahead == 'a')
+        ADVANCE(130);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
+      if (lookahead == 'p')
         ADVANCE(131);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2051,25 +2085,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
-        ADVANCE(132);
-      if (lookahead == 's')
-        ADVANCE(135);
+      if (lookahead == 'h')
+        ADVANCE(45);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 132:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(133);
+      if (lookahead == 'u')
+        ADVANCE(138);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 133:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 'c')
         ADVANCE(134);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2077,17 +2111,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(119);
+      if (lookahead == 't')
+        ADVANCE(135);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(125);
-      if (lookahead == 'u')
+      if (lookahead == 'i')
         ADVANCE(136);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2095,7 +2127,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
+      if (lookahead == 'o')
         ADVANCE(137);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2103,39 +2135,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 's')
-        ADVANCE(138);
+      if (lookahead == 'n')
+        ADVANCE(45);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(125);
+      if (lookahead == 'b')
+        ADVANCE(139);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 139:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'p')
         ADVANCE(140);
+      if (lookahead == 's')
+        ADVANCE(143);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'x')
+      if (lookahead == 'a')
         ADVANCE(141);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'r')
         ADVANCE(142);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2143,61 +2177,65 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
-        ADVANCE(143);
-      if (lookahead == 'i')
-        ADVANCE(145);
-      if (lookahead == 't')
-        ADVANCE(147);
+      if (lookahead == 'a')
+        ADVANCE(127);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'f')
+      if (lookahead == 'e')
+        ADVANCE(133);
+      if (lookahead == 'u')
         ADVANCE(144);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 144:
-      ACCEPT_TOKEN(anon_sym_textbf);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'b')
+        ADVANCE(145);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 145:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 's')
         ADVANCE(146);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 146:
-      ACCEPT_TOKEN(anon_sym_textit);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(133);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(148);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(anon_sym_texttt);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'x')
+        ADVANCE(149);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 's')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 't')
         ADVANCE(150);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2205,75 +2243,137 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 150:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      if (lookahead == 'b')
         ADVANCE(151);
+      if (lookahead == 'i')
+        ADVANCE(153);
+      if (lookahead == 't')
+        ADVANCE(155);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 151:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
+      if (lookahead == 'f')
         ADVANCE(152);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 152:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(153);
+      ACCEPT_TOKEN(anon_sym_textbf);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 153:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 't')
         ADVANCE(154);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 154:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'k')
-        ADVANCE(155);
+      ACCEPT_TOKEN(anon_sym_textit);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 155:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 't')
         ADVANCE(156);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 156:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'g')
-        ADVANCE(157);
+      ACCEPT_TOKEN(anon_sym_texttt);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 157:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 's')
         ADVANCE(158);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(anon_sym_usepackage);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(159);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
     case 159:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'p')
+        ADVANCE(160);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'a')
+        ADVANCE(161);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'c')
+        ADVANCE(162);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'k')
+        ADVANCE(163);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 163:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'a')
+        ADVANCE(164);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 164:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'g')
+        ADVANCE(165);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(166);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(anon_sym_usepackage);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(46);
+      END_STATE();
+    case 167:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(86);
@@ -2281,16 +2381,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 160:
+    case 168:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 161:
+    case 169:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       END_STATE();
-    case 162:
+    case 170:
       if (lookahead == '#')
         ADVANCE(3);
       if (lookahead == '$')
@@ -2317,18 +2417,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (lookahead < '[' || lookahead > '_'))
         ADVANCE(35);
       END_STATE();
-    case 163:
+    case 171:
       if (lookahead == '%')
         ADVANCE(20);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(164);
+        ADVANCE(172);
       END_STATE();
-    case 164:
+    case 172:
       ACCEPT_TOKEN(sym_number);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(164);
+        ADVANCE(172);
       END_STATE();
-    case 165:
+    case 173:
       if (lookahead == 0)
         ADVANCE(1);
       if (lookahead == '#')
@@ -2357,13 +2457,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(32);
       ADVANCE(35);
       END_STATE();
-    case 166:
+    case 174:
       if (lookahead == 0)
         ADVANCE(1);
       if (lookahead == '%')
         ADVANCE(20);
       END_STATE();
-    case 167:
+    case 175:
       if (lookahead == '\n')
         ADVANCE(2);
       if (lookahead == '%')
@@ -2373,36 +2473,100 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0)
         ADVANCE(33);
       END_STATE();
-    case 168:
+    case 176:
+      if (lookahead == 0)
+        ADVANCE(1);
+      if (lookahead == '#')
+        ADVANCE(3);
+      if (lookahead == '$')
+        ADVANCE(4);
+      if (lookahead == '%')
+        ADVANCE(20);
+      if (lookahead == '&')
+        ADVANCE(21);
+      if (lookahead == '[')
+        ADVANCE(25);
+      if (lookahead == '\\')
+        ADVANCE(26);
+      if (lookahead == ']')
+        ADVANCE(27);
+      if (lookahead == '^')
+        ADVANCE(28);
+      if (lookahead == '_')
+        ADVANCE(29);
+      if (lookahead == '{')
+        ADVANCE(30);
+      if (lookahead == '}')
+        ADVANCE(31);
+      if (lookahead == '~')
+        ADVANCE(32);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(177);
+      ADVANCE(35);
+      END_STATE();
+    case 177:
+      ACCEPT_TOKEN(sym__whitespace);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(177);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 178:
+      if (lookahead == '\n')
+        ADVANCE(2);
+      if (lookahead == '%')
+        ADVANCE(20);
+      if (lookahead == '[')
+        ADVANCE(25);
+      if (lookahead == '{')
+        ADVANCE(30);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(179);
+      END_STATE();
+    case 179:
+      ACCEPT_TOKEN(sym__whitespace);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(179);
+      END_STATE();
+    case 180:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == 'b')
         ADVANCE(52);
       if (lookahead == 'c')
-        ADVANCE(169);
+        ADVANCE(181);
       if (lookahead == 'd')
-        ADVANCE(170);
+        ADVANCE(182);
       if (lookahead == 'i')
-        ADVANCE(90);
+        ADVANCE(98);
       if (lookahead == 'k')
-        ADVANCE(99);
+        ADVANCE(107);
       if (lookahead == 't')
-        ADVANCE(171);
+        ADVANCE(183);
       if (lookahead == 'e' ||
           lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(159);
+        ADVANCE(167);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(160);
+        ADVANCE(168);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < 'A' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 169:
+    case 181:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
         ADVANCE(58);
@@ -2410,7 +2574,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 170:
+    case 182:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'e')
         ADVANCE(71);
@@ -2418,46 +2582,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 171:
+    case 183:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(172);
+        ADVANCE(184);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 172:
+    case 184:
       ACCEPT_TOKEN(sym__name);
       if (lookahead == 'g')
-        ADVANCE(173);
+        ADVANCE(185);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 173:
+    case 185:
       ACCEPT_TOKEN(anon_sym_tag);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 174:
+    case 186:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'e')
-        ADVANCE(175);
+        ADVANCE(187);
       END_STATE();
-    case 175:
+    case 187:
       if (lookahead == 'n')
-        ADVANCE(176);
+        ADVANCE(188);
       END_STATE();
-    case 176:
+    case 188:
       if (lookahead == 'd')
-        ADVANCE(177);
+        ADVANCE(189);
       END_STATE();
-    case 177:
+    case 189:
       ACCEPT_TOKEN(anon_sym_end);
       END_STATE();
-    case 178:
+    case 190:
       if (lookahead == '\n')
         ADVANCE(2);
       if (lookahead == '%')
@@ -2465,7 +2629,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0)
         ADVANCE(33);
       END_STATE();
-    case 179:
+    case 191:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == '(')
@@ -2481,227 +2645,87 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'd')
         ADVANCE(70);
       if (lookahead == 'e')
-        ADVANCE(180);
-      if (lookahead == 'i')
+        ADVANCE(192);
+      if (lookahead == 'f')
         ADVANCE(90);
+      if (lookahead == 'i')
+        ADVANCE(98);
       if (lookahead == 'k')
-        ADVANCE(99);
+        ADVANCE(107);
       if (lookahead == 'm')
-        ADVANCE(101);
+        ADVANCE(109);
       if (lookahead == 'p')
-        ADVANCE(116);
-      if (lookahead == 's')
         ADVANCE(124);
+      if (lookahead == 's')
+        ADVANCE(132);
       if (lookahead == 't')
-        ADVANCE(139);
+        ADVANCE(147);
       if (lookahead == 'u')
-        ADVANCE(149);
+        ADVANCE(157);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(159);
+        ADVANCE(167);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(160);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(168);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 180:
+    case 192:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(86);
       if (lookahead == 'm')
         ADVANCE(87);
       if (lookahead == 'n')
-        ADVANCE(181);
+        ADVANCE(193);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 181:
+    case 193:
       ACCEPT_TOKEN(sym__name);
       if (lookahead == 'd')
-        ADVANCE(182);
+        ADVANCE(194);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 182:
+    case 194:
       ACCEPT_TOKEN(anon_sym_end);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 183:
+    case 195:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'V')
-        ADVANCE(184);
+        ADVANCE(196);
       if (lookahead == 'a')
-        ADVANCE(193);
+        ADVANCE(205);
       if (lookahead == 'd')
-        ADVANCE(201);
+        ADVANCE(213);
       if (lookahead == 'e')
-        ADVANCE(227);
+        ADVANCE(239);
       if (lookahead == 'f')
-        ADVANCE(235);
+        ADVANCE(247);
       if (lookahead == 'g')
-        ADVANCE(240);
+        ADVANCE(252);
       if (lookahead == 'l')
-        ADVANCE(245);
+        ADVANCE(257);
       if (lookahead == 'm')
-        ADVANCE(254);
+        ADVANCE(266);
       if (lookahead == 's')
-        ADVANCE(269);
+        ADVANCE(281);
       if (lookahead == 'v')
-        ADVANCE(272);
+        ADVANCE(284);
       if (lookahead == 'B' ||
           lookahead == 'L')
-        ADVANCE(279);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 184:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
-        ADVANCE(185);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 185:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(186);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 186:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'b')
-        ADVANCE(187);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 187:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(188);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 188:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(189);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 189:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(190);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 190:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
-        ADVANCE(191);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 191:
-      ACCEPT_TOKEN(sym_verbatim_env_name);
-      if (lookahead == '*')
-        ADVANCE(192);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 192:
-      ACCEPT_TOKEN(sym_verbatim_env_name);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 193:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
-        ADVANCE(194);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(195);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(35);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
-        ADVANCE(196);
+        ADVANCE(291);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2712,7 +2736,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 196:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'e')
         ADVANCE(197);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2723,11 +2747,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(sym_display_math_env_name);
-      if (lookahead == '*')
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r')
         ADVANCE(198);
-      if (lookahead == 'a')
-        ADVANCE(199);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2737,7 +2759,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(sym_display_math_env_name);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'b')
+        ADVANCE(199);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2748,7 +2772,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 199:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(200);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2759,9 +2783,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(sym_display_math_env_name);
-      if (lookahead == '*')
-        ADVANCE(198);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 't')
+        ADVANCE(201);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2772,16 +2796,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 201:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(202);
-      if (lookahead == 'g')
-        ADVANCE(206);
       if (lookahead == 'i')
-        ADVANCE(210);
-      if (lookahead == 'm')
-        ADVANCE(219);
-      if (lookahead == 's')
-        ADVANCE(222);
+        ADVANCE(202);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2792,7 +2808,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 202:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'm')
         ADVANCE(203);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2803,8 +2819,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      ACCEPT_TOKEN(sym_verbatim_env_name);
+      if (lookahead == '*')
         ADVANCE(204);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2815,9 +2831,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(205);
+      ACCEPT_TOKEN(sym_verbatim_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2828,8 +2842,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 205:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'y')
-        ADVANCE(200);
+      if (lookahead == 'l')
+        ADVANCE(206);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2840,7 +2854,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 206:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'i')
         ADVANCE(207);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2852,7 +2866,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 207:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'o')
+      if (lookahead == 'g')
         ADVANCE(208);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2864,7 +2878,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 208:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'u')
+      if (lookahead == 'n')
         ADVANCE(209);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2875,9 +2889,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 209:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
-        ADVANCE(200);
+      ACCEPT_TOKEN(sym_display_math_env_name);
+      if (lookahead == '*')
+        ADVANCE(210);
+      if (lookahead == 'a')
+        ADVANCE(211);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2887,9 +2903,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 210:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
-        ADVANCE(211);
+      ACCEPT_TOKEN(sym_display_math_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2900,7 +2914,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
+      if (lookahead == 't')
         ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2911,9 +2925,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 212:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
-        ADVANCE(213);
+      ACCEPT_TOKEN(sym_display_math_env_name);
+      if (lookahead == '*')
+        ADVANCE(210);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2926,6 +2940,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_text);
       if (lookahead == 'a')
         ADVANCE(214);
+      if (lookahead == 'g')
+        ADVANCE(218);
+      if (lookahead == 'i')
+        ADVANCE(222);
+      if (lookahead == 'm')
+        ADVANCE(231);
+      if (lookahead == 's')
+        ADVANCE(234);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2936,7 +2958,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 214:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'y')
+      if (lookahead == 'r')
         ADVANCE(215);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2948,7 +2970,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 215:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
+      if (lookahead == 'r')
         ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2972,8 +2994,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 217:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(218);
+      if (lookahead == 'y')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2984,8 +3006,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 218:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
-        ADVANCE(198);
+      if (lookahead == 'r')
+        ADVANCE(219);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2996,7 +3018,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 219:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'o')
         ADVANCE(220);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3008,7 +3030,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 220:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'u')
         ADVANCE(221);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3020,8 +3042,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 221:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
-        ADVANCE(200);
+      if (lookahead == 'p')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3032,7 +3054,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 222:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 's')
         ADVANCE(223);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3044,7 +3066,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 223:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'p')
         ADVANCE(224);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3056,7 +3078,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 224:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'l')
         ADVANCE(225);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3068,7 +3090,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 225:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'a')
         ADVANCE(226);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3080,8 +3102,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 226:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
-        ADVANCE(200);
+      if (lookahead == 'y')
+        ADVANCE(227);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3092,7 +3114,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 227:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'q')
+      if (lookahead == 'm')
         ADVANCE(228);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3104,10 +3126,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 228:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'a')
         ADVANCE(229);
-      if (lookahead == 'u')
-        ADVANCE(230);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3118,8 +3138,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 229:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(202);
+      if (lookahead == 't')
+        ADVANCE(230);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3130,8 +3150,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 230:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(231);
+      if (lookahead == 'h')
+        ADVANCE(210);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3142,7 +3162,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 231:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(232);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3154,7 +3174,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 232:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 't')
         ADVANCE(233);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3166,8 +3186,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 233:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'o')
-        ADVANCE(234);
+      if (lookahead == 'h')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3178,8 +3198,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 234:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
-        ADVANCE(200);
+      if (lookahead == 'e')
+        ADVANCE(235);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3190,7 +3210,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 235:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'r')
         ADVANCE(236);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3202,7 +3222,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 236:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'i')
         ADVANCE(237);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3214,7 +3234,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 237:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'e')
         ADVANCE(238);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3226,8 +3246,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 238:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(239);
+      if (lookahead == 's')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3238,8 +3258,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 239:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
-        ADVANCE(234);
+      if (lookahead == 'q')
+        ADVANCE(240);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3250,8 +3270,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 240:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'n')
         ADVANCE(241);
+      if (lookahead == 'u')
+        ADVANCE(242);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3262,8 +3284,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 241:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(242);
+      if (lookahead == 'a')
+        ADVANCE(214);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3274,7 +3296,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 242:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
+      if (lookahead == 'a')
         ADVANCE(243);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3286,7 +3308,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 243:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 't')
         ADVANCE(244);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3298,8 +3320,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 244:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(200);
+      if (lookahead == 'i')
+        ADVANCE(245);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3310,7 +3332,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 245:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
+      if (lookahead == 'o')
         ADVANCE(246);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3322,8 +3344,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 246:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(247);
+      if (lookahead == 'n')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3346,7 +3368,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 248:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'a')
         ADVANCE(249);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3358,7 +3380,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 249:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
+      if (lookahead == 'l')
         ADVANCE(250);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3370,7 +3392,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 250:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'i')
         ADVANCE(251);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3382,8 +3404,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 251:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(252);
+      if (lookahead == 'g')
+        ADVANCE(246);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3394,7 +3416,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 252:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'a')
         ADVANCE(253);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3406,8 +3428,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 253:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
-        ADVANCE(192);
+      if (lookahead == 't')
+        ADVANCE(254);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3418,12 +3440,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 254:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'h')
         ADVANCE(255);
-      if (lookahead == 'i')
-        ADVANCE(258);
-      if (lookahead == 'u')
-        ADVANCE(262);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3434,7 +3452,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 255:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'e')
         ADVANCE(256);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3446,8 +3464,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 256:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
-        ADVANCE(257);
+      if (lookahead == 'r')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3457,7 +3475,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 257:
-      ACCEPT_TOKEN(sym_inline_math_env_name);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 's')
+        ADVANCE(258);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3468,7 +3488,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 258:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 't')
         ADVANCE(259);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3480,7 +3500,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 259:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'l')
         ADVANCE(260);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3492,7 +3512,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 260:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'i')
         ADVANCE(261);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3504,8 +3524,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 261:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'd')
-        ADVANCE(192);
+      if (lookahead == 's')
+        ADVANCE(262);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3516,7 +3536,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 262:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 't')
         ADVANCE(263);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3528,7 +3548,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 263:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'i')
         ADVANCE(264);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3540,7 +3560,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 264:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'n')
         ADVANCE(265);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3552,8 +3572,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 265:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
-        ADVANCE(266);
+      if (lookahead == 'g')
+        ADVANCE(204);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3564,8 +3584,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 266:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'a')
         ADVANCE(267);
+      if (lookahead == 'i')
+        ADVANCE(270);
+      if (lookahead == 'u')
+        ADVANCE(274);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3576,7 +3600,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 267:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 't')
         ADVANCE(268);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3588,8 +3612,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 268:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
-        ADVANCE(200);
+      if (lookahead == 'h')
+        ADVANCE(269);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3599,9 +3623,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 269:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
-        ADVANCE(270);
+      ACCEPT_TOKEN(sym_inline_math_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3612,7 +3634,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 270:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'n')
         ADVANCE(271);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3624,8 +3646,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 271:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(199);
+      if (lookahead == 't')
+        ADVANCE(272);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3648,8 +3670,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 273:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(274);
+      if (lookahead == 'd')
+        ADVANCE(204);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3660,7 +3682,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 274:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'b')
+      if (lookahead == 'l')
         ADVANCE(275);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3672,7 +3694,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 275:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 't')
         ADVANCE(276);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3684,7 +3706,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 276:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'i')
         ADVANCE(277);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3696,7 +3718,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 277:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'l')
         ADVANCE(278);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3708,8 +3730,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 278:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
-        ADVANCE(192);
+      if (lookahead == 'i')
+        ADVANCE(279);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3720,8 +3742,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 279:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'V')
-        ADVANCE(184);
+      if (lookahead == 'n')
+        ADVANCE(280);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3731,16 +3753,150 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(35);
       END_STATE();
     case 280:
-      if (lookahead == '\n')
-        ADVANCE(2);
-      if (lookahead == '%')
-        ADVANCE(20);
-      if (lookahead == '[')
-        ADVANCE(25);
-      if (lookahead == '{')
-        ADVANCE(30);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e')
+        ADVANCE(212);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
       END_STATE();
     case 281:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'p')
+        ADVANCE(282);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 282:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l')
+        ADVANCE(283);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 283:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'i')
+        ADVANCE(211);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 284:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e')
+        ADVANCE(285);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 285:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r')
+        ADVANCE(286);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 286:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'b')
+        ADVANCE(287);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 287:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'a')
+        ADVANCE(288);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 't')
+        ADVANCE(289);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'i')
+        ADVANCE(290);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'm')
+        ADVANCE(204);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'V')
+        ADVANCE(196);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(35);
+      END_STATE();
+    case 292:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead != 0 &&
@@ -3748,15 +3904,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ')' &&
           lookahead != '[' &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 282:
+    case 293:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == '=')
         ADVANCE(24);
       END_STATE();
-    case 283:
+    case 294:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == '(')
@@ -3764,344 +3920,258 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(284);
+        ADVANCE(295);
       if (lookahead == 'b')
-        ADVANCE(297);
+        ADVANCE(308);
       if (lookahead == 'c')
-        ADVANCE(302);
+        ADVANCE(313);
       if (lookahead == 'd')
-        ADVANCE(314);
+        ADVANCE(325);
       if (lookahead == 'e')
-        ADVANCE(329);
-      if (lookahead == 'i')
-        ADVANCE(334);
-      if (lookahead == 'k')
-        ADVANCE(343);
-      if (lookahead == 'm')
+        ADVANCE(340);
+      if (lookahead == 'f')
         ADVANCE(345);
+      if (lookahead == 'i')
+        ADVANCE(353);
+      if (lookahead == 'k')
+        ADVANCE(362);
+      if (lookahead == 'm')
+        ADVANCE(364);
       if (lookahead == 'p')
-        ADVANCE(359);
+        ADVANCE(378);
       if (lookahead == 's')
-        ADVANCE(367);
+        ADVANCE(386);
       if (lookahead == 't')
-        ADVANCE(382);
+        ADVANCE(401);
       if (lookahead == 'u')
-        ADVANCE(392);
+        ADVANCE(411);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(402);
+        ADVANCE(421);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(403);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(161);
-      END_STATE();
-    case 284:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'd')
-        ADVANCE(285);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 285:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'd')
-        ADVANCE(286);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 286:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(287);
-      if (lookahead == 'p')
-        ADVANCE(292);
-      if (lookahead == 's')
-        ADVANCE(295);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 287:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
-        ADVANCE(288);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 288:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(289);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 289:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
-        ADVANCE(290);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(sym__name_at);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(293);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(294);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(290);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(169);
       END_STATE();
     case 295:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'd')
         ADVANCE(296);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 296:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(290);
+      if (lookahead == 'd')
+        ADVANCE(297);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 297:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
-        ADVANCE(298);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
-        ADVANCE(299);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 299:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
-        ADVANCE(300);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 300:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
-        ADVANCE(301);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 301:
-      ACCEPT_TOKEN(anon_sym_begin);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 302:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
-        ADVANCE(303);
-      if (lookahead == 'h')
-        ADVANCE(309);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 303:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(304);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 304:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'c')
-        ADVANCE(305);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 305:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
+        ADVANCE(298);
+      if (lookahead == 'p')
+        ADVANCE(303);
+      if (lookahead == 's')
         ADVANCE(306);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 298:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'h')
+        ADVANCE(299);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 299:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(300);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 300:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'p')
+        ADVANCE(301);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 301:
+      ACCEPT_TOKEN(aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 302:
+      ACCEPT_TOKEN(sym__name_at);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 303:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(304);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 304:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
+        ADVANCE(305);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 305:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(301);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'd')
+      if (lookahead == 'e')
         ADVANCE(307);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 307:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(308);
+      if (lookahead == 'c')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 308:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
+        ADVANCE(309);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 309:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'g')
+        ADVANCE(310);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 310:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'i')
+        ADVANCE(311);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 311:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'n')
+        ADVANCE(312);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 312:
+      ACCEPT_TOKEN(anon_sym_begin);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 313:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
+        ADVANCE(314);
+      if (lookahead == 'h')
+        ADVANCE(320);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 314:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(315);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(316);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'o')
+        ADVANCE(317);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'd')
+        ADVANCE(318);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(319);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 319:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == '`')
         ADVANCE(64);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 309:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(310);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 310:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
-        ADVANCE(311);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 311:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(312);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 312:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(313);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 313:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(290);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 314:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
-        ADVANCE(315);
-      if (lookahead == 'o')
-        ADVANCE(317);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 315:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'f')
-        ADVANCE(316);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 316:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 317:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(318);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 318:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
-        ADVANCE(319);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 319:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'm')
-        ADVANCE(320);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 320:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 'a')
         ADVANCE(321);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 321:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
+      if (lookahead == 'p')
         ADVANCE(322);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 322:
       ACCEPT_TOKEN(sym__name_at);
@@ -4109,535 +4179,527 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(323);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 323:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 'e')
         ADVANCE(324);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'l')
-        ADVANCE(325);
+      if (lookahead == 'r')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 325:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(326);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 326:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
-        ADVANCE(327);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 327:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
+      if (lookahead == 'o')
         ADVANCE(328);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 328:
-      ACCEPT_TOKEN(anon_sym_documentclass);
+    case 326:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'f')
+        ADVANCE(327);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 327:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 328:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(329);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 329:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'd')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'u')
         ADVANCE(330);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 330:
+      ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'm')
         ADVANCE(331);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 330:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(315);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 331:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
+      if (lookahead == 'e')
         ADVANCE(332);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
+      if (lookahead == 'n')
         ADVANCE(333);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 333:
-      ACCEPT_TOKEN(anon_sym_emph);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(334);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 334:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'n')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
         ADVANCE(335);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 335:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 'l')
         ADVANCE(336);
-      if (lookahead == 'p')
-        ADVANCE(341);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 336:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'l')
+      if (lookahead == 'a')
         ADVANCE(337);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 337:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
+      if (lookahead == 's')
         ADVANCE(338);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'd')
+      if (lookahead == 's')
         ADVANCE(339);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 339:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(340);
+      ACCEPT_TOKEN(anon_sym_documentclass);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 340:
-      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 341:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'd')
+        ADVANCE(341);
+      if (lookahead == 'm')
         ADVANCE(342);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 341:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(326);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 342:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(340);
+      if (lookahead == 'p')
+        ADVANCE(343);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 343:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'c')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'h')
         ADVANCE(344);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 344:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(303);
+      ACCEPT_TOKEN(anon_sym_emph);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      if (lookahead == 'o')
         ADVANCE(346);
-      if (lookahead == 'i')
-        ADVANCE(356);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 346:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'k')
+      if (lookahead == 'o')
         ADVANCE(347);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 't')
         ADVANCE(348);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 348:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 'n')
         ADVANCE(349);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'o')
         ADVANCE(350);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 350:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
+      if (lookahead == 't')
         ADVANCE(351);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 351:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'e')
         ADVANCE(352);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 352:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
-        ADVANCE(353);
+      ACCEPT_TOKEN(anon_sym_footnote);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 353:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'n')
         ADVANCE(354);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 354:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      if (lookahead == 'c')
         ADVANCE(355);
+      if (lookahead == 'p')
+        ADVANCE(360);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 355:
-      ACCEPT_TOKEN(anon_sym_makeatother);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'l')
+        ADVANCE(356);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 356:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
+      if (lookahead == 'u')
         ADVANCE(357);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 357:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
+      if (lookahead == 'd')
         ADVANCE(358);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 358:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
-        ADVANCE(295);
+      if (lookahead == 'e')
+        ADVANCE(359);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 359:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
-        ADVANCE(360);
+      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 360:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      if (lookahead == 'u')
         ADVANCE(361);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 361:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(362);
       if (lookahead == 't')
-        ADVANCE(290);
+        ADVANCE(359);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 362:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'c')
         ADVANCE(363);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 363:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(364);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 364:
-      ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'a')
-        ADVANCE(365);
+        ADVANCE(314);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 364:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
+        ADVANCE(365);
+      if (lookahead == 'i')
+        ADVANCE(375);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 365:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
+      if (lookahead == 'k')
         ADVANCE(366);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 366:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
-        ADVANCE(290);
+      if (lookahead == 'e')
+        ADVANCE(367);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 367:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
         ADVANCE(368);
-      if (lookahead == 'u')
-        ADVANCE(373);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 368:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 't')
         ADVANCE(369);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'o')
         ADVANCE(370);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
+      if (lookahead == 't')
         ADVANCE(371);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
+      if (lookahead == 'h')
         ADVANCE(372);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
-        ADVANCE(290);
+      if (lookahead == 'e')
+        ADVANCE(373);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 373:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
+      if (lookahead == 'r')
         ADVANCE(374);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 374:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
-        ADVANCE(375);
-      if (lookahead == 's')
-        ADVANCE(378);
+      ACCEPT_TOKEN(anon_sym_makeatother);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 375:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 'n')
         ADVANCE(376);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 376:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      if (lookahead == 'i')
         ADVANCE(377);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 377:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(362);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 378:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(368);
-      if (lookahead == 'u')
-        ADVANCE(379);
+      if (lookahead == 's')
+        ADVANCE(306);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 378:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
+        ADVANCE(379);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 379:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
+      if (lookahead == 'r')
         ADVANCE(380);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 380:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
+      if (lookahead == 'a')
         ADVANCE(381);
+      if (lookahead == 't')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 381:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(368);
+      if (lookahead == 'g')
+        ADVANCE(382);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 382:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
         ADVANCE(383);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 383:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'x')
+      if (lookahead == 'a')
         ADVANCE(384);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 384:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'p')
         ADVANCE(385);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 385:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
-        ADVANCE(386);
-      if (lookahead == 'i')
-        ADVANCE(388);
-      if (lookahead == 't')
-        ADVANCE(390);
+      if (lookahead == 'h')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 386:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'f')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(387);
+      if (lookahead == 'u')
+        ADVANCE(392);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 387:
-      ACCEPT_TOKEN(anon_sym_textbf);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(388);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 388:
       ACCEPT_TOKEN(sym__name_at);
@@ -4645,167 +4707,325 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(389);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 389:
-      ACCEPT_TOKEN(anon_sym_textit);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'i')
+        ADVANCE(390);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 390:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'o')
         ADVANCE(391);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 391:
-      ACCEPT_TOKEN(anon_sym_texttt);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'n')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 392:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 's')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'b')
         ADVANCE(393);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 393:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(394);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 394:
-      ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'p')
-        ADVANCE(395);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 395:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(396);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
-      END_STATE();
-    case 396:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+        ADVANCE(394);
+      if (lookahead == 's')
         ADVANCE(397);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
+      END_STATE();
+    case 394:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(395);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 395:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
+        ADVANCE(396);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 396:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(381);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 397:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'k')
+      if (lookahead == 'e')
+        ADVANCE(387);
+      if (lookahead == 'u')
         ADVANCE(398);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 398:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 'b')
         ADVANCE(399);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
       END_STATE();
     case 399:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
+      if (lookahead == 's')
         ADVANCE(400);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 400:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'e')
-        ADVANCE(401);
+        ADVANCE(387);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     case 401:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
+        ADVANCE(402);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 402:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'x')
+        ADVANCE(403);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 403:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(404);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 404:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'b')
+        ADVANCE(405);
+      if (lookahead == 'i')
+        ADVANCE(407);
+      if (lookahead == 't')
+        ADVANCE(409);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 405:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'f')
+        ADVANCE(406);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 406:
+      ACCEPT_TOKEN(anon_sym_textbf);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 407:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(408);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 408:
+      ACCEPT_TOKEN(anon_sym_textit);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 409:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(410);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 410:
+      ACCEPT_TOKEN(anon_sym_texttt);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 411:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 's')
+        ADVANCE(412);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(413);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'p')
+        ADVANCE(414);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(415);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(416);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'k')
+        ADVANCE(417);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(418);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'g')
+        ADVANCE(419);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(420);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(302);
+      END_STATE();
+    case 420:
       ACCEPT_TOKEN(anon_sym_usepackage);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 402:
+    case 421:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(330);
+        ADVANCE(341);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 403:
+    case 422:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 404:
+    case 423:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == 'b')
         ADVANCE(52);
       if (lookahead == 'c')
-        ADVANCE(169);
+        ADVANCE(181);
       if (lookahead == 'd')
-        ADVANCE(170);
+        ADVANCE(182);
       if (lookahead == 'e')
-        ADVANCE(405);
+        ADVANCE(424);
       if (lookahead == 'i')
-        ADVANCE(90);
+        ADVANCE(98);
       if (lookahead == 'k')
-        ADVANCE(99);
+        ADVANCE(107);
       if (lookahead == 't')
-        ADVANCE(171);
+        ADVANCE(183);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(159);
+        ADVANCE(167);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(160);
+        ADVANCE(168);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < 'A' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 405:
+    case 424:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(86);
       if (lookahead == 'n')
-        ADVANCE(181);
+        ADVANCE(193);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(46);
       END_STATE();
-    case 406:
+    case 425:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == ')')
         ADVANCE(23);
       END_STATE();
-    case 407:
+    case 426:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == '(')
@@ -4813,166 +5033,168 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(284);
+        ADVANCE(295);
       if (lookahead == 'b')
-        ADVANCE(297);
+        ADVANCE(308);
       if (lookahead == 'c')
-        ADVANCE(302);
+        ADVANCE(313);
       if (lookahead == 'd')
-        ADVANCE(314);
+        ADVANCE(325);
       if (lookahead == 'e')
-        ADVANCE(329);
+        ADVANCE(340);
+      if (lookahead == 'f')
+        ADVANCE(345);
       if (lookahead == 'i')
-        ADVANCE(334);
+        ADVANCE(353);
       if (lookahead == 'k')
-        ADVANCE(343);
+        ADVANCE(362);
       if (lookahead == 'm')
-        ADVANCE(408);
+        ADVANCE(427);
       if (lookahead == 'p')
-        ADVANCE(359);
+        ADVANCE(378);
       if (lookahead == 's')
-        ADVANCE(367);
+        ADVANCE(386);
       if (lookahead == 't')
-        ADVANCE(382);
+        ADVANCE(401);
       if (lookahead == 'u')
-        ADVANCE(392);
+        ADVANCE(411);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(402);
+        ADVANCE(421);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(403);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 408:
+    case 427:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'i')
-        ADVANCE(356);
+        ADVANCE(375);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 409:
+    case 428:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == 'b')
-        ADVANCE(297);
+        ADVANCE(308);
       if (lookahead == 'c')
-        ADVANCE(410);
+        ADVANCE(429);
       if (lookahead == 'd')
-        ADVANCE(411);
+        ADVANCE(430);
       if (lookahead == 'i')
-        ADVANCE(334);
+        ADVANCE(353);
       if (lookahead == 'k')
-        ADVANCE(343);
+        ADVANCE(362);
       if (lookahead == 't')
-        ADVANCE(412);
+        ADVANCE(431);
       if (lookahead == 'e' ||
           lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(402);
+        ADVANCE(421);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(403);
+        ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < '@' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 410:
+    case 429:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(303);
+        ADVANCE(314);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 411:
+    case 430:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'e')
-        ADVANCE(315);
+        ADVANCE(326);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 412:
+    case 431:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(413);
+        ADVANCE(432);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 413:
+    case 432:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'g')
-        ADVANCE(414);
+        ADVANCE(433);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 414:
+    case 433:
       ACCEPT_TOKEN(anon_sym_tag);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 415:
+    case 434:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'm')
-        ADVANCE(416);
+        ADVANCE(435);
       END_STATE();
-    case 416:
+    case 435:
       if (lookahead == 'a')
-        ADVANCE(417);
+        ADVANCE(436);
       END_STATE();
-    case 417:
+    case 436:
       if (lookahead == 'k')
-        ADVANCE(418);
+        ADVANCE(437);
       END_STATE();
-    case 418:
+    case 437:
       if (lookahead == 'e')
-        ADVANCE(419);
+        ADVANCE(438);
       END_STATE();
-    case 419:
+    case 438:
       if (lookahead == 'a')
-        ADVANCE(420);
+        ADVANCE(439);
       END_STATE();
-    case 420:
+    case 439:
       if (lookahead == 't')
-        ADVANCE(421);
+        ADVANCE(440);
       END_STATE();
-    case 421:
+    case 440:
       if (lookahead == 'o')
-        ADVANCE(422);
+        ADVANCE(441);
       END_STATE();
-    case 422:
+    case 441:
       if (lookahead == 't')
-        ADVANCE(423);
+        ADVANCE(442);
       END_STATE();
-    case 423:
+    case 442:
       if (lookahead == 'h')
-        ADVANCE(424);
+        ADVANCE(443);
       END_STATE();
-    case 424:
+    case 443:
       if (lookahead == 'e')
-        ADVANCE(425);
+        ADVANCE(444);
       END_STATE();
-    case 425:
+    case 444:
       if (lookahead == 'r')
-        ADVANCE(426);
+        ADVANCE(445);
       END_STATE();
-    case 426:
+    case 445:
       ACCEPT_TOKEN(anon_sym_makeatother);
       END_STATE();
-    case 427:
+    case 446:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == '(')
@@ -4980,106 +5202,108 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(284);
+        ADVANCE(295);
       if (lookahead == 'b')
-        ADVANCE(297);
+        ADVANCE(308);
       if (lookahead == 'c')
-        ADVANCE(302);
+        ADVANCE(313);
       if (lookahead == 'd')
-        ADVANCE(314);
+        ADVANCE(325);
       if (lookahead == 'e')
-        ADVANCE(428);
+        ADVANCE(447);
+      if (lookahead == 'f')
+        ADVANCE(345);
       if (lookahead == 'i')
-        ADVANCE(334);
+        ADVANCE(353);
       if (lookahead == 'k')
-        ADVANCE(343);
+        ADVANCE(362);
       if (lookahead == 'm')
-        ADVANCE(408);
+        ADVANCE(427);
       if (lookahead == 'p')
-        ADVANCE(359);
+        ADVANCE(378);
       if (lookahead == 's')
-        ADVANCE(367);
+        ADVANCE(386);
       if (lookahead == 't')
-        ADVANCE(382);
+        ADVANCE(401);
       if (lookahead == 'u')
-        ADVANCE(392);
+        ADVANCE(411);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(402);
+        ADVANCE(421);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(403);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 428:
+    case 447:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(330);
+        ADVANCE(341);
       if (lookahead == 'm')
-        ADVANCE(331);
+        ADVANCE(342);
       if (lookahead == 'n')
-        ADVANCE(429);
+        ADVANCE(448);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 429:
+    case 448:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'd')
-        ADVANCE(430);
+        ADVANCE(449);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 430:
+    case 449:
       ACCEPT_TOKEN(anon_sym_end);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
-    case 431:
+    case 450:
       if (lookahead == '%')
         ADVANCE(38);
       if (lookahead == 'b')
-        ADVANCE(297);
+        ADVANCE(308);
       if (lookahead == 'c')
-        ADVANCE(410);
+        ADVANCE(429);
       if (lookahead == 'd')
-        ADVANCE(411);
+        ADVANCE(430);
       if (lookahead == 'e')
-        ADVANCE(432);
+        ADVANCE(451);
       if (lookahead == 'i')
-        ADVANCE(334);
+        ADVANCE(353);
       if (lookahead == 'k')
-        ADVANCE(343);
+        ADVANCE(362);
       if (lookahead == 't')
-        ADVANCE(412);
+        ADVANCE(431);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(402);
+        ADVANCE(421);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(403);
+        ADVANCE(422);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < '@' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(161);
+        ADVANCE(169);
       END_STATE();
-    case 432:
+    case 451:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(330);
+        ADVANCE(341);
       if (lookahead == 'n')
-        ADVANCE(429);
+        ADVANCE(448);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(291);
+        ADVANCE(302);
       END_STATE();
     default:
       return false;
@@ -5091,24 +5315,24 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [1] = {.lex_state = 34},
   [2] = {.lex_state = 36},
   [3] = {.lex_state = 37},
-  [4] = {.lex_state = 162},
+  [4] = {.lex_state = 170},
   [5] = {.lex_state = 34},
-  [6] = {.lex_state = 163},
-  [7] = {.lex_state = 165},
-  [8] = {.lex_state = 166},
-  [9] = {.lex_state = 166},
+  [6] = {.lex_state = 171},
+  [7] = {.lex_state = 173},
+  [8] = {.lex_state = 174},
+  [9] = {.lex_state = 174},
   [10] = {.lex_state = 34},
   [11] = {.lex_state = 34},
   [12] = {.lex_state = 34},
   [13] = {.lex_state = 34},
-  [14] = {.lex_state = 167},
+  [14] = {.lex_state = 175},
   [15] = {.lex_state = 34},
   [16] = {.lex_state = 34},
   [17] = {.lex_state = 34},
   [18] = {.lex_state = 34},
   [19] = {.lex_state = 34},
   [20] = {.lex_state = 34},
-  [21] = {.lex_state = 165},
+  [21] = {.lex_state = 173},
   [22] = {.lex_state = 34},
   [23] = {.lex_state = 34},
   [24] = {.lex_state = 34},
@@ -5116,77 +5340,77 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [26] = {.lex_state = 34},
   [27] = {.lex_state = 34},
   [28] = {.lex_state = 34},
-  [29] = {.lex_state = 36},
-  [30] = {.lex_state = 34},
+  [29] = {.lex_state = 34},
+  [30] = {.lex_state = 36},
   [31] = {.lex_state = 34},
-  [32] = {.lex_state = 34},
-  [33] = {.lex_state = 165},
-  [34] = {.lex_state = 34},
-  [35] = {.lex_state = 34},
-  [36] = {.lex_state = 34},
-  [37] = {.lex_state = 34},
+  [32] = {.lex_state = 176},
+  [33] = {.lex_state = 176},
+  [34] = {.lex_state = 173},
+  [35] = {.lex_state = 178},
+  [36] = {.lex_state = 178},
+  [37] = {.lex_state = 178},
   [38] = {.lex_state = 34},
-  [39] = {.lex_state = 165},
-  [40] = {.lex_state = 34},
+  [39] = {.lex_state = 34},
+  [40] = {.lex_state = 173},
   [41] = {.lex_state = 34},
-  [42] = {.lex_state = 34},
-  [43] = {.lex_state = 34},
-  [44] = {.lex_state = 34},
-  [45] = {.lex_state = 34},
-  [46] = {.lex_state = 165},
-  [47] = {.lex_state = 165},
-  [48] = {.lex_state = 162},
-  [49] = {.lex_state = 168},
-  [50] = {.lex_state = 162},
-  [51] = {.lex_state = 34},
-  [52] = {.lex_state = 34},
+  [42] = {.lex_state = 178},
+  [43] = {.lex_state = 178},
+  [44] = {.lex_state = 178},
+  [45] = {.lex_state = 178},
+  [46] = {.lex_state = 178},
+  [47] = {.lex_state = 176},
+  [48] = {.lex_state = 176},
+  [49] = {.lex_state = 173},
+  [50] = {.lex_state = 170},
+  [51] = {.lex_state = 180},
+  [52] = {.lex_state = 170},
   [53] = {.lex_state = 34},
   [54] = {.lex_state = 34},
   [55] = {.lex_state = 34},
-  [56] = {.lex_state = 36},
+  [56] = {.lex_state = 34},
   [57] = {.lex_state = 34},
-  [58] = {.lex_state = 165},
+  [58] = {.lex_state = 36},
   [59] = {.lex_state = 34},
-  [60] = {.lex_state = 34},
+  [60] = {.lex_state = 173},
   [61] = {.lex_state = 34},
   [62] = {.lex_state = 34},
   [63] = {.lex_state = 34},
-  [64] = {.lex_state = 174},
-  [65] = {.lex_state = 165},
-  [66] = {.lex_state = 34},
-  [67] = {.lex_state = 34},
-  [68] = {.lex_state = 178},
-  [69] = {.lex_state = 167},
-  [70] = {.lex_state = 179},
-  [71] = {.lex_state = 165},
-  [72] = {.lex_state = 34},
-  [73] = {.lex_state = 34},
-  [74] = {.lex_state = 183},
-  [75] = {.lex_state = 280},
-  [76] = {.lex_state = 34},
-  [77] = {.lex_state = 280},
+  [64] = {.lex_state = 34},
+  [65] = {.lex_state = 34},
+  [66] = {.lex_state = 186},
+  [67] = {.lex_state = 173},
+  [68] = {.lex_state = 34},
+  [69] = {.lex_state = 34},
+  [70] = {.lex_state = 190},
+  [71] = {.lex_state = 175},
+  [72] = {.lex_state = 191},
+  [73] = {.lex_state = 173},
+  [74] = {.lex_state = 34},
+  [75] = {.lex_state = 34},
+  [76] = {.lex_state = 195},
+  [77] = {.lex_state = 178},
   [78] = {.lex_state = 34},
-  [79] = {.lex_state = 34},
-  [80] = {.lex_state = 165},
+  [79] = {.lex_state = 178},
+  [80] = {.lex_state = 34},
   [81] = {.lex_state = 34},
-  [82] = {.lex_state = 165},
-  [83] = {.lex_state = 34},
-  [84] = {.lex_state = 165},
-  [85] = {.lex_state = 165},
-  [86] = {.lex_state = 34},
-  [87] = {.lex_state = 281},
-  [88] = {.lex_state = 282},
-  [89] = {.lex_state = 165},
-  [90] = {.lex_state = 165},
-  [91] = {.lex_state = 165},
-  [92] = {.lex_state = 165},
-  [93] = {.lex_state = 283},
-  [94] = {.lex_state = 162},
-  [95] = {.lex_state = 34},
-  [96] = {.lex_state = 34},
-  [97] = {.lex_state = 34},
-  [98] = {.lex_state = 34},
-  [99] = {.lex_state = 34},
+  [82] = {.lex_state = 173},
+  [83] = {.lex_state = 178},
+  [84] = {.lex_state = 36},
+  [85] = {.lex_state = 173},
+  [86] = {.lex_state = 178},
+  [87] = {.lex_state = 173},
+  [88] = {.lex_state = 173},
+  [89] = {.lex_state = 178},
+  [90] = {.lex_state = 292},
+  [91] = {.lex_state = 293},
+  [92] = {.lex_state = 173},
+  [93] = {.lex_state = 173},
+  [94] = {.lex_state = 178},
+  [95] = {.lex_state = 173},
+  [96] = {.lex_state = 173},
+  [97] = {.lex_state = 173},
+  [98] = {.lex_state = 294},
+  [99] = {.lex_state = 170},
   [100] = {.lex_state = 34},
   [101] = {.lex_state = 34},
   [102] = {.lex_state = 34},
@@ -5196,188 +5420,236 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [106] = {.lex_state = 34},
   [107] = {.lex_state = 34},
   [108] = {.lex_state = 34},
-  [109] = {.lex_state = 165},
-  [110] = {.lex_state = 165},
-  [111] = {.lex_state = 36},
+  [109] = {.lex_state = 34},
+  [110] = {.lex_state = 34},
+  [111] = {.lex_state = 34},
   [112] = {.lex_state = 34},
-  [113] = {.lex_state = 165},
-  [114] = {.lex_state = 165},
-  [115] = {.lex_state = 36},
-  [116] = {.lex_state = 34},
-  [117] = {.lex_state = 165},
-  [118] = {.lex_state = 162},
-  [119] = {.lex_state = 34},
-  [120] = {.lex_state = 165},
-  [121] = {.lex_state = 162},
+  [113] = {.lex_state = 34},
+  [114] = {.lex_state = 34},
+  [115] = {.lex_state = 173},
+  [116] = {.lex_state = 173},
+  [117] = {.lex_state = 36},
+  [118] = {.lex_state = 34},
+  [119] = {.lex_state = 173},
+  [120] = {.lex_state = 173},
+  [121] = {.lex_state = 36},
   [122] = {.lex_state = 34},
-  [123] = {.lex_state = 165},
-  [124] = {.lex_state = 162},
-  [125] = {.lex_state = 165},
-  [126] = {.lex_state = 404},
-  [127] = {.lex_state = 165},
+  [123] = {.lex_state = 34},
+  [124] = {.lex_state = 34},
+  [125] = {.lex_state = 34},
+  [126] = {.lex_state = 34},
+  [127] = {.lex_state = 34},
   [128] = {.lex_state = 34},
-  [129] = {.lex_state = 165},
-  [130] = {.lex_state = 36},
+  [129] = {.lex_state = 34},
+  [130] = {.lex_state = 34},
   [131] = {.lex_state = 34},
-  [132] = {.lex_state = 36},
-  [133] = {.lex_state = 165},
-  [134] = {.lex_state = 34},
-  [135] = {.lex_state = 406},
-  [136] = {.lex_state = 165},
-  [137] = {.lex_state = 165},
-  [138] = {.lex_state = 34},
-  [139] = {.lex_state = 165},
+  [132] = {.lex_state = 34},
+  [133] = {.lex_state = 34},
+  [134] = {.lex_state = 173},
+  [135] = {.lex_state = 173},
+  [136] = {.lex_state = 170},
+  [137] = {.lex_state = 178},
+  [138] = {.lex_state = 173},
+  [139] = {.lex_state = 170},
   [140] = {.lex_state = 34},
-  [141] = {.lex_state = 34},
-  [142] = {.lex_state = 165},
-  [143] = {.lex_state = 183},
-  [144] = {.lex_state = 165},
-  [145] = {.lex_state = 167},
-  [146] = {.lex_state = 178},
-  [147] = {.lex_state = 167},
-  [148] = {.lex_state = 165},
-  [149] = {.lex_state = 165},
-  [150] = {.lex_state = 34},
-  [151] = {.lex_state = 162},
-  [152] = {.lex_state = 162},
-  [153] = {.lex_state = 162},
-  [154] = {.lex_state = 162},
-  [155] = {.lex_state = 162},
+  [141] = {.lex_state = 173},
+  [142] = {.lex_state = 170},
+  [143] = {.lex_state = 173},
+  [144] = {.lex_state = 423},
+  [145] = {.lex_state = 173},
+  [146] = {.lex_state = 34},
+  [147] = {.lex_state = 173},
+  [148] = {.lex_state = 36},
+  [149] = {.lex_state = 34},
+  [150] = {.lex_state = 36},
+  [151] = {.lex_state = 173},
+  [152] = {.lex_state = 34},
+  [153] = {.lex_state = 425},
+  [154] = {.lex_state = 173},
+  [155] = {.lex_state = 173},
   [156] = {.lex_state = 34},
-  [157] = {.lex_state = 280},
-  [158] = {.lex_state = 280},
-  [159] = {.lex_state = 36},
-  [160] = {.lex_state = 167},
-  [161] = {.lex_state = 280},
-  [162] = {.lex_state = 280},
-  [163] = {.lex_state = 165},
-  [164] = {.lex_state = 165},
-  [165] = {.lex_state = 165},
-  [166] = {.lex_state = 282},
-  [167] = {.lex_state = 163},
-  [168] = {.lex_state = 165},
-  [169] = {.lex_state = 165},
-  [170] = {.lex_state = 407},
-  [171] = {.lex_state = 165},
-  [172] = {.lex_state = 162},
-  [173] = {.lex_state = 409},
-  [174] = {.lex_state = 162},
-  [175] = {.lex_state = 34},
-  [176] = {.lex_state = 34},
-  [177] = {.lex_state = 34},
-  [178] = {.lex_state = 34},
-  [179] = {.lex_state = 36},
+  [157] = {.lex_state = 173},
+  [158] = {.lex_state = 34},
+  [159] = {.lex_state = 178},
+  [160] = {.lex_state = 173},
+  [161] = {.lex_state = 195},
+  [162] = {.lex_state = 173},
+  [163] = {.lex_state = 175},
+  [164] = {.lex_state = 190},
+  [165] = {.lex_state = 175},
+  [166] = {.lex_state = 173},
+  [167] = {.lex_state = 173},
+  [168] = {.lex_state = 34},
+  [169] = {.lex_state = 170},
+  [170] = {.lex_state = 170},
+  [171] = {.lex_state = 170},
+  [172] = {.lex_state = 170},
+  [173] = {.lex_state = 170},
+  [174] = {.lex_state = 34},
+  [175] = {.lex_state = 178},
+  [176] = {.lex_state = 178},
+  [177] = {.lex_state = 175},
+  [178] = {.lex_state = 178},
+  [179] = {.lex_state = 178},
   [180] = {.lex_state = 34},
-  [181] = {.lex_state = 415},
-  [182] = {.lex_state = 165},
-  [183] = {.lex_state = 34},
-  [184] = {.lex_state = 34},
+  [181] = {.lex_state = 173},
+  [182] = {.lex_state = 178},
+  [183] = {.lex_state = 178},
+  [184] = {.lex_state = 36},
   [185] = {.lex_state = 34},
-  [186] = {.lex_state = 34},
+  [186] = {.lex_state = 173},
   [187] = {.lex_state = 34},
-  [188] = {.lex_state = 427},
-  [189] = {.lex_state = 165},
-  [190] = {.lex_state = 34},
-  [191] = {.lex_state = 280},
-  [192] = {.lex_state = 165},
-  [193] = {.lex_state = 165},
-  [194] = {.lex_state = 34},
-  [195] = {.lex_state = 165},
-  [196] = {.lex_state = 165},
-  [197] = {.lex_state = 165},
-  [198] = {.lex_state = 165},
-  [199] = {.lex_state = 165},
-  [200] = {.lex_state = 36},
+  [188] = {.lex_state = 173},
+  [189] = {.lex_state = 293},
+  [190] = {.lex_state = 171},
+  [191] = {.lex_state = 34},
+  [192] = {.lex_state = 173},
+  [193] = {.lex_state = 176},
+  [194] = {.lex_state = 176},
+  [195] = {.lex_state = 426},
+  [196] = {.lex_state = 173},
+  [197] = {.lex_state = 170},
+  [198] = {.lex_state = 428},
+  [199] = {.lex_state = 170},
+  [200] = {.lex_state = 34},
   [201] = {.lex_state = 34},
-  [202] = {.lex_state = 165},
-  [203] = {.lex_state = 36},
-  [204] = {.lex_state = 165},
-  [205] = {.lex_state = 162},
-  [206] = {.lex_state = 34},
-  [207] = {.lex_state = 165},
-  [208] = {.lex_state = 162},
-  [209] = {.lex_state = 162},
-  [210] = {.lex_state = 165},
-  [211] = {.lex_state = 165},
-  [212] = {.lex_state = 36},
-  [213] = {.lex_state = 165},
-  [214] = {.lex_state = 165},
-  [215] = {.lex_state = 183},
-  [216] = {.lex_state = 165},
-  [217] = {.lex_state = 183},
-  [218] = {.lex_state = 165},
-  [219] = {.lex_state = 162},
-  [220] = {.lex_state = 280},
-  [221] = {.lex_state = 165},
-  [222] = {.lex_state = 280},
-  [223] = {.lex_state = 165},
-  [224] = {.lex_state = 280},
-  [225] = {.lex_state = 162},
-  [226] = {.lex_state = 34},
-  [227] = {.lex_state = 280},
-  [228] = {.lex_state = 280},
-  [229] = {.lex_state = 280},
-  [230] = {.lex_state = 36},
-  [231] = {.lex_state = 167},
-  [232] = {.lex_state = 280},
-  [233] = {.lex_state = 165},
-  [234] = {.lex_state = 165},
-  [235] = {.lex_state = 162},
-  [236] = {.lex_state = 165},
-  [237] = {.lex_state = 162},
-  [238] = {.lex_state = 34},
-  [239] = {.lex_state = 165},
-  [240] = {.lex_state = 162},
-  [241] = {.lex_state = 165},
-  [242] = {.lex_state = 431},
-  [243] = {.lex_state = 165},
-  [244] = {.lex_state = 34},
-  [245] = {.lex_state = 165},
-  [246] = {.lex_state = 36},
-  [247] = {.lex_state = 34},
-  [248] = {.lex_state = 165},
-  [249] = {.lex_state = 34},
-  [250] = {.lex_state = 165},
-  [251] = {.lex_state = 165},
-  [252] = {.lex_state = 165},
-  [253] = {.lex_state = 165},
-  [254] = {.lex_state = 162},
-  [255] = {.lex_state = 34},
-  [256] = {.lex_state = 280},
-  [257] = {.lex_state = 280},
-  [258] = {.lex_state = 36},
-  [259] = {.lex_state = 165},
-  [260] = {.lex_state = 165},
-  [261] = {.lex_state = 36},
-  [262] = {.lex_state = 165},
-  [263] = {.lex_state = 165},
-  [264] = {.lex_state = 162},
-  [265] = {.lex_state = 165},
-  [266] = {.lex_state = 280},
-  [267] = {.lex_state = 34},
-  [268] = {.lex_state = 280},
-  [269] = {.lex_state = 167},
-  [270] = {.lex_state = 165},
-  [271] = {.lex_state = 162},
-  [272] = {.lex_state = 34},
-  [273] = {.lex_state = 165},
-  [274] = {.lex_state = 162},
-  [275] = {.lex_state = 162},
-  [276] = {.lex_state = 165},
-  [277] = {.lex_state = 165},
-  [278] = {.lex_state = 36},
-  [279] = {.lex_state = 280},
-  [280] = {.lex_state = 162},
-  [281] = {.lex_state = 34},
-  [282] = {.lex_state = 280},
-  [283] = {.lex_state = 280},
-  [284] = {.lex_state = 36},
-  [285] = {.lex_state = 165},
-  [286] = {.lex_state = 165},
-  [287] = {.lex_state = 165},
-  [288] = {.lex_state = 280},
-  [289] = {.lex_state = 34},
-  [290] = {.lex_state = 280},
+  [202] = {.lex_state = 34},
+  [203] = {.lex_state = 34},
+  [204] = {.lex_state = 36},
+  [205] = {.lex_state = 34},
+  [206] = {.lex_state = 434},
+  [207] = {.lex_state = 173},
+  [208] = {.lex_state = 34},
+  [209] = {.lex_state = 34},
+  [210] = {.lex_state = 34},
+  [211] = {.lex_state = 34},
+  [212] = {.lex_state = 34},
+  [213] = {.lex_state = 446},
+  [214] = {.lex_state = 173},
+  [215] = {.lex_state = 34},
+  [216] = {.lex_state = 178},
+  [217] = {.lex_state = 173},
+  [218] = {.lex_state = 173},
+  [219] = {.lex_state = 178},
+  [220] = {.lex_state = 36},
+  [221] = {.lex_state = 173},
+  [222] = {.lex_state = 173},
+  [223] = {.lex_state = 178},
+  [224] = {.lex_state = 173},
+  [225] = {.lex_state = 173},
+  [226] = {.lex_state = 173},
+  [227] = {.lex_state = 173},
+  [228] = {.lex_state = 36},
+  [229] = {.lex_state = 34},
+  [230] = {.lex_state = 173},
+  [231] = {.lex_state = 36},
+  [232] = {.lex_state = 34},
+  [233] = {.lex_state = 173},
+  [234] = {.lex_state = 170},
+  [235] = {.lex_state = 34},
+  [236] = {.lex_state = 173},
+  [237] = {.lex_state = 170},
+  [238] = {.lex_state = 170},
+  [239] = {.lex_state = 173},
+  [240] = {.lex_state = 173},
+  [241] = {.lex_state = 36},
+  [242] = {.lex_state = 176},
+  [243] = {.lex_state = 176},
+  [244] = {.lex_state = 195},
+  [245] = {.lex_state = 173},
+  [246] = {.lex_state = 195},
+  [247] = {.lex_state = 173},
+  [248] = {.lex_state = 34},
+  [249] = {.lex_state = 170},
+  [250] = {.lex_state = 178},
+  [251] = {.lex_state = 173},
+  [252] = {.lex_state = 178},
+  [253] = {.lex_state = 173},
+  [254] = {.lex_state = 178},
+  [255] = {.lex_state = 170},
+  [256] = {.lex_state = 34},
+  [257] = {.lex_state = 178},
+  [258] = {.lex_state = 178},
+  [259] = {.lex_state = 175},
+  [260] = {.lex_state = 178},
+  [261] = {.lex_state = 178},
+  [262] = {.lex_state = 173},
+  [263] = {.lex_state = 178},
+  [264] = {.lex_state = 173},
+  [265] = {.lex_state = 173},
+  [266] = {.lex_state = 173},
+  [267] = {.lex_state = 173},
+  [268] = {.lex_state = 173},
+  [269] = {.lex_state = 173},
+  [270] = {.lex_state = 173},
+  [271] = {.lex_state = 170},
+  [272] = {.lex_state = 173},
+  [273] = {.lex_state = 170},
+  [274] = {.lex_state = 34},
+  [275] = {.lex_state = 173},
+  [276] = {.lex_state = 170},
+  [277] = {.lex_state = 173},
+  [278] = {.lex_state = 450},
+  [279] = {.lex_state = 173},
+  [280] = {.lex_state = 34},
+  [281] = {.lex_state = 173},
+  [282] = {.lex_state = 36},
+  [283] = {.lex_state = 34},
+  [284] = {.lex_state = 173},
+  [285] = {.lex_state = 34},
+  [286] = {.lex_state = 173},
+  [287] = {.lex_state = 173},
+  [288] = {.lex_state = 173},
+  [289] = {.lex_state = 173},
+  [290] = {.lex_state = 170},
+  [291] = {.lex_state = 34},
+  [292] = {.lex_state = 178},
+  [293] = {.lex_state = 178},
+  [294] = {.lex_state = 34},
+  [295] = {.lex_state = 173},
+  [296] = {.lex_state = 178},
+  [297] = {.lex_state = 36},
+  [298] = {.lex_state = 34},
+  [299] = {.lex_state = 173},
+  [300] = {.lex_state = 173},
+  [301] = {.lex_state = 36},
+  [302] = {.lex_state = 173},
+  [303] = {.lex_state = 173},
+  [304] = {.lex_state = 173},
+  [305] = {.lex_state = 173},
+  [306] = {.lex_state = 170},
+  [307] = {.lex_state = 173},
+  [308] = {.lex_state = 178},
+  [309] = {.lex_state = 34},
+  [310] = {.lex_state = 178},
+  [311] = {.lex_state = 175},
+  [312] = {.lex_state = 178},
+  [313] = {.lex_state = 173},
+  [314] = {.lex_state = 170},
+  [315] = {.lex_state = 34},
+  [316] = {.lex_state = 173},
+  [317] = {.lex_state = 170},
+  [318] = {.lex_state = 170},
+  [319] = {.lex_state = 173},
+  [320] = {.lex_state = 173},
+  [321] = {.lex_state = 36},
+  [322] = {.lex_state = 178},
+  [323] = {.lex_state = 170},
+  [324] = {.lex_state = 34},
+  [325] = {.lex_state = 178},
+  [326] = {.lex_state = 178},
+  [327] = {.lex_state = 173},
+  [328] = {.lex_state = 178},
+  [329] = {.lex_state = 173},
+  [330] = {.lex_state = 173},
+  [331] = {.lex_state = 34},
+  [332] = {.lex_state = 175},
+  [333] = {.lex_state = 173},
+  [334] = {.lex_state = 173},
+  [335] = {.lex_state = 178},
+  [336] = {.lex_state = 34},
+  [337] = {.lex_state = 178},
+  [338] = {.lex_state = 34},
 };
 
 static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
@@ -5405,57 +5677,59 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [1] = {
     [sym_document] = STATE(8),
-    [sym__common] = STATE(30),
-    [sym__text_mode_common] = STATE(30),
-    [sym__text_mode] = STATE(30),
+    [sym__common] = STATE(31),
+    [sym__text_mode_common] = STATE(31),
+    [sym__text_mode] = STATE(31),
     [sym_text_mode] = STATE(9),
-    [sym_text_mode_at_region] = STATE(30),
-    [sym_parameter] = STATE(30),
-    [sym_text_env] = STATE(30),
-    [sym__display_math] = STATE(30),
-    [sym_tex_display_math] = STATE(30),
-    [sym_latex_display_math] = STATE(30),
+    [sym_text_mode_at_region] = STATE(31),
+    [sym_parameter] = STATE(31),
+    [sym_text_env] = STATE(31),
+    [sym__display_math] = STATE(31),
+    [sym_tex_display_math] = STATE(31),
+    [sym_latex_display_math] = STATE(31),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(30),
+    [sym_display_math_env] = STATE(31),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(30),
-    [sym_tex_inline_math] = STATE(30),
-    [sym_latex_inline_math] = STATE(30),
-    [sym_inline_math_env] = STATE(30),
+    [sym__inline_math] = STATE(31),
+    [sym_tex_inline_math] = STATE(31),
+    [sym_latex_inline_math] = STATE(31),
+    [sym_inline_math_env] = STATE(31),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(30),
+    [sym_verbatim_env] = STATE(31),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(30),
+    [sym_escaped] = STATE(31),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(30),
+    [sym_documentclass] = STATE(31),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(30),
+    [sym_usepackage] = STATE(31),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(30),
+    [sym_include] = STATE(31),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(30),
+    [sym_section] = STATE(31),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(30),
+    [sym_storage] = STATE(31),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(30),
+    [sym_catcode] = STATE(31),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(30),
+    [sym_emph] = STATE(31),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(30),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(30),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(30),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(30),
-    [sym_opt_text_group] = STATE(30),
-    [sym_token] = STATE(30),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(30),
+    [sym_footnote] = STATE(31),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(31),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(31),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(31),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(31),
+    [sym_opt_text_group] = STATE(31),
+    [sym_token] = STATE(31),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(31),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
@@ -5497,673 +5771,680 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
     [anon_sym_emph] = ACTIONS(47),
-    [anon_sym_textbf] = ACTIONS(49),
-    [anon_sym_textit] = ACTIONS(51),
-    [anon_sym_texttt] = ACTIONS(53),
-    [anon_sym_makeatletter] = ACTIONS(55),
+    [anon_sym_footnote] = ACTIONS(49),
+    [anon_sym_textbf] = ACTIONS(51),
+    [anon_sym_textit] = ACTIONS(53),
+    [anon_sym_texttt] = ACTIONS(55),
+    [anon_sym_makeatletter] = ACTIONS(57),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(57),
+    [sym__name] = ACTIONS(59),
   },
   [4] = {
-    [sym__common] = STATE(48),
-    [sym__text_mode_common] = STATE(48),
-    [sym__text_mode] = STATE(48),
-    [sym_text_mode_at_region] = STATE(48),
-    [sym_parameter] = STATE(48),
-    [sym_text_env] = STATE(48),
-    [sym__display_math] = STATE(48),
-    [sym_tex_display_math] = STATE(48),
-    [sym_latex_display_math] = STATE(48),
+    [sym__common] = STATE(50),
+    [sym__text_mode_common] = STATE(50),
+    [sym__text_mode] = STATE(50),
+    [sym_text_mode_at_region] = STATE(50),
+    [sym_parameter] = STATE(50),
+    [sym_text_env] = STATE(50),
+    [sym__display_math] = STATE(50),
+    [sym_tex_display_math] = STATE(50),
+    [sym_latex_display_math] = STATE(50),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(48),
+    [sym_display_math_env] = STATE(50),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(48),
-    [sym_tex_inline_math] = STATE(48),
-    [sym_latex_inline_math] = STATE(48),
-    [sym_inline_math_env] = STATE(48),
+    [sym__inline_math] = STATE(50),
+    [sym_tex_inline_math] = STATE(50),
+    [sym_latex_inline_math] = STATE(50),
+    [sym_inline_math_env] = STATE(50),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(48),
+    [sym_verbatim_env] = STATE(50),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(48),
+    [sym_escaped] = STATE(50),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(48),
+    [sym_documentclass] = STATE(50),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(48),
+    [sym_usepackage] = STATE(50),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(48),
+    [sym_include] = STATE(50),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(48),
+    [sym_section] = STATE(50),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(48),
+    [sym_storage] = STATE(50),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(48),
+    [sym_catcode] = STATE(50),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(48),
+    [sym_emph] = STATE(50),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(48),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(48),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(48),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(48),
-    [sym_opt_text_group] = STATE(48),
-    [sym_token] = STATE(48),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(48),
+    [sym_footnote] = STATE(50),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(50),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(50),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(50),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(50),
+    [sym_opt_text_group] = STATE(50),
+    [sym_token] = STATE(50),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(50),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(59),
+    [sym_end_group] = ACTIONS(61),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(61),
+    [sym_alignment_tab] = ACTIONS(63),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(61),
-    [sym_text] = ACTIONS(61),
+    [sym_active_char] = ACTIONS(63),
+    [sym_text] = ACTIONS(63),
   },
   [5] = {
-    [sym__common] = STATE(57),
-    [sym__math_mode_common] = STATE(57),
-    [sym__math_mode] = STATE(57),
-    [sym_math_mode] = STATE(52),
-    [sym_parameter] = STATE(57),
-    [sym_math_env] = STATE(57),
-    [sym_tag] = STATE(57),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(57),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(57),
+    [sym__common] = STATE(59),
+    [sym__math_mode_common] = STATE(59),
+    [sym__math_mode] = STATE(59),
+    [sym_math_mode] = STATE(54),
+    [sym_parameter] = STATE(59),
+    [sym_math_env] = STATE(59),
+    [sym_tag] = STATE(59),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(59),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(59),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(57),
+    [sym_storage] = STATE(59),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(57),
+    [sym_catcode] = STATE(59),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(57),
-    [sym_opt_math_group] = STATE(57),
-    [sym_token] = STATE(57),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(57),
+    [sym_math_group] = STATE(59),
+    [sym_opt_math_group] = STATE(59),
+    [sym_token] = STATE(59),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(59),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_math_shift] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(69),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_math_shift] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(71),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(69),
-    [sym_subscript] = ACTIONS(69),
-    [sym_active_char] = ACTIONS(69),
-    [sym_text] = ACTIONS(69),
+    [sym_superscript] = ACTIONS(71),
+    [sym_subscript] = ACTIONS(71),
+    [sym_active_char] = ACTIONS(71),
+    [sym_text] = ACTIONS(71),
   },
   [6] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_number] = ACTIONS(71),
+    [sym_number] = ACTIONS(73),
   },
   [7] = {
-    [ts_builtin_sym_end] = ACTIONS(73),
-    [anon_sym_LBRACK] = ACTIONS(73),
-    [anon_sym_RBRACK] = ACTIONS(73),
+    [ts_builtin_sym_end] = ACTIONS(75),
+    [anon_sym_LBRACK] = ACTIONS(75),
+    [anon_sym_RBRACK] = ACTIONS(75),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(73),
-    [sym_begin_group] = ACTIONS(73),
-    [sym_end_group] = ACTIONS(73),
-    [sym_math_shift] = ACTIONS(73),
-    [sym_alignment_tab] = ACTIONS(73),
-    [sym_parameter_char] = ACTIONS(73),
-    [sym_superscript] = ACTIONS(73),
-    [sym_subscript] = ACTIONS(73),
-    [sym_active_char] = ACTIONS(73),
-    [sym_text] = ACTIONS(73),
+    [sym__escape] = ACTIONS(75),
+    [sym_begin_group] = ACTIONS(75),
+    [sym_end_group] = ACTIONS(75),
+    [sym_math_shift] = ACTIONS(75),
+    [sym_alignment_tab] = ACTIONS(75),
+    [sym_parameter_char] = ACTIONS(75),
+    [sym_superscript] = ACTIONS(75),
+    [sym_subscript] = ACTIONS(75),
+    [sym_active_char] = ACTIONS(75),
+    [sym_text] = ACTIONS(75),
   },
   [8] = {
-    [ts_builtin_sym_end] = ACTIONS(75),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [9] = {
     [ts_builtin_sym_end] = ACTIONS(77),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
   },
+  [9] = {
+    [ts_builtin_sym_end] = ACTIONS(79),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
   [10] = {
-    [sym__common] = STATE(60),
-    [sym__math_mode_common] = STATE(60),
-    [sym__math_mode] = STATE(60),
-    [sym_math_mode] = STATE(59),
-    [sym_parameter] = STATE(60),
-    [sym_math_env] = STATE(60),
-    [sym_tag] = STATE(60),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(60),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(60),
+    [sym__common] = STATE(62),
+    [sym__math_mode_common] = STATE(62),
+    [sym__math_mode] = STATE(62),
+    [sym_math_mode] = STATE(61),
+    [sym_parameter] = STATE(62),
+    [sym_math_env] = STATE(62),
+    [sym_tag] = STATE(62),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(62),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(62),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(60),
+    [sym_storage] = STATE(62),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(60),
+    [sym_catcode] = STATE(62),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(60),
-    [sym_opt_math_group] = STATE(60),
-    [sym_token] = STATE(60),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(60),
+    [sym_math_group] = STATE(62),
+    [sym_opt_math_group] = STATE(62),
+    [sym_token] = STATE(62),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(62),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(79),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(81),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(79),
-    [sym_subscript] = ACTIONS(79),
-    [sym_active_char] = ACTIONS(79),
-    [sym_text] = ACTIONS(79),
+    [sym_superscript] = ACTIONS(81),
+    [sym_subscript] = ACTIONS(81),
+    [sym_active_char] = ACTIONS(81),
+    [sym_text] = ACTIONS(81),
   },
   [11] = {
-    [sym__common] = STATE(60),
-    [sym__math_mode_common] = STATE(60),
-    [sym__math_mode] = STATE(60),
-    [sym_math_mode] = STATE(61),
-    [sym_parameter] = STATE(60),
-    [sym_math_env] = STATE(60),
-    [sym_tag] = STATE(60),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(60),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(60),
+    [sym__common] = STATE(62),
+    [sym__math_mode_common] = STATE(62),
+    [sym__math_mode] = STATE(62),
+    [sym_math_mode] = STATE(63),
+    [sym_parameter] = STATE(62),
+    [sym_math_env] = STATE(62),
+    [sym_tag] = STATE(62),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(62),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(62),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(60),
+    [sym_storage] = STATE(62),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(60),
+    [sym_catcode] = STATE(62),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(60),
-    [sym_opt_math_group] = STATE(60),
-    [sym_token] = STATE(60),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(60),
+    [sym_math_group] = STATE(62),
+    [sym_opt_math_group] = STATE(62),
+    [sym_token] = STATE(62),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(62),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(79),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(81),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(79),
-    [sym_subscript] = ACTIONS(79),
-    [sym_active_char] = ACTIONS(79),
-    [sym_text] = ACTIONS(79),
+    [sym_superscript] = ACTIONS(81),
+    [sym_subscript] = ACTIONS(81),
+    [sym_active_char] = ACTIONS(81),
+    [sym_text] = ACTIONS(81),
   },
   [12] = {
-    [sym__common] = STATE(60),
-    [sym__math_mode_common] = STATE(60),
-    [sym__math_mode] = STATE(60),
-    [sym_math_mode] = STATE(62),
-    [sym_parameter] = STATE(60),
-    [sym_math_env] = STATE(60),
-    [sym_tag] = STATE(60),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(60),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(60),
+    [sym__common] = STATE(62),
+    [sym__math_mode_common] = STATE(62),
+    [sym__math_mode] = STATE(62),
+    [sym_math_mode] = STATE(64),
+    [sym_parameter] = STATE(62),
+    [sym_math_env] = STATE(62),
+    [sym_tag] = STATE(62),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(62),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(62),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(60),
+    [sym_storage] = STATE(62),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(60),
+    [sym_catcode] = STATE(62),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(60),
-    [sym_opt_math_group] = STATE(60),
-    [sym_token] = STATE(60),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(60),
+    [sym_math_group] = STATE(62),
+    [sym_opt_math_group] = STATE(62),
+    [sym_token] = STATE(62),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(62),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(79),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(81),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(79),
-    [sym_subscript] = ACTIONS(79),
-    [sym_active_char] = ACTIONS(79),
-    [sym_text] = ACTIONS(79),
+    [sym_superscript] = ACTIONS(81),
+    [sym_subscript] = ACTIONS(81),
+    [sym_active_char] = ACTIONS(81),
+    [sym_text] = ACTIONS(81),
   },
   [13] = {
-    [sym__common] = STATE(60),
-    [sym__math_mode_common] = STATE(60),
-    [sym__math_mode] = STATE(60),
-    [sym_math_mode] = STATE(63),
-    [sym_parameter] = STATE(60),
-    [sym_math_env] = STATE(60),
-    [sym_tag] = STATE(60),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(60),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(60),
+    [sym__common] = STATE(62),
+    [sym__math_mode_common] = STATE(62),
+    [sym__math_mode] = STATE(62),
+    [sym_math_mode] = STATE(65),
+    [sym_parameter] = STATE(62),
+    [sym_math_env] = STATE(62),
+    [sym_tag] = STATE(62),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(62),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(62),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(60),
+    [sym_storage] = STATE(62),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(60),
+    [sym_catcode] = STATE(62),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(60),
-    [sym_opt_math_group] = STATE(60),
-    [sym_token] = STATE(60),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(60),
+    [sym_math_group] = STATE(62),
+    [sym_opt_math_group] = STATE(62),
+    [sym_token] = STATE(62),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(62),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(79),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(81),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(79),
-    [sym_subscript] = ACTIONS(79),
-    [sym_active_char] = ACTIONS(79),
-    [sym_text] = ACTIONS(79),
+    [sym_superscript] = ACTIONS(81),
+    [sym_subscript] = ACTIONS(81),
+    [sym_active_char] = ACTIONS(81),
+    [sym_text] = ACTIONS(81),
   },
   [14] = {
-    [sym_verbatim_end] = STATE(65),
-    [sym_verbatim_text] = STATE(66),
-    [sym_end_token] = STATE(67),
-    [aux_sym_verbatim_text_repeat1] = STATE(68),
-    [aux_sym_verbatim_text_repeat2] = STATE(69),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(81),
+    [sym_verbatim_end] = STATE(67),
+    [sym_verbatim_text] = STATE(68),
+    [sym_end_token] = STATE(69),
+    [aux_sym_verbatim_text_repeat1] = STATE(70),
+    [aux_sym_verbatim_text_repeat2] = STATE(71),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(83),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
-    [sym__end_of_line] = ACTIONS(85),
+    [sym__escape] = ACTIONS(85),
+    [sym__end_of_line] = ACTIONS(87),
   },
   [15] = {
-    [sym__common] = STATE(73),
-    [sym__text_mode_common] = STATE(73),
-    [sym__text_mode] = STATE(73),
-    [sym_text_mode_at_region] = STATE(73),
-    [sym_parameter] = STATE(73),
-    [sym_text_env] = STATE(73),
-    [sym__display_math] = STATE(73),
-    [sym_tex_display_math] = STATE(73),
-    [sym_latex_display_math] = STATE(73),
+    [sym__common] = STATE(75),
+    [sym__text_mode_common] = STATE(75),
+    [sym__text_mode] = STATE(75),
+    [sym_text_mode_at_region] = STATE(75),
+    [sym_parameter] = STATE(75),
+    [sym_text_env] = STATE(75),
+    [sym__display_math] = STATE(75),
+    [sym_tex_display_math] = STATE(75),
+    [sym_latex_display_math] = STATE(75),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(73),
+    [sym_display_math_env] = STATE(75),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(73),
-    [sym_tex_inline_math] = STATE(73),
-    [sym_latex_inline_math] = STATE(73),
-    [sym_inline_math_env] = STATE(73),
+    [sym__inline_math] = STATE(75),
+    [sym_tex_inline_math] = STATE(75),
+    [sym_latex_inline_math] = STATE(75),
+    [sym_inline_math_env] = STATE(75),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(73),
+    [sym_verbatim_env] = STATE(75),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(73),
+    [sym_escaped] = STATE(75),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_end] = STATE(71),
-    [sym_end_token] = STATE(72),
-    [sym_documentclass] = STATE(73),
+    [sym_end] = STATE(73),
+    [sym_end_token] = STATE(74),
+    [sym_documentclass] = STATE(75),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(73),
+    [sym_usepackage] = STATE(75),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(73),
+    [sym_include] = STATE(75),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(73),
+    [sym_section] = STATE(75),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(73),
+    [sym_storage] = STATE(75),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(73),
+    [sym_catcode] = STATE(75),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(73),
+    [sym_emph] = STATE(75),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(73),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(73),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(73),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(73),
-    [sym_opt_text_group] = STATE(73),
-    [sym_token] = STATE(73),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(73),
+    [sym_footnote] = STATE(75),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(75),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(75),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(75),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(75),
+    [sym_opt_text_group] = STATE(75),
+    [sym_token] = STATE(75),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(75),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(87),
+    [sym__escape] = ACTIONS(89),
     [sym_begin_group] = ACTIONS(15),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(89),
+    [sym_alignment_tab] = ACTIONS(91),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(89),
-    [sym_text] = ACTIONS(89),
+    [sym_active_char] = ACTIONS(91),
+    [sym_text] = ACTIONS(91),
   },
   [16] = {
-    [sym_display_math_env_group] = STATE(75),
-    [sym_inline_math_env_group] = STATE(76),
-    [sym_verbatim_env_group] = STATE(77),
-    [sym_simple_text_group] = STATE(78),
+    [sym_display_math_env_group] = STATE(77),
+    [sym_inline_math_env_group] = STATE(78),
+    [sym_verbatim_env_group] = STATE(79),
+    [sym_simple_text_group] = STATE(80),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(91),
+    [sym_begin_group] = ACTIONS(93),
   },
   [17] = {
-    [sym_simple_text_group] = STATE(80),
-    [sym_opt_text_group] = STATE(81),
-    [sym_begin_opt] = STATE(29),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
-  },
-  [18] = {
     [sym_simple_text_group] = STATE(82),
     [sym_opt_text_group] = STATE(83),
-    [sym_begin_opt] = STATE(29),
+    [sym_begin_opt] = STATE(84),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
+    [sym_begin_group] = ACTIONS(95),
+  },
+  [18] = {
+    [sym_simple_text_group] = STATE(85),
+    [sym_opt_text_group] = STATE(86),
+    [sym_begin_opt] = STATE(84),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(95),
   },
   [19] = {
-    [sym_text_group] = STATE(84),
+    [sym_text_group] = STATE(87),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
   [20] = {
-    [sym_text_group] = STATE(85),
-    [sym_opt_text_group] = STATE(86),
-    [sym_begin_opt] = STATE(29),
+    [sym_text_group] = STATE(88),
+    [sym_opt_text_group] = STATE(89),
+    [sym_begin_opt] = STATE(84),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
   [21] = {
-    [ts_builtin_sym_end] = ACTIONS(95),
-    [anon_sym_LBRACK] = ACTIONS(95),
-    [anon_sym_RBRACK] = ACTIONS(95),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(95),
-    [sym_begin_group] = ACTIONS(95),
-    [sym_end_group] = ACTIONS(95),
-    [sym_math_shift] = ACTIONS(95),
-    [sym_alignment_tab] = ACTIONS(95),
-    [sym_parameter_char] = ACTIONS(95),
-    [sym_superscript] = ACTIONS(95),
-    [sym_subscript] = ACTIONS(95),
-    [sym_active_char] = ACTIONS(95),
-    [sym_text] = ACTIONS(95),
-  },
-  [22] = {
-    [sym_escaped] = STATE(88),
+    [ts_builtin_sym_end] = ACTIONS(97),
+    [anon_sym_LBRACK] = ACTIONS(97),
+    [anon_sym_RBRACK] = ACTIONS(97),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(97),
+    [sym_begin_group] = ACTIONS(97),
+    [sym_end_group] = ACTIONS(97),
+    [sym_math_shift] = ACTIONS(97),
+    [sym_alignment_tab] = ACTIONS(97),
+    [sym_parameter_char] = ACTIONS(97),
+    [sym_superscript] = ACTIONS(97),
+    [sym_subscript] = ACTIONS(97),
+    [sym_active_char] = ACTIONS(97),
+    [sym_text] = ACTIONS(97),
+  },
+  [22] = {
+    [sym_escaped] = STATE(91),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(99),
   },
   [23] = {
-    [sym_text_group] = STATE(89),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [24] = {
-    [sym_text_group] = STATE(90),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [25] = {
-    [sym_text_group] = STATE(91),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [26] = {
     [sym_text_group] = STATE(92),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
-  [27] = {
-    [sym__common] = STATE(112),
-    [sym__text_mode_common] = STATE(112),
-    [sym__text_mode_at] = STATE(112),
-    [sym_text_mode_at] = STATE(96),
-    [sym_parameter] = STATE(112),
-    [sym_text_env_at] = STATE(112),
-    [sym__display_math_at] = STATE(112),
-    [sym_tex_display_math_at] = STATE(112),
-    [sym_latex_display_math_at] = STATE(112),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(112),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(112),
-    [sym_tex_inline_math_at] = STATE(112),
-    [sym_latex_inline_math_at] = STATE(112),
-    [sym_inline_math_env_at] = STATE(112),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(112),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(112),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(112),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(112),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(112),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(112),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(112),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(112),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(112),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(112),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(112),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(112),
-    [sym_texttt_token] = STATE(108),
-    [sym_makeatother] = STATE(109),
-    [sym_makeatother_token] = STATE(110),
-    [sym_text_group_at] = STATE(112),
-    [sym_opt_text_group_at] = STATE(112),
-    [sym_token_at] = STATE(112),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(112),
+  [24] = {
+    [sym_text_group] = STATE(93),
+    [sym_opt_text_group] = STATE(94),
+    [sym_begin_opt] = STATE(84),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(99),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(105),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [25] = {
+    [sym_text_group] = STATE(95),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [26] = {
+    [sym_text_group] = STATE(96),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [27] = {
+    [sym_text_group] = STATE(97),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [28] = {
+    [sym__common] = STATE(118),
+    [sym__text_mode_common] = STATE(118),
+    [sym__text_mode_at] = STATE(118),
+    [sym_text_mode_at] = STATE(101),
+    [sym_parameter] = STATE(118),
+    [sym_text_env_at] = STATE(118),
+    [sym__display_math_at] = STATE(118),
+    [sym_tex_display_math_at] = STATE(118),
+    [sym_latex_display_math_at] = STATE(118),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(118),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(118),
+    [sym_tex_inline_math_at] = STATE(118),
+    [sym_latex_inline_math_at] = STATE(118),
+    [sym_inline_math_env_at] = STATE(118),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(118),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(118),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(118),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(118),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(118),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(118),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(118),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(118),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(118),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(118),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(118),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(118),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(118),
+    [sym_texttt_token] = STATE(114),
+    [sym_makeatother] = STATE(115),
+    [sym_makeatother_token] = STATE(116),
+    [sym_text_group_at] = STATE(118),
+    [sym_opt_text_group_at] = STATE(118),
+    [sym_token_at] = STATE(118),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(118),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(101),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(107),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(105),
-    [sym_text] = ACTIONS(105),
-  },
-  [28] = {
-    [anon_sym_LBRACK] = ACTIONS(107),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(107),
-    [sym_begin_group] = ACTIONS(107),
-    [sym_math_shift] = ACTIONS(107),
-    [sym_alignment_tab] = ACTIONS(107),
-    [sym_parameter_char] = ACTIONS(107),
-    [sym_superscript] = ACTIONS(107),
-    [sym_subscript] = ACTIONS(107),
     [sym_active_char] = ACTIONS(107),
     [sym_text] = ACTIONS(107),
   },
   [29] = {
-    [sym__common] = STATE(115),
-    [sym__text_mode_common] = STATE(115),
-    [sym__text_mode] = STATE(115),
-    [sym_text_mode_at_region] = STATE(115),
-    [sym_parameter] = STATE(115),
-    [sym_text_env] = STATE(115),
-    [sym__display_math] = STATE(115),
-    [sym_tex_display_math] = STATE(115),
-    [sym_latex_display_math] = STATE(115),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(115),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(115),
-    [sym_tex_inline_math] = STATE(115),
-    [sym_latex_inline_math] = STATE(115),
-    [sym_inline_math_env] = STATE(115),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(115),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(115),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(115),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(115),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(115),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(115),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(115),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(115),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(115),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(115),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(115),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(115),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(115),
-    [sym_opt_text_group] = STATE(115),
-    [sym_token] = STATE(115),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(114),
-    [aux_sym_text_mode_repeat1] = STATE(115),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
+    [anon_sym_LBRACK] = ACTIONS(109),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(111),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(111),
-    [sym_text] = ACTIONS(111),
+    [sym__escape] = ACTIONS(109),
+    [sym_begin_group] = ACTIONS(109),
+    [sym_math_shift] = ACTIONS(109),
+    [sym_alignment_tab] = ACTIONS(109),
+    [sym_parameter_char] = ACTIONS(109),
+    [sym_superscript] = ACTIONS(109),
+    [sym_subscript] = ACTIONS(109),
+    [sym_active_char] = ACTIONS(109),
+    [sym_text] = ACTIONS(109),
   },
   [30] = {
-    [sym__common] = STATE(116),
-    [sym__text_mode_common] = STATE(116),
-    [sym__text_mode] = STATE(116),
-    [sym_text_mode_at_region] = STATE(116),
-    [sym_parameter] = STATE(116),
-    [sym_text_env] = STATE(116),
-    [sym__display_math] = STATE(116),
-    [sym_tex_display_math] = STATE(116),
-    [sym_latex_display_math] = STATE(116),
+    [sym__common] = STATE(121),
+    [sym__text_mode_common] = STATE(121),
+    [sym__text_mode] = STATE(121),
+    [sym_text_mode_at_region] = STATE(121),
+    [sym_parameter] = STATE(121),
+    [sym_text_env] = STATE(121),
+    [sym__display_math] = STATE(121),
+    [sym_tex_display_math] = STATE(121),
+    [sym_latex_display_math] = STATE(121),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(116),
+    [sym_display_math_env] = STATE(121),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(116),
-    [sym_tex_inline_math] = STATE(116),
-    [sym_latex_inline_math] = STATE(116),
-    [sym_inline_math_env] = STATE(116),
+    [sym__inline_math] = STATE(121),
+    [sym_tex_inline_math] = STATE(121),
+    [sym_latex_inline_math] = STATE(121),
+    [sym_inline_math_env] = STATE(121),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(116),
+    [sym_verbatim_env] = STATE(121),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(116),
+    [sym_escaped] = STATE(121),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(116),
+    [sym_documentclass] = STATE(121),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(116),
+    [sym_usepackage] = STATE(121),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(116),
+    [sym_include] = STATE(121),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(116),
+    [sym_section] = STATE(121),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(116),
+    [sym_storage] = STATE(121),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(116),
+    [sym_catcode] = STATE(121),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(116),
+    [sym_emph] = STATE(121),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(116),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(116),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(116),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(116),
-    [sym_opt_text_group] = STATE(116),
-    [sym_token] = STATE(116),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(116),
-    [ts_builtin_sym_end] = ACTIONS(113),
+    [sym_footnote] = STATE(121),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(121),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(121),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(121),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(121),
+    [sym_opt_text_group] = STATE(121),
+    [sym_token] = STATE(121),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(120),
+    [aux_sym_text_mode_repeat1] = STATE(121),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(113),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(113),
+    [sym_text] = ACTIONS(113),
+  },
+  [31] = {
+    [sym__common] = STATE(122),
+    [sym__text_mode_common] = STATE(122),
+    [sym__text_mode] = STATE(122),
+    [sym_text_mode_at_region] = STATE(122),
+    [sym_parameter] = STATE(122),
+    [sym_text_env] = STATE(122),
+    [sym__display_math] = STATE(122),
+    [sym_tex_display_math] = STATE(122),
+    [sym_latex_display_math] = STATE(122),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(122),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(122),
+    [sym_tex_inline_math] = STATE(122),
+    [sym_latex_inline_math] = STATE(122),
+    [sym_inline_math_env] = STATE(122),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(122),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(122),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(122),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(122),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(122),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(122),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(122),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(122),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(122),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(122),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(122),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(122),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(122),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(122),
+    [sym_opt_text_group] = STATE(122),
+    [sym_token] = STATE(122),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(122),
+    [ts_builtin_sym_end] = ACTIONS(115),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(115),
+    [sym_alignment_tab] = ACTIONS(117),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(115),
-    [sym_text] = ACTIONS(115),
-  },
-  [31] = {
-    [anon_sym_LBRACK] = ACTIONS(117),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(117),
-    [sym_begin_group] = ACTIONS(117),
-    [sym_alignment_tab] = ACTIONS(117),
-    [sym_parameter_char] = ACTIONS(117),
-    [sym_superscript] = ACTIONS(117),
-    [sym_subscript] = ACTIONS(117),
     [sym_active_char] = ACTIONS(117),
     [sym_text] = ACTIONS(117),
   },
@@ -6177,128 +6458,73 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_parameter_char] = ACTIONS(119),
     [sym_superscript] = ACTIONS(119),
     [sym_subscript] = ACTIONS(119),
+    [sym__whitespace] = ACTIONS(121),
     [sym_active_char] = ACTIONS(119),
-    [sym_text] = ACTIONS(119),
+    [sym_text] = ACTIONS(123),
   },
   [33] = {
-    [ts_builtin_sym_end] = ACTIONS(121),
-    [anon_sym_LBRACK] = ACTIONS(121),
-    [anon_sym_RBRACK] = ACTIONS(121),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(121),
-    [sym_begin_group] = ACTIONS(121),
-    [sym_end_group] = ACTIONS(121),
-    [sym_math_shift] = ACTIONS(121),
-    [sym_alignment_tab] = ACTIONS(121),
-    [sym_parameter_char] = ACTIONS(121),
-    [sym_superscript] = ACTIONS(121),
-    [sym_subscript] = ACTIONS(121),
-    [sym_active_char] = ACTIONS(121),
-    [sym_text] = ACTIONS(121),
-  },
-  [34] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(123),
-  },
-  [35] = {
     [anon_sym_LBRACK] = ACTIONS(125),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(125),
     [sym_begin_group] = ACTIONS(125),
+    [sym_alignment_tab] = ACTIONS(125),
+    [sym_parameter_char] = ACTIONS(125),
+    [sym_superscript] = ACTIONS(125),
+    [sym_subscript] = ACTIONS(125),
+    [sym__whitespace] = ACTIONS(127),
+    [sym_active_char] = ACTIONS(125),
+    [sym_text] = ACTIONS(129),
+  },
+  [34] = {
+    [ts_builtin_sym_end] = ACTIONS(131),
+    [anon_sym_LBRACK] = ACTIONS(131),
+    [anon_sym_RBRACK] = ACTIONS(131),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(131),
+    [sym_begin_group] = ACTIONS(131),
+    [sym_end_group] = ACTIONS(131),
+    [sym_math_shift] = ACTIONS(131),
+    [sym_alignment_tab] = ACTIONS(131),
+    [sym_parameter_char] = ACTIONS(131),
+    [sym_superscript] = ACTIONS(131),
+    [sym_subscript] = ACTIONS(131),
+    [sym_active_char] = ACTIONS(131),
+    [sym_text] = ACTIONS(131),
+  },
+  [35] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(133),
+    [sym__whitespace] = ACTIONS(135),
   },
   [36] = {
-    [anon_sym_LBRACK] = ACTIONS(127),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(127),
-  },
-  [37] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(129),
-  },
-  [38] = {
-    [anon_sym_LBRACK] = ACTIONS(131),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(131),
-  },
-  [39] = {
-    [ts_builtin_sym_end] = ACTIONS(133),
-    [anon_sym_LBRACK] = ACTIONS(133),
-    [anon_sym_RBRACK] = ACTIONS(133),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(133),
-    [sym_begin_group] = ACTIONS(133),
-    [sym_end_group] = ACTIONS(133),
-    [sym_math_shift] = ACTIONS(133),
-    [sym_alignment_tab] = ACTIONS(133),
-    [sym_parameter_char] = ACTIONS(133),
-    [sym_superscript] = ACTIONS(133),
-    [sym_subscript] = ACTIONS(133),
-    [sym_active_char] = ACTIONS(133),
-    [sym_text] = ACTIONS(133),
-  },
-  [40] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(135),
-  },
-  [41] = {
+    [anon_sym_LBRACK] = ACTIONS(137),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(137),
+    [sym__whitespace] = ACTIONS(139),
   },
-  [42] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(139),
-  },
-  [43] = {
+  [37] = {
+    [anon_sym_LBRACK] = ACTIONS(141),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(141),
+    [sym__whitespace] = ACTIONS(143),
   },
-  [44] = {
+  [38] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(143),
-  },
-  [45] = {
-    [anon_sym_LBRACK] = ACTIONS(145),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(145),
     [sym_begin_group] = ACTIONS(145),
-    [sym_math_shift] = ACTIONS(145),
-    [sym_alignment_tab] = ACTIONS(145),
-    [sym_parameter_char] = ACTIONS(145),
-    [sym_superscript] = ACTIONS(145),
-    [sym_subscript] = ACTIONS(145),
-    [sym_active_char] = ACTIONS(145),
-    [sym_text] = ACTIONS(145),
   },
-  [46] = {
-    [ts_builtin_sym_end] = ACTIONS(147),
+  [39] = {
     [anon_sym_LBRACK] = ACTIONS(147),
-    [anon_sym_RBRACK] = ACTIONS(147),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(147),
     [sym_begin_group] = ACTIONS(147),
-    [sym_end_group] = ACTIONS(147),
-    [sym_math_shift] = ACTIONS(147),
-    [sym_alignment_tab] = ACTIONS(147),
-    [sym_parameter_char] = ACTIONS(147),
-    [sym_superscript] = ACTIONS(147),
-    [sym_subscript] = ACTIONS(147),
-    [sym_active_char] = ACTIONS(147),
-    [sym_text] = ACTIONS(147),
   },
-  [47] = {
+  [40] = {
     [ts_builtin_sym_end] = ACTIONS(149),
     [anon_sym_LBRACK] = ACTIONS(149),
     [anon_sym_RBRACK] = ACTIONS(149),
@@ -6315,359 +6541,76 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(149),
     [sym_text] = ACTIONS(149),
   },
-  [48] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [41] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(151),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(153),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(153),
-    [sym_text] = ACTIONS(153),
+    [sym__escape] = ACTIONS(151),
   },
-  [49] = {
-    [anon_sym_tag] = ACTIONS(155),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+  [42] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(57),
+    [sym_begin_group] = ACTIONS(153),
+    [sym__whitespace] = ACTIONS(155),
   },
-  [50] = {
-    [sym__common] = STATE(121),
-    [sym__math_mode_common] = STATE(121),
-    [sym__math_mode] = STATE(121),
-    [sym_parameter] = STATE(121),
-    [sym_math_env] = STATE(121),
-    [sym_tag] = STATE(121),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(121),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(121),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(121),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(121),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(121),
-    [sym_opt_math_group] = STATE(121),
-    [sym_token] = STATE(121),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(121),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [43] = {
+    [anon_sym_LBRACK] = ACTIONS(157),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_end_group] = ACTIONS(157),
-    [sym_alignment_tab] = ACTIONS(159),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(159),
-    [sym_subscript] = ACTIONS(159),
-    [sym_active_char] = ACTIONS(159),
-    [sym_text] = ACTIONS(159),
+    [sym_begin_group] = ACTIONS(157),
+    [sym__whitespace] = ACTIONS(159),
   },
-  [51] = {
-    [sym__common] = STATE(57),
-    [sym__math_mode_common] = STATE(57),
-    [sym__math_mode] = STATE(57),
-    [sym_math_mode] = STATE(122),
-    [sym_parameter] = STATE(57),
-    [sym_math_env] = STATE(57),
-    [sym_tag] = STATE(57),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(57),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(57),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(57),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(57),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(57),
-    [sym_opt_math_group] = STATE(57),
-    [sym_token] = STATE(57),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(57),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [44] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(69),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(69),
-    [sym_subscript] = ACTIONS(69),
-    [sym_active_char] = ACTIONS(69),
-    [sym_text] = ACTIONS(69),
+    [sym_begin_group] = ACTIONS(161),
+    [sym__whitespace] = ACTIONS(163),
   },
-  [52] = {
+  [45] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(161),
+    [sym_begin_group] = ACTIONS(165),
+    [sym__whitespace] = ACTIONS(167),
   },
-  [53] = {
-    [sym_math_text_group] = STATE(125),
+  [46] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(163),
+    [sym_begin_group] = ACTIONS(169),
+    [sym__whitespace] = ACTIONS(171),
   },
-  [54] = {
-    [sym__common] = STATE(128),
-    [sym__math_mode_common] = STATE(128),
-    [sym__math_mode] = STATE(128),
-    [sym_parameter] = STATE(128),
-    [sym_math_env] = STATE(128),
-    [sym_tag] = STATE(128),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(128),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_end] = STATE(127),
-    [sym_end_token] = STATE(72),
-    [sym_include] = STATE(128),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(128),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(128),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(128),
-    [sym_opt_math_group] = STATE(128),
-    [sym_token] = STATE(128),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(128),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [47] = {
+    [anon_sym_LBRACK] = ACTIONS(173),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(165),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(167),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(167),
-    [sym_subscript] = ACTIONS(167),
-    [sym_active_char] = ACTIONS(167),
-    [sym_text] = ACTIONS(167),
-  },
-  [55] = {
-    [sym_simple_text_group] = STATE(78),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
-  },
-  [56] = {
-    [sym__common] = STATE(130),
-    [sym__math_mode_common] = STATE(130),
-    [sym__math_mode] = STATE(130),
-    [sym_parameter] = STATE(130),
-    [sym_math_env] = STATE(130),
-    [sym_tag] = STATE(130),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(130),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(130),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(130),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(130),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(130),
-    [sym_opt_math_group] = STATE(130),
-    [sym_token] = STATE(130),
-    [sym_begin_opt] = STATE(56),
-    [sym_end_opt] = STATE(129),
-    [aux_sym_math_mode_repeat1] = STATE(130),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(169),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(169),
-    [sym_subscript] = ACTIONS(169),
-    [sym_active_char] = ACTIONS(169),
-    [sym_text] = ACTIONS(169),
-  },
-  [57] = {
-    [sym__common] = STATE(131),
-    [sym__math_mode_common] = STATE(131),
-    [sym__math_mode] = STATE(131),
-    [sym_parameter] = STATE(131),
-    [sym_math_env] = STATE(131),
-    [sym_tag] = STATE(131),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(131),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(131),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(131),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(131),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(131),
-    [sym_opt_math_group] = STATE(131),
-    [sym_token] = STATE(131),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(131),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_math_shift] = ACTIONS(171),
+    [sym__escape] = ACTIONS(173),
+    [sym_begin_group] = ACTIONS(173),
+    [sym_math_shift] = ACTIONS(173),
     [sym_alignment_tab] = ACTIONS(173),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(173),
     [sym_superscript] = ACTIONS(173),
     [sym_subscript] = ACTIONS(173),
+    [sym__whitespace] = ACTIONS(175),
     [sym_active_char] = ACTIONS(173),
-    [sym_text] = ACTIONS(173),
+    [sym_text] = ACTIONS(177),
   },
-  [58] = {
-    [ts_builtin_sym_end] = ACTIONS(175),
-    [anon_sym_LBRACK] = ACTIONS(175),
-    [anon_sym_RBRACK] = ACTIONS(175),
+  [48] = {
+    [ts_builtin_sym_end] = ACTIONS(179),
+    [anon_sym_LBRACK] = ACTIONS(179),
+    [anon_sym_RBRACK] = ACTIONS(179),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(175),
-    [sym_begin_group] = ACTIONS(175),
-    [sym_end_group] = ACTIONS(175),
-    [sym_math_shift] = ACTIONS(175),
-    [sym_alignment_tab] = ACTIONS(175),
-    [sym_parameter_char] = ACTIONS(175),
-    [sym_superscript] = ACTIONS(175),
-    [sym_subscript] = ACTIONS(175),
-    [sym_active_char] = ACTIONS(175),
-    [sym_text] = ACTIONS(175),
-  },
-  [59] = {
-    [sym_end_display_math] = STATE(133),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(177),
-  },
-  [60] = {
-    [sym__common] = STATE(134),
-    [sym__math_mode_common] = STATE(134),
-    [sym__math_mode] = STATE(134),
-    [sym_parameter] = STATE(134),
-    [sym_math_env] = STATE(134),
-    [sym_tag] = STATE(134),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(134),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(134),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(134),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(134),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(134),
-    [sym_opt_math_group] = STATE(134),
-    [sym_token] = STATE(134),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(134),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(171),
-    [sym_begin_group] = ACTIONS(65),
+    [sym__escape] = ACTIONS(179),
+    [sym_begin_group] = ACTIONS(179),
+    [sym_end_group] = ACTIONS(179),
+    [sym_math_shift] = ACTIONS(179),
     [sym_alignment_tab] = ACTIONS(179),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(179),
     [sym_superscript] = ACTIONS(179),
     [sym_subscript] = ACTIONS(179),
+    [sym__whitespace] = ACTIONS(181),
     [sym_active_char] = ACTIONS(179),
-    [sym_text] = ACTIONS(179),
+    [sym_text] = ACTIONS(183),
   },
-  [61] = {
-    [sym_end_inline_math] = STATE(136),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(181),
-  },
-  [62] = {
-    [sym_display_math_end] = STATE(137),
-    [sym_end_token] = STATE(138),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
-  },
-  [63] = {
-    [sym_inline_math_end] = STATE(139),
-    [sym_end_token] = STATE(140),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
-  },
-  [64] = {
-    [anon_sym_end] = ACTIONS(183),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [65] = {
+  [49] = {
     [ts_builtin_sym_end] = ACTIONS(185),
     [anon_sym_LBRACK] = ACTIONS(185),
     [anon_sym_RBRACK] = ACTIONS(185),
@@ -6684,41 +6627,412 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(185),
     [sym_text] = ACTIONS(185),
   },
-  [66] = {
-    [sym_verbatim_end] = STATE(142),
-    [sym_end_token] = STATE(67),
+  [50] = {
+    [sym__common] = STATE(136),
+    [sym__text_mode_common] = STATE(136),
+    [sym__text_mode] = STATE(136),
+    [sym_text_mode_at_region] = STATE(136),
+    [sym_parameter] = STATE(136),
+    [sym_text_env] = STATE(136),
+    [sym__display_math] = STATE(136),
+    [sym_tex_display_math] = STATE(136),
+    [sym_latex_display_math] = STATE(136),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(136),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(136),
+    [sym_tex_inline_math] = STATE(136),
+    [sym_latex_inline_math] = STATE(136),
+    [sym_inline_math_env] = STATE(136),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(136),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(136),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(136),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(136),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(136),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(136),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(136),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(136),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(136),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(136),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(136),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(136),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(136),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(136),
+    [sym_opt_text_group] = STATE(136),
+    [sym_token] = STATE(136),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(136),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(187),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(189),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(189),
+    [sym_text] = ACTIONS(189),
+  },
+  [51] = {
+    [anon_sym_tag] = ACTIONS(191),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name] = ACTIONS(59),
+  },
+  [52] = {
+    [sym__common] = STATE(139),
+    [sym__math_mode_common] = STATE(139),
+    [sym__math_mode] = STATE(139),
+    [sym_parameter] = STATE(139),
+    [sym_math_env] = STATE(139),
+    [sym_tag] = STATE(139),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(139),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(139),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(139),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(139),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(139),
+    [sym_opt_math_group] = STATE(139),
+    [sym_token] = STATE(139),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(139),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_end_group] = ACTIONS(193),
+    [sym_alignment_tab] = ACTIONS(195),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(195),
+    [sym_subscript] = ACTIONS(195),
+    [sym_active_char] = ACTIONS(195),
+    [sym_text] = ACTIONS(195),
+  },
+  [53] = {
+    [sym__common] = STATE(59),
+    [sym__math_mode_common] = STATE(59),
+    [sym__math_mode] = STATE(59),
+    [sym_math_mode] = STATE(140),
+    [sym_parameter] = STATE(59),
+    [sym_math_env] = STATE(59),
+    [sym_tag] = STATE(59),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(59),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(59),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(59),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(59),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(59),
+    [sym_opt_math_group] = STATE(59),
+    [sym_token] = STATE(59),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(59),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(71),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(71),
+    [sym_subscript] = ACTIONS(71),
+    [sym_active_char] = ACTIONS(71),
+    [sym_text] = ACTIONS(71),
+  },
+  [54] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(197),
+  },
+  [55] = {
+    [sym_math_text_group] = STATE(143),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(199),
+  },
+  [56] = {
+    [sym__common] = STATE(146),
+    [sym__math_mode_common] = STATE(146),
+    [sym__math_mode] = STATE(146),
+    [sym_parameter] = STATE(146),
+    [sym_math_env] = STATE(146),
+    [sym_tag] = STATE(146),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(146),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_end] = STATE(145),
+    [sym_end_token] = STATE(74),
+    [sym_include] = STATE(146),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(146),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(146),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(146),
+    [sym_opt_math_group] = STATE(146),
+    [sym_token] = STATE(146),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(146),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(201),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(203),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(203),
+    [sym_subscript] = ACTIONS(203),
+    [sym_active_char] = ACTIONS(203),
+    [sym_text] = ACTIONS(203),
+  },
+  [57] = {
+    [sym_simple_text_group] = STATE(80),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(95),
+  },
+  [58] = {
+    [sym__common] = STATE(148),
+    [sym__math_mode_common] = STATE(148),
+    [sym__math_mode] = STATE(148),
+    [sym_parameter] = STATE(148),
+    [sym_math_env] = STATE(148),
+    [sym_tag] = STATE(148),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(148),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(148),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(148),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(148),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(148),
+    [sym_opt_math_group] = STATE(148),
+    [sym_token] = STATE(148),
+    [sym_begin_opt] = STATE(58),
+    [sym_end_opt] = STATE(147),
+    [aux_sym_math_mode_repeat1] = STATE(148),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(205),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(205),
+    [sym_subscript] = ACTIONS(205),
+    [sym_active_char] = ACTIONS(205),
+    [sym_text] = ACTIONS(205),
+  },
+  [59] = {
+    [sym__common] = STATE(149),
+    [sym__math_mode_common] = STATE(149),
+    [sym__math_mode] = STATE(149),
+    [sym_parameter] = STATE(149),
+    [sym_math_env] = STATE(149),
+    [sym_tag] = STATE(149),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(149),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(149),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(149),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(149),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(149),
+    [sym_opt_math_group] = STATE(149),
+    [sym_token] = STATE(149),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(149),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_math_shift] = ACTIONS(207),
+    [sym_alignment_tab] = ACTIONS(209),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(209),
+    [sym_subscript] = ACTIONS(209),
+    [sym_active_char] = ACTIONS(209),
+    [sym_text] = ACTIONS(209),
+  },
+  [60] = {
+    [ts_builtin_sym_end] = ACTIONS(211),
+    [anon_sym_LBRACK] = ACTIONS(211),
+    [anon_sym_RBRACK] = ACTIONS(211),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(211),
+    [sym_begin_group] = ACTIONS(211),
+    [sym_end_group] = ACTIONS(211),
+    [sym_math_shift] = ACTIONS(211),
+    [sym_alignment_tab] = ACTIONS(211),
+    [sym_parameter_char] = ACTIONS(211),
+    [sym_superscript] = ACTIONS(211),
+    [sym_subscript] = ACTIONS(211),
+    [sym_active_char] = ACTIONS(211),
+    [sym_text] = ACTIONS(211),
+  },
+  [61] = {
+    [sym_end_display_math] = STATE(151),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(213),
+  },
+  [62] = {
+    [sym__common] = STATE(152),
+    [sym__math_mode_common] = STATE(152),
+    [sym__math_mode] = STATE(152),
+    [sym_parameter] = STATE(152),
+    [sym_math_env] = STATE(152),
+    [sym_tag] = STATE(152),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(152),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(152),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(152),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(152),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(152),
+    [sym_opt_math_group] = STATE(152),
+    [sym_token] = STATE(152),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(152),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(207),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(215),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(215),
+    [sym_subscript] = ACTIONS(215),
+    [sym_active_char] = ACTIONS(215),
+    [sym_text] = ACTIONS(215),
+  },
+  [63] = {
+    [sym_end_inline_math] = STATE(154),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(217),
+  },
+  [64] = {
+    [sym_display_math_end] = STATE(155),
+    [sym_end_token] = STATE(156),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(85),
+  },
+  [65] = {
+    [sym_inline_math_end] = STATE(157),
+    [sym_end_token] = STATE(158),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(85),
+  },
+  [66] = {
+    [anon_sym_end] = ACTIONS(219),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
   },
   [67] = {
-    [sym_verbatim_env_group] = STATE(144),
+    [ts_builtin_sym_end] = ACTIONS(221),
+    [anon_sym_LBRACK] = ACTIONS(221),
+    [anon_sym_RBRACK] = ACTIONS(221),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(187),
+    [sym__escape] = ACTIONS(221),
+    [sym_begin_group] = ACTIONS(221),
+    [sym_end_group] = ACTIONS(221),
+    [sym_math_shift] = ACTIONS(221),
+    [sym_alignment_tab] = ACTIONS(221),
+    [sym_parameter_char] = ACTIONS(221),
+    [sym_superscript] = ACTIONS(221),
+    [sym_subscript] = ACTIONS(221),
+    [sym_active_char] = ACTIONS(221),
+    [sym_text] = ACTIONS(221),
   },
   [68] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(146),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(189),
+    [sym_verbatim_end] = STATE(160),
+    [sym_end_token] = STATE(69),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(191),
+    [sym__escape] = ACTIONS(85),
   },
   [69] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(68),
-    [aux_sym_verbatim_text_repeat2] = STATE(147),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(81),
+    [sym_verbatim_env_group] = STATE(162),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(193),
-    [sym__end_of_line] = ACTIONS(195),
+    [sym_begin_group] = ACTIONS(223),
   },
   [70] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(164),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(225),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(227),
+  },
+  [71] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(70),
+    [aux_sym_verbatim_text_repeat2] = STATE(165),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(83),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(229),
+    [sym__end_of_line] = ACTIONS(231),
+  },
+  [72] = {
     [anon_sym_LBRACK] = ACTIONS(27),
     [anon_sym_LPAREN] = ACTIONS(29),
     [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
     [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_end] = ACTIONS(197),
+    [anon_sym_end] = ACTIONS(233),
     [anon_sym_documentclass] = ACTIONS(35),
     [anon_sym_usepackage] = ACTIONS(37),
     [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
@@ -6726,260 +7040,16 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
     [anon_sym_emph] = ACTIONS(47),
-    [anon_sym_textbf] = ACTIONS(49),
-    [anon_sym_textit] = ACTIONS(51),
-    [anon_sym_texttt] = ACTIONS(53),
-    [anon_sym_makeatletter] = ACTIONS(55),
+    [anon_sym_footnote] = ACTIONS(49),
+    [anon_sym_textbf] = ACTIONS(51),
+    [anon_sym_textit] = ACTIONS(53),
+    [anon_sym_texttt] = ACTIONS(55),
+    [anon_sym_makeatletter] = ACTIONS(57),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(57),
-  },
-  [71] = {
-    [ts_builtin_sym_end] = ACTIONS(199),
-    [anon_sym_LBRACK] = ACTIONS(199),
-    [anon_sym_RBRACK] = ACTIONS(199),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(199),
-    [sym_begin_group] = ACTIONS(199),
-    [sym_end_group] = ACTIONS(199),
-    [sym_math_shift] = ACTIONS(199),
-    [sym_alignment_tab] = ACTIONS(199),
-    [sym_parameter_char] = ACTIONS(199),
-    [sym_superscript] = ACTIONS(199),
-    [sym_subscript] = ACTIONS(199),
-    [sym_active_char] = ACTIONS(199),
-    [sym_text] = ACTIONS(199),
-  },
-  [72] = {
-    [sym_simple_text_group] = STATE(148),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
+    [sym__name] = ACTIONS(59),
   },
   [73] = {
-    [sym__common] = STATE(150),
-    [sym__text_mode_common] = STATE(150),
-    [sym__text_mode] = STATE(150),
-    [sym_text_mode_at_region] = STATE(150),
-    [sym_parameter] = STATE(150),
-    [sym_text_env] = STATE(150),
-    [sym__display_math] = STATE(150),
-    [sym_tex_display_math] = STATE(150),
-    [sym_latex_display_math] = STATE(150),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(150),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(150),
-    [sym_tex_inline_math] = STATE(150),
-    [sym_latex_inline_math] = STATE(150),
-    [sym_inline_math_env] = STATE(150),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(150),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(150),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_end] = STATE(149),
-    [sym_end_token] = STATE(72),
-    [sym_documentclass] = STATE(150),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(150),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(150),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(150),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(150),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(150),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(150),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(150),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(150),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(150),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(150),
-    [sym_opt_text_group] = STATE(150),
-    [sym_token] = STATE(150),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(150),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(87),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(201),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(201),
-    [sym_text] = ACTIONS(201),
-  },
-  [74] = {
-    [sym_display_math_env_name] = ACTIONS(203),
-    [sym_inline_math_env_name] = ACTIONS(205),
-    [sym_verbatim_env_name] = ACTIONS(207),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_text] = ACTIONS(209),
-  },
-  [75] = {
-    [sym_text_group] = STATE(157),
-    [sym_opt_text_group] = STATE(158),
-    [sym_begin_opt] = STATE(159),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(211),
-    [sym__end_of_line] = ACTIONS(213),
-  },
-  [76] = {
-    [anon_sym_LBRACK] = ACTIONS(215),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(215),
-    [sym_begin_group] = ACTIONS(215),
-    [sym_alignment_tab] = ACTIONS(215),
-    [sym_parameter_char] = ACTIONS(215),
-    [sym_superscript] = ACTIONS(215),
-    [sym_subscript] = ACTIONS(215),
-    [sym_active_char] = ACTIONS(215),
-    [sym_text] = ACTIONS(215),
-  },
-  [77] = {
-    [sym_text_group] = STATE(161),
-    [sym_opt_text_group] = STATE(162),
-    [sym_begin_opt] = STATE(159),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(211),
-    [sym__end_of_line] = ACTIONS(217),
-  },
-  [78] = {
-    [anon_sym_LBRACK] = ACTIONS(219),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(219),
-    [sym_begin_group] = ACTIONS(219),
-    [sym_math_shift] = ACTIONS(219),
-    [sym_alignment_tab] = ACTIONS(219),
-    [sym_parameter_char] = ACTIONS(219),
-    [sym_superscript] = ACTIONS(219),
-    [sym_subscript] = ACTIONS(219),
-    [sym_active_char] = ACTIONS(219),
-    [sym_text] = ACTIONS(219),
-  },
-  [79] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_text] = ACTIONS(221),
-  },
-  [80] = {
-    [ts_builtin_sym_end] = ACTIONS(223),
-    [anon_sym_LBRACK] = ACTIONS(223),
-    [anon_sym_RBRACK] = ACTIONS(223),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(223),
-    [sym_begin_group] = ACTIONS(223),
-    [sym_end_group] = ACTIONS(223),
-    [sym_math_shift] = ACTIONS(223),
-    [sym_alignment_tab] = ACTIONS(223),
-    [sym_parameter_char] = ACTIONS(223),
-    [sym_superscript] = ACTIONS(223),
-    [sym_subscript] = ACTIONS(223),
-    [sym_active_char] = ACTIONS(223),
-    [sym_text] = ACTIONS(223),
-  },
-  [81] = {
-    [sym_simple_text_group] = STATE(163),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
-  },
-  [82] = {
-    [ts_builtin_sym_end] = ACTIONS(225),
-    [anon_sym_LBRACK] = ACTIONS(225),
-    [anon_sym_RBRACK] = ACTIONS(225),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(225),
-    [sym_begin_group] = ACTIONS(225),
-    [sym_end_group] = ACTIONS(225),
-    [sym_math_shift] = ACTIONS(225),
-    [sym_alignment_tab] = ACTIONS(225),
-    [sym_parameter_char] = ACTIONS(225),
-    [sym_superscript] = ACTIONS(225),
-    [sym_subscript] = ACTIONS(225),
-    [sym_active_char] = ACTIONS(225),
-    [sym_text] = ACTIONS(225),
-  },
-  [83] = {
-    [sym_simple_text_group] = STATE(164),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
-  },
-  [84] = {
-    [ts_builtin_sym_end] = ACTIONS(227),
-    [anon_sym_LBRACK] = ACTIONS(227),
-    [anon_sym_RBRACK] = ACTIONS(227),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(227),
-    [sym_begin_group] = ACTIONS(227),
-    [sym_end_group] = ACTIONS(227),
-    [sym_math_shift] = ACTIONS(227),
-    [sym_alignment_tab] = ACTIONS(227),
-    [sym_parameter_char] = ACTIONS(227),
-    [sym_superscript] = ACTIONS(227),
-    [sym_subscript] = ACTIONS(227),
-    [sym_active_char] = ACTIONS(227),
-    [sym_text] = ACTIONS(227),
-  },
-  [85] = {
-    [ts_builtin_sym_end] = ACTIONS(229),
-    [anon_sym_LBRACK] = ACTIONS(229),
-    [anon_sym_RBRACK] = ACTIONS(229),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(229),
-    [sym_begin_group] = ACTIONS(229),
-    [sym_end_group] = ACTIONS(229),
-    [sym_math_shift] = ACTIONS(229),
-    [sym_alignment_tab] = ACTIONS(229),
-    [sym_parameter_char] = ACTIONS(229),
-    [sym_superscript] = ACTIONS(229),
-    [sym_subscript] = ACTIONS(229),
-    [sym_active_char] = ACTIONS(229),
-    [sym_text] = ACTIONS(229),
-  },
-  [86] = {
-    [sym_text_group] = STATE(165),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [87] = {
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(231),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [88] = {
-    [anon_sym_EQ] = ACTIONS(233),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [89] = {
     [ts_builtin_sym_end] = ACTIONS(235),
     [anon_sym_LBRACK] = ACTIONS(235),
     [anon_sym_RBRACK] = ACTIONS(235),
@@ -6996,451 +7066,257 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(235),
     [sym_text] = ACTIONS(235),
   },
-  [90] = {
-    [ts_builtin_sym_end] = ACTIONS(237),
-    [anon_sym_LBRACK] = ACTIONS(237),
-    [anon_sym_RBRACK] = ACTIONS(237),
+  [74] = {
+    [sym_simple_text_group] = STATE(166),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(237),
-    [sym_begin_group] = ACTIONS(237),
-    [sym_end_group] = ACTIONS(237),
-    [sym_math_shift] = ACTIONS(237),
-    [sym_alignment_tab] = ACTIONS(237),
-    [sym_parameter_char] = ACTIONS(237),
-    [sym_superscript] = ACTIONS(237),
-    [sym_subscript] = ACTIONS(237),
-    [sym_active_char] = ACTIONS(237),
-    [sym_text] = ACTIONS(237),
+    [sym_begin_group] = ACTIONS(95),
   },
-  [91] = {
-    [ts_builtin_sym_end] = ACTIONS(239),
-    [anon_sym_LBRACK] = ACTIONS(239),
-    [anon_sym_RBRACK] = ACTIONS(239),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(239),
-    [sym_begin_group] = ACTIONS(239),
-    [sym_end_group] = ACTIONS(239),
-    [sym_math_shift] = ACTIONS(239),
-    [sym_alignment_tab] = ACTIONS(239),
-    [sym_parameter_char] = ACTIONS(239),
-    [sym_superscript] = ACTIONS(239),
-    [sym_subscript] = ACTIONS(239),
-    [sym_active_char] = ACTIONS(239),
-    [sym_text] = ACTIONS(239),
-  },
-  [92] = {
-    [ts_builtin_sym_end] = ACTIONS(241),
-    [anon_sym_LBRACK] = ACTIONS(241),
-    [anon_sym_RBRACK] = ACTIONS(241),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(241),
-    [sym_begin_group] = ACTIONS(241),
-    [sym_end_group] = ACTIONS(241),
-    [sym_math_shift] = ACTIONS(241),
-    [sym_alignment_tab] = ACTIONS(241),
-    [sym_parameter_char] = ACTIONS(241),
-    [sym_superscript] = ACTIONS(241),
-    [sym_subscript] = ACTIONS(241),
-    [sym_active_char] = ACTIONS(241),
-    [sym_text] = ACTIONS(241),
-  },
-  [93] = {
-    [anon_sym_LBRACK] = ACTIONS(27),
-    [anon_sym_LPAREN] = ACTIONS(29),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_documentclass] = ACTIONS(35),
-    [anon_sym_usepackage] = ACTIONS(37),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
-    [anon_sym_emph] = ACTIONS(47),
-    [anon_sym_textbf] = ACTIONS(49),
-    [anon_sym_textit] = ACTIONS(51),
-    [anon_sym_texttt] = ACTIONS(53),
-    [anon_sym_makeatother] = ACTIONS(243),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(245),
-  },
-  [94] = {
-    [sym__common] = STATE(172),
-    [sym__text_mode_common] = STATE(172),
-    [sym__text_mode_at] = STATE(172),
-    [sym_parameter] = STATE(172),
-    [sym_text_env_at] = STATE(172),
-    [sym__display_math_at] = STATE(172),
-    [sym_tex_display_math_at] = STATE(172),
-    [sym_latex_display_math_at] = STATE(172),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(172),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(172),
-    [sym_tex_inline_math_at] = STATE(172),
-    [sym_latex_inline_math_at] = STATE(172),
-    [sym_inline_math_env_at] = STATE(172),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(172),
+  [75] = {
+    [sym__common] = STATE(168),
+    [sym__text_mode_common] = STATE(168),
+    [sym__text_mode] = STATE(168),
+    [sym_text_mode_at_region] = STATE(168),
+    [sym_parameter] = STATE(168),
+    [sym_text_env] = STATE(168),
+    [sym__display_math] = STATE(168),
+    [sym_tex_display_math] = STATE(168),
+    [sym_latex_display_math] = STATE(168),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(168),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(168),
+    [sym_tex_inline_math] = STATE(168),
+    [sym_latex_inline_math] = STATE(168),
+    [sym_inline_math_env] = STATE(168),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(168),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(172),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(172),
+    [sym_escaped] = STATE(168),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_end] = STATE(167),
+    [sym_end_token] = STATE(74),
+    [sym_documentclass] = STATE(168),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(172),
+    [sym_usepackage] = STATE(168),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(172),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(172),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(172),
+    [sym_include] = STATE(168),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(168),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(168),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(172),
+    [sym_catcode] = STATE(168),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(172),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(172),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(172),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(172),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(172),
-    [sym_opt_text_group_at] = STATE(172),
-    [sym_token_at] = STATE(172),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(172),
+    [sym_emph] = STATE(168),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(168),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(168),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(168),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(168),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(168),
+    [sym_opt_text_group] = STATE(168),
+    [sym_token] = STATE(168),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(168),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_end_group] = ACTIONS(249),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(251),
+    [sym__escape] = ACTIONS(89),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(237),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(251),
-    [sym_text] = ACTIONS(251),
+    [sym_active_char] = ACTIONS(237),
+    [sym_text] = ACTIONS(237),
   },
-  [95] = {
-    [sym__common] = STATE(180),
-    [sym__math_mode_common] = STATE(180),
-    [sym__math_mode_at] = STATE(180),
-    [sym_math_mode_at] = STATE(176),
-    [sym_parameter] = STATE(180),
-    [sym_math_env_at] = STATE(180),
-    [sym_tag_at] = STATE(180),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(180),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(180),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(180),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(180),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(180),
-    [sym_opt_math_group_at] = STATE(180),
-    [sym_token_at] = STATE(180),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(180),
+  [76] = {
+    [sym_display_math_env_name] = ACTIONS(239),
+    [sym_inline_math_env_name] = ACTIONS(241),
+    [sym_verbatim_env_name] = ACTIONS(243),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_text] = ACTIONS(245),
+  },
+  [77] = {
+    [sym_text_group] = STATE(175),
+    [sym_opt_text_group] = STATE(176),
+    [sym_begin_opt] = STATE(84),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(249),
+  },
+  [78] = {
+    [anon_sym_LBRACK] = ACTIONS(251),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(251),
+    [sym_begin_group] = ACTIONS(251),
+    [sym_alignment_tab] = ACTIONS(251),
+    [sym_parameter_char] = ACTIONS(251),
+    [sym_superscript] = ACTIONS(251),
+    [sym_subscript] = ACTIONS(251),
+    [sym_active_char] = ACTIONS(251),
+    [sym_text] = ACTIONS(251),
+  },
+  [79] = {
+    [sym_text_group] = STATE(178),
+    [sym_opt_text_group] = STATE(179),
+    [sym_begin_opt] = STATE(84),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(253),
+  },
+  [80] = {
+    [anon_sym_LBRACK] = ACTIONS(255),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(255),
     [sym_begin_group] = ACTIONS(255),
-    [sym_math_shift] = ACTIONS(257),
+    [sym_math_shift] = ACTIONS(255),
+    [sym_alignment_tab] = ACTIONS(255),
+    [sym_parameter_char] = ACTIONS(255),
+    [sym_superscript] = ACTIONS(255),
+    [sym_subscript] = ACTIONS(255),
+    [sym_active_char] = ACTIONS(255),
+    [sym_text] = ACTIONS(255),
+  },
+  [81] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_text] = ACTIONS(257),
+  },
+  [82] = {
+    [ts_builtin_sym_end] = ACTIONS(259),
+    [anon_sym_LBRACK] = ACTIONS(259),
+    [anon_sym_RBRACK] = ACTIONS(259),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(259),
+    [sym_begin_group] = ACTIONS(259),
+    [sym_end_group] = ACTIONS(259),
+    [sym_math_shift] = ACTIONS(259),
     [sym_alignment_tab] = ACTIONS(259),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(259),
     [sym_superscript] = ACTIONS(259),
     [sym_subscript] = ACTIONS(259),
     [sym_active_char] = ACTIONS(259),
     [sym_text] = ACTIONS(259),
   },
-  [96] = {
-    [sym_makeatother] = STATE(182),
-    [sym_makeatother_token] = STATE(110),
+  [83] = {
+    [sym_simple_text_group] = STATE(181),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(261),
+    [sym_begin_group] = ACTIONS(95),
+    [sym__whitespace] = ACTIONS(261),
   },
-  [97] = {
+  [84] = {
     [sym__common] = STATE(184),
-    [sym__math_mode_common] = STATE(184),
-    [sym__math_mode_at] = STATE(184),
-    [sym_math_mode_at] = STATE(183),
+    [sym__text_mode_common] = STATE(184),
+    [sym__text_mode] = STATE(184),
+    [sym_text_mode_at_region] = STATE(184),
     [sym_parameter] = STATE(184),
-    [sym_math_env_at] = STATE(184),
-    [sym_tag_at] = STATE(184),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(184),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(184),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(184),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(184),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(184),
-    [sym_opt_math_group_at] = STATE(184),
-    [sym_token_at] = STATE(184),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(184),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(263),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(263),
-    [sym_subscript] = ACTIONS(263),
-    [sym_active_char] = ACTIONS(263),
-    [sym_text] = ACTIONS(263),
-  },
-  [98] = {
-    [sym__common] = STATE(184),
-    [sym__math_mode_common] = STATE(184),
-    [sym__math_mode_at] = STATE(184),
-    [sym_math_mode_at] = STATE(185),
-    [sym_parameter] = STATE(184),
-    [sym_math_env_at] = STATE(184),
-    [sym_tag_at] = STATE(184),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(184),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(184),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(184),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(184),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(184),
-    [sym_opt_math_group_at] = STATE(184),
-    [sym_token_at] = STATE(184),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(184),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(263),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(263),
-    [sym_subscript] = ACTIONS(263),
-    [sym_active_char] = ACTIONS(263),
-    [sym_text] = ACTIONS(263),
-  },
-  [99] = {
-    [sym__common] = STATE(184),
-    [sym__math_mode_common] = STATE(184),
-    [sym__math_mode_at] = STATE(184),
-    [sym_math_mode_at] = STATE(186),
-    [sym_parameter] = STATE(184),
-    [sym_math_env_at] = STATE(184),
-    [sym_tag_at] = STATE(184),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(184),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(184),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(184),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(184),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(184),
-    [sym_opt_math_group_at] = STATE(184),
-    [sym_token_at] = STATE(184),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(184),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(263),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(263),
-    [sym_subscript] = ACTIONS(263),
-    [sym_active_char] = ACTIONS(263),
-    [sym_text] = ACTIONS(263),
-  },
-  [100] = {
-    [sym__common] = STATE(184),
-    [sym__math_mode_common] = STATE(184),
-    [sym__math_mode_at] = STATE(184),
-    [sym_math_mode_at] = STATE(187),
-    [sym_parameter] = STATE(184),
-    [sym_math_env_at] = STATE(184),
-    [sym_tag_at] = STATE(184),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(184),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(184),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(184),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(184),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(184),
-    [sym_opt_math_group_at] = STATE(184),
-    [sym_token_at] = STATE(184),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(184),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(263),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(263),
-    [sym_subscript] = ACTIONS(263),
-    [sym_active_char] = ACTIONS(263),
-    [sym_text] = ACTIONS(263),
-  },
-  [101] = {
-    [sym__common] = STATE(190),
-    [sym__text_mode_common] = STATE(190),
-    [sym__text_mode_at] = STATE(190),
-    [sym_parameter] = STATE(190),
-    [sym_text_env_at] = STATE(190),
-    [sym__display_math_at] = STATE(190),
-    [sym_tex_display_math_at] = STATE(190),
-    [sym_latex_display_math_at] = STATE(190),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(190),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(190),
-    [sym_tex_inline_math_at] = STATE(190),
-    [sym_latex_inline_math_at] = STATE(190),
-    [sym_inline_math_env_at] = STATE(190),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(190),
+    [sym_text_env] = STATE(184),
+    [sym__display_math] = STATE(184),
+    [sym_tex_display_math] = STATE(184),
+    [sym_latex_display_math] = STATE(184),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(184),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(184),
+    [sym_tex_inline_math] = STATE(184),
+    [sym_latex_inline_math] = STATE(184),
+    [sym_inline_math_env] = STATE(184),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(184),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(190),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_end] = STATE(189),
-    [sym_end_token] = STATE(72),
-    [sym_documentclass] = STATE(190),
+    [sym_escaped] = STATE(184),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(184),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(190),
+    [sym_usepackage] = STATE(184),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(190),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(190),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(190),
+    [sym_include] = STATE(184),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(184),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(184),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(190),
+    [sym_catcode] = STATE(184),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(190),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(190),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(190),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(190),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(190),
-    [sym_opt_text_group_at] = STATE(190),
-    [sym_token_at] = STATE(190),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(190),
+    [sym_emph] = STATE(184),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(184),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(184),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(184),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(184),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(184),
+    [sym_opt_text_group] = STATE(184),
+    [sym_token] = STATE(184),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(183),
+    [aux_sym_text_mode_repeat1] = STATE(184),
     [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(263),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(265),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(267),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(265),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(265),
+    [sym_text] = ACTIONS(265),
+  },
+  [85] = {
+    [ts_builtin_sym_end] = ACTIONS(267),
+    [anon_sym_LBRACK] = ACTIONS(267),
+    [anon_sym_RBRACK] = ACTIONS(267),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(267),
+    [sym_begin_group] = ACTIONS(267),
+    [sym_end_group] = ACTIONS(267),
+    [sym_math_shift] = ACTIONS(267),
+    [sym_alignment_tab] = ACTIONS(267),
+    [sym_parameter_char] = ACTIONS(267),
+    [sym_superscript] = ACTIONS(267),
+    [sym_subscript] = ACTIONS(267),
     [sym_active_char] = ACTIONS(267),
     [sym_text] = ACTIONS(267),
   },
-  [102] = {
-    [sym_display_math_env_group] = STATE(191),
-    [sym_inline_math_env_group] = STATE(76),
-    [sym_verbatim_env_group] = STATE(77),
-    [sym_simple_text_group] = STATE(78),
+  [86] = {
+    [sym_simple_text_group] = STATE(186),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(91),
+    [sym_begin_group] = ACTIONS(95),
+    [sym__whitespace] = ACTIONS(269),
   },
-  [103] = {
-    [sym_text_group_at] = STATE(192),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [104] = {
-    [sym_text_group_at] = STATE(193),
-    [sym_opt_text_group_at] = STATE(194),
-    [sym_begin_opt] = STATE(111),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [105] = {
-    [sym_text_group_at] = STATE(195),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [106] = {
-    [sym_text_group_at] = STATE(196),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [107] = {
-    [sym_text_group_at] = STATE(197),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [108] = {
-    [sym_text_group_at] = STATE(198),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [109] = {
-    [ts_builtin_sym_end] = ACTIONS(269),
-    [anon_sym_LBRACK] = ACTIONS(269),
-    [anon_sym_RBRACK] = ACTIONS(269),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(269),
-    [sym_begin_group] = ACTIONS(269),
-    [sym_end_group] = ACTIONS(269),
-    [sym_math_shift] = ACTIONS(269),
-    [sym_alignment_tab] = ACTIONS(269),
-    [sym_parameter_char] = ACTIONS(269),
-    [sym_superscript] = ACTIONS(269),
-    [sym_subscript] = ACTIONS(269),
-    [sym_active_char] = ACTIONS(269),
-    [sym_text] = ACTIONS(269),
-  },
-  [110] = {
+  [87] = {
     [ts_builtin_sym_end] = ACTIONS(271),
     [anon_sym_LBRACK] = ACTIONS(271),
     [anon_sym_RBRACK] = ACTIONS(271),
@@ -7457,148 +7333,41 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(271),
     [sym_text] = ACTIONS(271),
   },
-  [111] = {
-    [sym__common] = STATE(200),
-    [sym__text_mode_common] = STATE(200),
-    [sym__text_mode_at] = STATE(200),
-    [sym_parameter] = STATE(200),
-    [sym_text_env_at] = STATE(200),
-    [sym__display_math_at] = STATE(200),
-    [sym_tex_display_math_at] = STATE(200),
-    [sym_latex_display_math_at] = STATE(200),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(200),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(200),
-    [sym_tex_inline_math_at] = STATE(200),
-    [sym_latex_inline_math_at] = STATE(200),
-    [sym_inline_math_env_at] = STATE(200),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(200),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(200),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(200),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(200),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(200),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(200),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(200),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(200),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(200),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(200),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(200),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(200),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(200),
-    [sym_opt_text_group_at] = STATE(200),
-    [sym_token_at] = STATE(200),
-    [sym_begin_opt] = STATE(111),
-    [sym_end_opt] = STATE(199),
-    [aux_sym_text_mode_at_repeat1] = STATE(200),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
+  [88] = {
+    [ts_builtin_sym_end] = ACTIONS(273),
+    [anon_sym_LBRACK] = ACTIONS(273),
+    [anon_sym_RBRACK] = ACTIONS(273),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
+    [sym__escape] = ACTIONS(273),
+    [sym_begin_group] = ACTIONS(273),
+    [sym_end_group] = ACTIONS(273),
+    [sym_math_shift] = ACTIONS(273),
     [sym_alignment_tab] = ACTIONS(273),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(273),
+    [sym_superscript] = ACTIONS(273),
+    [sym_subscript] = ACTIONS(273),
     [sym_active_char] = ACTIONS(273),
     [sym_text] = ACTIONS(273),
   },
-  [112] = {
-    [sym__common] = STATE(201),
-    [sym__text_mode_common] = STATE(201),
-    [sym__text_mode_at] = STATE(201),
-    [sym_parameter] = STATE(201),
-    [sym_text_env_at] = STATE(201),
-    [sym__display_math_at] = STATE(201),
-    [sym_tex_display_math_at] = STATE(201),
-    [sym_latex_display_math_at] = STATE(201),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(201),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(201),
-    [sym_tex_inline_math_at] = STATE(201),
-    [sym_latex_inline_math_at] = STATE(201),
-    [sym_inline_math_env_at] = STATE(201),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(201),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(201),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(201),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(201),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(201),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(201),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(201),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(201),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(201),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(201),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(201),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(201),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(201),
-    [sym_opt_text_group_at] = STATE(201),
-    [sym_token_at] = STATE(201),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(201),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [89] = {
+    [sym_text_group] = STATE(188),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(275),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(277),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(277),
-    [sym_text] = ACTIONS(277),
+    [sym_begin_group] = ACTIONS(15),
+    [sym__whitespace] = ACTIONS(275),
   },
-  [113] = {
-    [ts_builtin_sym_end] = ACTIONS(279),
-    [anon_sym_LBRACK] = ACTIONS(279),
-    [anon_sym_RBRACK] = ACTIONS(279),
+  [90] = {
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(277),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(279),
-    [sym_begin_group] = ACTIONS(279),
-    [sym_end_group] = ACTIONS(279),
-    [sym_math_shift] = ACTIONS(279),
-    [sym_alignment_tab] = ACTIONS(279),
-    [sym_parameter_char] = ACTIONS(279),
-    [sym_superscript] = ACTIONS(279),
-    [sym_subscript] = ACTIONS(279),
-    [sym_active_char] = ACTIONS(279),
-    [sym_text] = ACTIONS(279),
   },
-  [114] = {
+  [91] = {
+    [anon_sym_EQ] = ACTIONS(279),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [92] = {
     [ts_builtin_sym_end] = ACTIONS(281),
     [anon_sym_LBRACK] = ACTIONS(281),
     [anon_sym_RBRACK] = ACTIONS(281),
@@ -7615,356 +7384,626 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(281),
     [sym_text] = ACTIONS(281),
   },
-  [115] = {
-    [sym__common] = STATE(203),
-    [sym__text_mode_common] = STATE(203),
-    [sym__text_mode] = STATE(203),
-    [sym_text_mode_at_region] = STATE(203),
-    [sym_parameter] = STATE(203),
-    [sym_text_env] = STATE(203),
-    [sym__display_math] = STATE(203),
-    [sym_tex_display_math] = STATE(203),
-    [sym_latex_display_math] = STATE(203),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(203),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(203),
-    [sym_tex_inline_math] = STATE(203),
-    [sym_latex_inline_math] = STATE(203),
-    [sym_inline_math_env] = STATE(203),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(203),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(203),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(203),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(203),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(203),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(203),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(203),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(203),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(203),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(203),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(203),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(203),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(203),
-    [sym_opt_text_group] = STATE(203),
-    [sym_token] = STATE(203),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(202),
-    [aux_sym_text_mode_repeat1] = STATE(203),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
+  [93] = {
+    [ts_builtin_sym_end] = ACTIONS(283),
+    [anon_sym_LBRACK] = ACTIONS(283),
+    [anon_sym_RBRACK] = ACTIONS(283),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
+    [sym__escape] = ACTIONS(283),
+    [sym_begin_group] = ACTIONS(283),
+    [sym_end_group] = ACTIONS(283),
+    [sym_math_shift] = ACTIONS(283),
     [sym_alignment_tab] = ACTIONS(283),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(283),
+    [sym_superscript] = ACTIONS(283),
+    [sym_subscript] = ACTIONS(283),
     [sym_active_char] = ACTIONS(283),
     [sym_text] = ACTIONS(283),
   },
-  [116] = {
-    [sym__common] = STATE(116),
-    [sym__text_mode_common] = STATE(116),
-    [sym__text_mode] = STATE(116),
-    [sym_text_mode_at_region] = STATE(116),
-    [sym_parameter] = STATE(116),
-    [sym_text_env] = STATE(116),
-    [sym__display_math] = STATE(116),
-    [sym_tex_display_math] = STATE(116),
-    [sym_latex_display_math] = STATE(116),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(116),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(116),
-    [sym_tex_inline_math] = STATE(116),
-    [sym_latex_inline_math] = STATE(116),
-    [sym_inline_math_env] = STATE(116),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(116),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(116),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(116),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(116),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(116),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(116),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(116),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(116),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(116),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(116),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(116),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(116),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(116),
-    [sym_opt_text_group] = STATE(116),
-    [sym_token] = STATE(116),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(116),
-    [ts_builtin_sym_end] = ACTIONS(285),
+  [94] = {
+    [sym_text_group] = STATE(192),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+    [sym__whitespace] = ACTIONS(285),
+  },
+  [95] = {
+    [ts_builtin_sym_end] = ACTIONS(287),
     [anon_sym_LBRACK] = ACTIONS(287),
+    [anon_sym_RBRACK] = ACTIONS(287),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(290),
-    [sym_begin_group] = ACTIONS(293),
-    [sym_math_shift] = ACTIONS(296),
-    [sym_alignment_tab] = ACTIONS(299),
-    [sym_parameter_char] = ACTIONS(302),
-    [sym_superscript] = ACTIONS(305),
-    [sym_subscript] = ACTIONS(305),
-    [sym_active_char] = ACTIONS(299),
-    [sym_text] = ACTIONS(299),
+    [sym__escape] = ACTIONS(287),
+    [sym_begin_group] = ACTIONS(287),
+    [sym_end_group] = ACTIONS(287),
+    [sym_math_shift] = ACTIONS(287),
+    [sym_alignment_tab] = ACTIONS(287),
+    [sym_parameter_char] = ACTIONS(287),
+    [sym_superscript] = ACTIONS(287),
+    [sym_subscript] = ACTIONS(287),
+    [sym_active_char] = ACTIONS(287),
+    [sym_text] = ACTIONS(287),
   },
-  [117] = {
-    [ts_builtin_sym_end] = ACTIONS(308),
-    [anon_sym_LBRACK] = ACTIONS(308),
-    [anon_sym_RBRACK] = ACTIONS(308),
+  [96] = {
+    [ts_builtin_sym_end] = ACTIONS(289),
+    [anon_sym_LBRACK] = ACTIONS(289),
+    [anon_sym_RBRACK] = ACTIONS(289),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(308),
-    [sym_begin_group] = ACTIONS(308),
-    [sym_end_group] = ACTIONS(308),
-    [sym_math_shift] = ACTIONS(308),
-    [sym_alignment_tab] = ACTIONS(308),
-    [sym_parameter_char] = ACTIONS(308),
-    [sym_superscript] = ACTIONS(308),
-    [sym_subscript] = ACTIONS(308),
-    [sym_active_char] = ACTIONS(308),
-    [sym_text] = ACTIONS(308),
+    [sym__escape] = ACTIONS(289),
+    [sym_begin_group] = ACTIONS(289),
+    [sym_end_group] = ACTIONS(289),
+    [sym_math_shift] = ACTIONS(289),
+    [sym_alignment_tab] = ACTIONS(289),
+    [sym_parameter_char] = ACTIONS(289),
+    [sym_superscript] = ACTIONS(289),
+    [sym_subscript] = ACTIONS(289),
+    [sym_active_char] = ACTIONS(289),
+    [sym_text] = ACTIONS(289),
   },
-  [118] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
+  [97] = {
+    [ts_builtin_sym_end] = ACTIONS(291),
+    [anon_sym_LBRACK] = ACTIONS(291),
+    [anon_sym_RBRACK] = ACTIONS(291),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(291),
+    [sym_begin_group] = ACTIONS(291),
+    [sym_end_group] = ACTIONS(291),
+    [sym_math_shift] = ACTIONS(291),
+    [sym_alignment_tab] = ACTIONS(291),
+    [sym_parameter_char] = ACTIONS(291),
+    [sym_superscript] = ACTIONS(291),
+    [sym_subscript] = ACTIONS(291),
+    [sym_active_char] = ACTIONS(291),
+    [sym_text] = ACTIONS(291),
+  },
+  [98] = {
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LPAREN] = ACTIONS(29),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [anon_sym_documentclass] = ACTIONS(35),
+    [anon_sym_usepackage] = ACTIONS(37),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+    [anon_sym_emph] = ACTIONS(47),
+    [anon_sym_footnote] = ACTIONS(49),
+    [anon_sym_textbf] = ACTIONS(51),
+    [anon_sym_textit] = ACTIONS(53),
+    [anon_sym_texttt] = ACTIONS(55),
+    [anon_sym_makeatother] = ACTIONS(293),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(295),
+  },
+  [99] = {
+    [sym__common] = STATE(197),
+    [sym__text_mode_common] = STATE(197),
+    [sym__text_mode_at] = STATE(197),
+    [sym_parameter] = STATE(197),
+    [sym_text_env_at] = STATE(197),
+    [sym__display_math_at] = STATE(197),
+    [sym_tex_display_math_at] = STATE(197),
+    [sym_latex_display_math_at] = STATE(197),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(197),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(197),
+    [sym_tex_inline_math_at] = STATE(197),
+    [sym_latex_inline_math_at] = STATE(197),
+    [sym_inline_math_env_at] = STATE(197),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(197),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
+    [sym_escaped] = STATE(197),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(197),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
+    [sym_usepackage] = STATE(197),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
+    [sym_include_at] = STATE(197),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(197),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(197),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
+    [sym_catcode] = STATE(197),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [anon_sym_LBRACK] = ACTIONS(287),
+    [sym_emph_at] = STATE(197),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(197),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(197),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(197),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(197),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(197),
+    [sym_opt_text_group_at] = STATE(197),
+    [sym_token_at] = STATE(197),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(197),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(290),
-    [sym_begin_group] = ACTIONS(293),
-    [sym_end_group] = ACTIONS(285),
-    [sym_math_shift] = ACTIONS(296),
-    [sym_alignment_tab] = ACTIONS(310),
-    [sym_parameter_char] = ACTIONS(302),
-    [sym_superscript] = ACTIONS(305),
-    [sym_subscript] = ACTIONS(305),
-    [sym_active_char] = ACTIONS(310),
-    [sym_text] = ACTIONS(310),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(299),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(301),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(301),
+    [sym_text] = ACTIONS(301),
   },
-  [119] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(313),
-  },
-  [120] = {
-    [anon_sym_LBRACK] = ACTIONS(315),
-    [anon_sym_RBRACK] = ACTIONS(315),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(315),
-    [sym_begin_group] = ACTIONS(315),
-    [sym_end_group] = ACTIONS(315),
-    [sym_math_shift] = ACTIONS(315),
-    [sym_alignment_tab] = ACTIONS(315),
-    [sym_parameter_char] = ACTIONS(315),
-    [sym_superscript] = ACTIONS(315),
-    [sym_subscript] = ACTIONS(315),
-    [sym_active_char] = ACTIONS(315),
-    [sym_text] = ACTIONS(315),
-  },
-  [121] = {
+  [100] = {
     [sym__common] = STATE(205),
     [sym__math_mode_common] = STATE(205),
-    [sym__math_mode] = STATE(205),
+    [sym__math_mode_at] = STATE(205),
+    [sym_math_mode_at] = STATE(201),
     [sym_parameter] = STATE(205),
-    [sym_math_env] = STATE(205),
-    [sym_tag] = STATE(205),
-    [sym_tag_token] = STATE(53),
+    [sym_math_env_at] = STATE(205),
+    [sym_tag_at] = STATE(205),
+    [sym_tag_token] = STATE(202),
     [sym_escaped] = STATE(205),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(205),
-    [sym_include_token] = STATE(19),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(205),
+    [sym_include_token] = STATE(108),
     [sym_storage] = STATE(205),
     [sym_storage_token] = STATE(21),
     [sym_catcode] = STATE(205),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(205),
-    [sym_opt_math_group] = STATE(205),
-    [sym_token] = STATE(205),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(205),
+    [sym_math_group_at] = STATE(205),
+    [sym_opt_math_group_at] = STATE(205),
+    [sym_token_at] = STATE(205),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(205),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_end_group] = ACTIONS(317),
-    [sym_alignment_tab] = ACTIONS(319),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_math_shift] = ACTIONS(307),
+    [sym_alignment_tab] = ACTIONS(309),
     [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(309),
+    [sym_subscript] = ACTIONS(309),
+    [sym_active_char] = ACTIONS(309),
+    [sym_text] = ACTIONS(309),
+  },
+  [101] = {
+    [sym_makeatother] = STATE(207),
+    [sym_makeatother_token] = STATE(116),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(311),
+  },
+  [102] = {
+    [sym__common] = STATE(209),
+    [sym__math_mode_common] = STATE(209),
+    [sym__math_mode_at] = STATE(209),
+    [sym_math_mode_at] = STATE(208),
+    [sym_parameter] = STATE(209),
+    [sym_math_env_at] = STATE(209),
+    [sym_tag_at] = STATE(209),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(209),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(209),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(209),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(209),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(209),
+    [sym_opt_math_group_at] = STATE(209),
+    [sym_token_at] = STATE(209),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(209),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(313),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(313),
+    [sym_subscript] = ACTIONS(313),
+    [sym_active_char] = ACTIONS(313),
+    [sym_text] = ACTIONS(313),
+  },
+  [103] = {
+    [sym__common] = STATE(209),
+    [sym__math_mode_common] = STATE(209),
+    [sym__math_mode_at] = STATE(209),
+    [sym_math_mode_at] = STATE(210),
+    [sym_parameter] = STATE(209),
+    [sym_math_env_at] = STATE(209),
+    [sym_tag_at] = STATE(209),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(209),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(209),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(209),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(209),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(209),
+    [sym_opt_math_group_at] = STATE(209),
+    [sym_token_at] = STATE(209),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(209),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(313),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(313),
+    [sym_subscript] = ACTIONS(313),
+    [sym_active_char] = ACTIONS(313),
+    [sym_text] = ACTIONS(313),
+  },
+  [104] = {
+    [sym__common] = STATE(209),
+    [sym__math_mode_common] = STATE(209),
+    [sym__math_mode_at] = STATE(209),
+    [sym_math_mode_at] = STATE(211),
+    [sym_parameter] = STATE(209),
+    [sym_math_env_at] = STATE(209),
+    [sym_tag_at] = STATE(209),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(209),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(209),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(209),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(209),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(209),
+    [sym_opt_math_group_at] = STATE(209),
+    [sym_token_at] = STATE(209),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(209),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(313),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(313),
+    [sym_subscript] = ACTIONS(313),
+    [sym_active_char] = ACTIONS(313),
+    [sym_text] = ACTIONS(313),
+  },
+  [105] = {
+    [sym__common] = STATE(209),
+    [sym__math_mode_common] = STATE(209),
+    [sym__math_mode_at] = STATE(209),
+    [sym_math_mode_at] = STATE(212),
+    [sym_parameter] = STATE(209),
+    [sym_math_env_at] = STATE(209),
+    [sym_tag_at] = STATE(209),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(209),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(209),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(209),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(209),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(209),
+    [sym_opt_math_group_at] = STATE(209),
+    [sym_token_at] = STATE(209),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(209),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(313),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(313),
+    [sym_subscript] = ACTIONS(313),
+    [sym_active_char] = ACTIONS(313),
+    [sym_text] = ACTIONS(313),
+  },
+  [106] = {
+    [sym__common] = STATE(215),
+    [sym__text_mode_common] = STATE(215),
+    [sym__text_mode_at] = STATE(215),
+    [sym_parameter] = STATE(215),
+    [sym_text_env_at] = STATE(215),
+    [sym__display_math_at] = STATE(215),
+    [sym_tex_display_math_at] = STATE(215),
+    [sym_latex_display_math_at] = STATE(215),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(215),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(215),
+    [sym_tex_inline_math_at] = STATE(215),
+    [sym_latex_inline_math_at] = STATE(215),
+    [sym_inline_math_env_at] = STATE(215),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(215),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(215),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_end] = STATE(214),
+    [sym_end_token] = STATE(74),
+    [sym_documentclass] = STATE(215),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(215),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(215),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(215),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(215),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(215),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(215),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(215),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(215),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(215),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(215),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(215),
+    [sym_opt_text_group_at] = STATE(215),
+    [sym_token_at] = STATE(215),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(215),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(315),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(317),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(317),
+    [sym_text] = ACTIONS(317),
+  },
+  [107] = {
+    [sym_display_math_env_group] = STATE(216),
+    [sym_inline_math_env_group] = STATE(78),
+    [sym_verbatim_env_group] = STATE(79),
+    [sym_simple_text_group] = STATE(80),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(93),
+  },
+  [108] = {
+    [sym_text_group_at] = STATE(217),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [109] = {
+    [sym_text_group_at] = STATE(218),
+    [sym_opt_text_group_at] = STATE(219),
+    [sym_begin_opt] = STATE(220),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [110] = {
+    [sym_text_group_at] = STATE(221),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [111] = {
+    [sym_text_group_at] = STATE(222),
+    [sym_opt_text_group_at] = STATE(223),
+    [sym_begin_opt] = STATE(220),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [112] = {
+    [sym_text_group_at] = STATE(224),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [113] = {
+    [sym_text_group_at] = STATE(225),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [114] = {
+    [sym_text_group_at] = STATE(226),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [115] = {
+    [ts_builtin_sym_end] = ACTIONS(319),
+    [anon_sym_LBRACK] = ACTIONS(319),
+    [anon_sym_RBRACK] = ACTIONS(319),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(319),
+    [sym_begin_group] = ACTIONS(319),
+    [sym_end_group] = ACTIONS(319),
+    [sym_math_shift] = ACTIONS(319),
+    [sym_alignment_tab] = ACTIONS(319),
+    [sym_parameter_char] = ACTIONS(319),
     [sym_superscript] = ACTIONS(319),
     [sym_subscript] = ACTIONS(319),
     [sym_active_char] = ACTIONS(319),
     [sym_text] = ACTIONS(319),
   },
-  [122] = {
+  [116] = {
+    [ts_builtin_sym_end] = ACTIONS(321),
+    [anon_sym_LBRACK] = ACTIONS(321),
+    [anon_sym_RBRACK] = ACTIONS(321),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(321),
+    [sym_begin_group] = ACTIONS(321),
+    [sym_end_group] = ACTIONS(321),
     [sym_math_shift] = ACTIONS(321),
+    [sym_alignment_tab] = ACTIONS(321),
+    [sym_parameter_char] = ACTIONS(321),
+    [sym_superscript] = ACTIONS(321),
+    [sym_subscript] = ACTIONS(321),
+    [sym_active_char] = ACTIONS(321),
+    [sym_text] = ACTIONS(321),
   },
-  [123] = {
-    [ts_builtin_sym_end] = ACTIONS(323),
-    [anon_sym_LBRACK] = ACTIONS(323),
-    [anon_sym_RBRACK] = ACTIONS(323),
+  [117] = {
+    [sym__common] = STATE(228),
+    [sym__text_mode_common] = STATE(228),
+    [sym__text_mode_at] = STATE(228),
+    [sym_parameter] = STATE(228),
+    [sym_text_env_at] = STATE(228),
+    [sym__display_math_at] = STATE(228),
+    [sym_tex_display_math_at] = STATE(228),
+    [sym_latex_display_math_at] = STATE(228),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(228),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(228),
+    [sym_tex_inline_math_at] = STATE(228),
+    [sym_latex_inline_math_at] = STATE(228),
+    [sym_inline_math_env_at] = STATE(228),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(228),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(228),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(228),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(228),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(228),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(228),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(228),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(228),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(228),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(228),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(228),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(228),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(228),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(228),
+    [sym_opt_text_group_at] = STATE(228),
+    [sym_token_at] = STATE(228),
+    [sym_begin_opt] = STATE(117),
+    [sym_end_opt] = STATE(227),
+    [aux_sym_text_mode_at_repeat1] = STATE(228),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(323),
-    [sym_begin_group] = ACTIONS(323),
-    [sym_end_group] = ACTIONS(323),
-    [sym_math_shift] = ACTIONS(323),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
     [sym_alignment_tab] = ACTIONS(323),
-    [sym_parameter_char] = ACTIONS(323),
-    [sym_superscript] = ACTIONS(323),
-    [sym_subscript] = ACTIONS(323),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
     [sym_active_char] = ACTIONS(323),
     [sym_text] = ACTIONS(323),
   },
-  [124] = {
-    [sym__common] = STATE(209),
-    [sym__text_mode_common] = STATE(209),
-    [sym__text_mode] = STATE(209),
-    [sym_text_mode] = STATE(208),
-    [sym_text_mode_at_region] = STATE(209),
-    [sym_parameter] = STATE(209),
-    [sym_text_env] = STATE(209),
-    [sym__display_math] = STATE(209),
-    [sym_tex_display_math] = STATE(209),
-    [sym_latex_display_math] = STATE(209),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(209),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(209),
-    [sym_tex_inline_math] = STATE(209),
-    [sym_latex_inline_math] = STATE(209),
-    [sym_inline_math_env] = STATE(209),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(209),
+  [118] = {
+    [sym__common] = STATE(229),
+    [sym__text_mode_common] = STATE(229),
+    [sym__text_mode_at] = STATE(229),
+    [sym_parameter] = STATE(229),
+    [sym_text_env_at] = STATE(229),
+    [sym__display_math_at] = STATE(229),
+    [sym_tex_display_math_at] = STATE(229),
+    [sym_latex_display_math_at] = STATE(229),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(229),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(229),
+    [sym_tex_inline_math_at] = STATE(229),
+    [sym_latex_inline_math_at] = STATE(229),
+    [sym_inline_math_env_at] = STATE(229),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(229),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(209),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(209),
+    [sym_escaped] = STATE(229),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(229),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(209),
+    [sym_usepackage] = STATE(229),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(209),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(209),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(209),
+    [sym_include_at] = STATE(229),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(229),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(229),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(209),
+    [sym_catcode] = STATE(229),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(209),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(209),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(209),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(209),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(209),
-    [sym_opt_text_group] = STATE(209),
-    [sym_token] = STATE(209),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(209),
+    [sym_emph_at] = STATE(229),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(229),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(229),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(229),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(229),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(229),
+    [sym_opt_text_group_at] = STATE(229),
+    [sym_token_at] = STATE(229),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(229),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(325),
-    [sym_math_shift] = ACTIONS(17),
+    [sym__escape] = ACTIONS(325),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
     [sym_alignment_tab] = ACTIONS(327),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
@@ -7972,7 +8011,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(327),
     [sym_text] = ACTIONS(327),
   },
-  [125] = {
+  [119] = {
+    [ts_builtin_sym_end] = ACTIONS(329),
     [anon_sym_LBRACK] = ACTIONS(329),
     [anon_sym_RBRACK] = ACTIONS(329),
     [sym_magic_comment] = ACTIONS(9),
@@ -7988,19 +8028,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(329),
     [sym_text] = ACTIONS(329),
   },
-  [126] = {
-    [anon_sym_tag] = ACTIONS(155),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_end] = ACTIONS(197),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(57),
-  },
-  [127] = {
+  [120] = {
+    [ts_builtin_sym_end] = ACTIONS(331),
     [anon_sym_LBRACK] = ACTIONS(331),
     [anon_sym_RBRACK] = ACTIONS(331),
     [sym_magic_comment] = ACTIONS(9),
@@ -8016,692 +8045,702 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(331),
     [sym_text] = ACTIONS(331),
   },
-  [128] = {
-    [sym__common] = STATE(134),
-    [sym__math_mode_common] = STATE(134),
-    [sym__math_mode] = STATE(134),
-    [sym_parameter] = STATE(134),
-    [sym_math_env] = STATE(134),
-    [sym_tag] = STATE(134),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(134),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_end] = STATE(210),
-    [sym_end_token] = STATE(72),
-    [sym_include] = STATE(134),
+  [121] = {
+    [sym__common] = STATE(231),
+    [sym__text_mode_common] = STATE(231),
+    [sym__text_mode] = STATE(231),
+    [sym_text_mode_at_region] = STATE(231),
+    [sym_parameter] = STATE(231),
+    [sym_text_env] = STATE(231),
+    [sym__display_math] = STATE(231),
+    [sym_tex_display_math] = STATE(231),
+    [sym_latex_display_math] = STATE(231),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(231),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(231),
+    [sym_tex_inline_math] = STATE(231),
+    [sym_latex_inline_math] = STATE(231),
+    [sym_inline_math_env] = STATE(231),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(231),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(231),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(231),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(231),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(231),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(134),
+    [sym_section] = STATE(231),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(231),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(134),
+    [sym_catcode] = STATE(231),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(134),
-    [sym_opt_math_group] = STATE(134),
-    [sym_token] = STATE(134),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(134),
+    [sym_emph] = STATE(231),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(231),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(231),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(231),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(231),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(231),
+    [sym_opt_text_group] = STATE(231),
+    [sym_token] = STATE(231),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(230),
+    [aux_sym_text_mode_repeat1] = STATE(231),
     [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(165),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(179),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(179),
-    [sym_subscript] = ACTIONS(179),
-    [sym_active_char] = ACTIONS(179),
-    [sym_text] = ACTIONS(179),
-  },
-  [129] = {
-    [anon_sym_LBRACK] = ACTIONS(333),
-    [anon_sym_RBRACK] = ACTIONS(333),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(333),
-    [sym_begin_group] = ACTIONS(333),
-    [sym_end_group] = ACTIONS(333),
-    [sym_math_shift] = ACTIONS(333),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
     [sym_alignment_tab] = ACTIONS(333),
-    [sym_parameter_char] = ACTIONS(333),
-    [sym_superscript] = ACTIONS(333),
-    [sym_subscript] = ACTIONS(333),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
     [sym_active_char] = ACTIONS(333),
     [sym_text] = ACTIONS(333),
   },
-  [130] = {
-    [sym__common] = STATE(212),
-    [sym__math_mode_common] = STATE(212),
-    [sym__math_mode] = STATE(212),
-    [sym_parameter] = STATE(212),
-    [sym_math_env] = STATE(212),
-    [sym_tag] = STATE(212),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(212),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(212),
+  [122] = {
+    [sym__common] = STATE(122),
+    [sym__text_mode_common] = STATE(122),
+    [sym__text_mode] = STATE(122),
+    [sym_text_mode_at_region] = STATE(122),
+    [sym_parameter] = STATE(122),
+    [sym_text_env] = STATE(122),
+    [sym__display_math] = STATE(122),
+    [sym_tex_display_math] = STATE(122),
+    [sym_latex_display_math] = STATE(122),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(122),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(122),
+    [sym_tex_inline_math] = STATE(122),
+    [sym_latex_inline_math] = STATE(122),
+    [sym_inline_math_env] = STATE(122),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(122),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(122),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(122),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(122),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(122),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(212),
+    [sym_section] = STATE(122),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(122),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(212),
+    [sym_catcode] = STATE(122),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(212),
-    [sym_opt_math_group] = STATE(212),
-    [sym_token] = STATE(212),
-    [sym_begin_opt] = STATE(56),
-    [sym_end_opt] = STATE(211),
-    [aux_sym_math_mode_repeat1] = STATE(212),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(63),
-    [sym_begin_group] = ACTIONS(65),
-    [sym_alignment_tab] = ACTIONS(335),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(335),
-    [sym_subscript] = ACTIONS(335),
-    [sym_active_char] = ACTIONS(335),
-    [sym_text] = ACTIONS(335),
-  },
-  [131] = {
-    [sym__common] = STATE(131),
-    [sym__math_mode_common] = STATE(131),
-    [sym__math_mode] = STATE(131),
-    [sym_parameter] = STATE(131),
-    [sym_math_env] = STATE(131),
-    [sym_tag] = STATE(131),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(131),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(131),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(131),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(131),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(131),
-    [sym_opt_math_group] = STATE(131),
-    [sym_token] = STATE(131),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(131),
+    [sym_emph] = STATE(122),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(122),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(122),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(122),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(122),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(122),
+    [sym_opt_text_group] = STATE(122),
+    [sym_token] = STATE(122),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(122),
+    [ts_builtin_sym_end] = ACTIONS(335),
     [anon_sym_LBRACK] = ACTIONS(337),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(340),
     [sym_begin_group] = ACTIONS(343),
     [sym_math_shift] = ACTIONS(346),
-    [sym_alignment_tab] = ACTIONS(348),
-    [sym_parameter_char] = ACTIONS(351),
-    [sym_superscript] = ACTIONS(348),
-    [sym_subscript] = ACTIONS(348),
-    [sym_active_char] = ACTIONS(348),
-    [sym_text] = ACTIONS(348),
+    [sym_alignment_tab] = ACTIONS(349),
+    [sym_parameter_char] = ACTIONS(352),
+    [sym_superscript] = ACTIONS(355),
+    [sym_subscript] = ACTIONS(355),
+    [sym_active_char] = ACTIONS(349),
+    [sym_text] = ACTIONS(349),
   },
-  [132] = {
-    [anon_sym_RBRACK] = ACTIONS(354),
+  [123] = {
+    [anon_sym_LBRACK] = ACTIONS(358),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-  },
-  [133] = {
-    [ts_builtin_sym_end] = ACTIONS(356),
-    [anon_sym_LBRACK] = ACTIONS(356),
-    [anon_sym_RBRACK] = ACTIONS(356),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(356),
-    [sym_begin_group] = ACTIONS(356),
-    [sym_end_group] = ACTIONS(356),
-    [sym_math_shift] = ACTIONS(356),
-    [sym_alignment_tab] = ACTIONS(356),
-    [sym_parameter_char] = ACTIONS(356),
-    [sym_superscript] = ACTIONS(356),
-    [sym_subscript] = ACTIONS(356),
-    [sym_active_char] = ACTIONS(356),
-    [sym_text] = ACTIONS(356),
-  },
-  [134] = {
-    [sym__common] = STATE(134),
-    [sym__math_mode_common] = STATE(134),
-    [sym__math_mode] = STATE(134),
-    [sym_parameter] = STATE(134),
-    [sym_math_env] = STATE(134),
-    [sym_tag] = STATE(134),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(134),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(134),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(134),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(134),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(134),
-    [sym_opt_math_group] = STATE(134),
-    [sym_token] = STATE(134),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(134),
-    [anon_sym_LBRACK] = ACTIONS(337),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(340),
-    [sym_begin_group] = ACTIONS(343),
+    [sym__escape] = ACTIONS(358),
+    [sym_begin_group] = ACTIONS(358),
     [sym_alignment_tab] = ACTIONS(358),
-    [sym_parameter_char] = ACTIONS(351),
+    [sym_parameter_char] = ACTIONS(358),
     [sym_superscript] = ACTIONS(358),
     [sym_subscript] = ACTIONS(358),
     [sym_active_char] = ACTIONS(358),
     [sym_text] = ACTIONS(358),
   },
-  [135] = {
-    [anon_sym_RPAREN] = ACTIONS(361),
+  [124] = {
+    [anon_sym_LBRACK] = ACTIONS(360),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(360),
+    [sym_begin_group] = ACTIONS(360),
+    [sym_alignment_tab] = ACTIONS(360),
+    [sym_parameter_char] = ACTIONS(360),
+    [sym_superscript] = ACTIONS(360),
+    [sym_subscript] = ACTIONS(360),
+    [sym_active_char] = ACTIONS(360),
+    [sym_text] = ACTIONS(360),
+  },
+  [125] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(362),
+  },
+  [126] = {
+    [anon_sym_LBRACK] = ACTIONS(364),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(364),
+  },
+  [127] = {
+    [anon_sym_LBRACK] = ACTIONS(366),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(366),
+  },
+  [128] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(368),
+  },
+  [129] = {
+    [anon_sym_LBRACK] = ACTIONS(370),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(370),
+  },
+  [130] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(372),
+  },
+  [131] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(374),
+  },
+  [132] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(376),
+  },
+  [133] = {
+    [anon_sym_LBRACK] = ACTIONS(378),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(378),
+    [sym_begin_group] = ACTIONS(378),
+    [sym_math_shift] = ACTIONS(378),
+    [sym_alignment_tab] = ACTIONS(378),
+    [sym_parameter_char] = ACTIONS(378),
+    [sym_superscript] = ACTIONS(378),
+    [sym_subscript] = ACTIONS(378),
+    [sym_active_char] = ACTIONS(378),
+    [sym_text] = ACTIONS(378),
+  },
+  [134] = {
+    [ts_builtin_sym_end] = ACTIONS(380),
+    [anon_sym_LBRACK] = ACTIONS(380),
+    [anon_sym_RBRACK] = ACTIONS(380),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(380),
+    [sym_begin_group] = ACTIONS(380),
+    [sym_end_group] = ACTIONS(380),
+    [sym_math_shift] = ACTIONS(380),
+    [sym_alignment_tab] = ACTIONS(380),
+    [sym_parameter_char] = ACTIONS(380),
+    [sym_superscript] = ACTIONS(380),
+    [sym_subscript] = ACTIONS(380),
+    [sym_active_char] = ACTIONS(380),
+    [sym_text] = ACTIONS(380),
+  },
+  [135] = {
+    [ts_builtin_sym_end] = ACTIONS(382),
+    [anon_sym_LBRACK] = ACTIONS(382),
+    [anon_sym_RBRACK] = ACTIONS(382),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(382),
+    [sym_begin_group] = ACTIONS(382),
+    [sym_end_group] = ACTIONS(382),
+    [sym_math_shift] = ACTIONS(382),
+    [sym_alignment_tab] = ACTIONS(382),
+    [sym_parameter_char] = ACTIONS(382),
+    [sym_superscript] = ACTIONS(382),
+    [sym_subscript] = ACTIONS(382),
+    [sym_active_char] = ACTIONS(382),
+    [sym_text] = ACTIONS(382),
   },
   [136] = {
-    [ts_builtin_sym_end] = ACTIONS(363),
-    [anon_sym_LBRACK] = ACTIONS(363),
-    [anon_sym_RBRACK] = ACTIONS(363),
+    [sym__common] = STATE(136),
+    [sym__text_mode_common] = STATE(136),
+    [sym__text_mode] = STATE(136),
+    [sym_text_mode_at_region] = STATE(136),
+    [sym_parameter] = STATE(136),
+    [sym_text_env] = STATE(136),
+    [sym__display_math] = STATE(136),
+    [sym_tex_display_math] = STATE(136),
+    [sym_latex_display_math] = STATE(136),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(136),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(136),
+    [sym_tex_inline_math] = STATE(136),
+    [sym_latex_inline_math] = STATE(136),
+    [sym_inline_math_env] = STATE(136),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(136),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(136),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(136),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(136),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(136),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(136),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(136),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(136),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(136),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(136),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(136),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(136),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(136),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(136),
+    [sym_opt_text_group] = STATE(136),
+    [sym_token] = STATE(136),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(136),
+    [anon_sym_LBRACK] = ACTIONS(337),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(363),
-    [sym_begin_group] = ACTIONS(363),
-    [sym_end_group] = ACTIONS(363),
-    [sym_math_shift] = ACTIONS(363),
-    [sym_alignment_tab] = ACTIONS(363),
-    [sym_parameter_char] = ACTIONS(363),
-    [sym_superscript] = ACTIONS(363),
-    [sym_subscript] = ACTIONS(363),
-    [sym_active_char] = ACTIONS(363),
-    [sym_text] = ACTIONS(363),
+    [sym__escape] = ACTIONS(340),
+    [sym_begin_group] = ACTIONS(343),
+    [sym_end_group] = ACTIONS(335),
+    [sym_math_shift] = ACTIONS(346),
+    [sym_alignment_tab] = ACTIONS(384),
+    [sym_parameter_char] = ACTIONS(352),
+    [sym_superscript] = ACTIONS(355),
+    [sym_subscript] = ACTIONS(355),
+    [sym_active_char] = ACTIONS(384),
+    [sym_text] = ACTIONS(384),
   },
   [137] = {
-    [ts_builtin_sym_end] = ACTIONS(365),
-    [anon_sym_LBRACK] = ACTIONS(365),
-    [anon_sym_RBRACK] = ACTIONS(365),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(365),
-    [sym_begin_group] = ACTIONS(365),
-    [sym_end_group] = ACTIONS(365),
-    [sym_math_shift] = ACTIONS(365),
-    [sym_alignment_tab] = ACTIONS(365),
-    [sym_parameter_char] = ACTIONS(365),
-    [sym_superscript] = ACTIONS(365),
-    [sym_subscript] = ACTIONS(365),
-    [sym_active_char] = ACTIONS(365),
-    [sym_text] = ACTIONS(365),
+    [sym_begin_group] = ACTIONS(387),
+    [sym__whitespace] = ACTIONS(389),
   },
   [138] = {
-    [sym_display_math_env_group] = STATE(216),
+    [anon_sym_LBRACK] = ACTIONS(391),
+    [anon_sym_RBRACK] = ACTIONS(391),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(367),
+    [sym__escape] = ACTIONS(391),
+    [sym_begin_group] = ACTIONS(391),
+    [sym_end_group] = ACTIONS(391),
+    [sym_math_shift] = ACTIONS(391),
+    [sym_alignment_tab] = ACTIONS(391),
+    [sym_parameter_char] = ACTIONS(391),
+    [sym_superscript] = ACTIONS(391),
+    [sym_subscript] = ACTIONS(391),
+    [sym_active_char] = ACTIONS(391),
+    [sym_text] = ACTIONS(391),
   },
   [139] = {
-    [ts_builtin_sym_end] = ACTIONS(369),
-    [anon_sym_LBRACK] = ACTIONS(369),
-    [anon_sym_RBRACK] = ACTIONS(369),
+    [sym__common] = STATE(234),
+    [sym__math_mode_common] = STATE(234),
+    [sym__math_mode] = STATE(234),
+    [sym_parameter] = STATE(234),
+    [sym_math_env] = STATE(234),
+    [sym_tag] = STATE(234),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(234),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(234),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(234),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(234),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(234),
+    [sym_opt_math_group] = STATE(234),
+    [sym_token] = STATE(234),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(234),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(369),
-    [sym_begin_group] = ACTIONS(369),
-    [sym_end_group] = ACTIONS(369),
-    [sym_math_shift] = ACTIONS(369),
-    [sym_alignment_tab] = ACTIONS(369),
-    [sym_parameter_char] = ACTIONS(369),
-    [sym_superscript] = ACTIONS(369),
-    [sym_subscript] = ACTIONS(369),
-    [sym_active_char] = ACTIONS(369),
-    [sym_text] = ACTIONS(369),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_end_group] = ACTIONS(393),
+    [sym_alignment_tab] = ACTIONS(395),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(395),
+    [sym_subscript] = ACTIONS(395),
+    [sym_active_char] = ACTIONS(395),
+    [sym_text] = ACTIONS(395),
   },
   [140] = {
-    [sym_inline_math_env_group] = STATE(218),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(371),
+    [sym_math_shift] = ACTIONS(397),
   },
   [141] = {
+    [ts_builtin_sym_end] = ACTIONS(399),
+    [anon_sym_LBRACK] = ACTIONS(399),
+    [anon_sym_RBRACK] = ACTIONS(399),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(373),
+    [sym__escape] = ACTIONS(399),
+    [sym_begin_group] = ACTIONS(399),
+    [sym_end_group] = ACTIONS(399),
+    [sym_math_shift] = ACTIONS(399),
+    [sym_alignment_tab] = ACTIONS(399),
+    [sym_parameter_char] = ACTIONS(399),
+    [sym_superscript] = ACTIONS(399),
+    [sym_subscript] = ACTIONS(399),
+    [sym_active_char] = ACTIONS(399),
+    [sym_text] = ACTIONS(399),
   },
   [142] = {
-    [ts_builtin_sym_end] = ACTIONS(375),
-    [anon_sym_LBRACK] = ACTIONS(375),
-    [anon_sym_RBRACK] = ACTIONS(375),
+    [sym__common] = STATE(238),
+    [sym__text_mode_common] = STATE(238),
+    [sym__text_mode] = STATE(238),
+    [sym_text_mode] = STATE(237),
+    [sym_text_mode_at_region] = STATE(238),
+    [sym_parameter] = STATE(238),
+    [sym_text_env] = STATE(238),
+    [sym__display_math] = STATE(238),
+    [sym_tex_display_math] = STATE(238),
+    [sym_latex_display_math] = STATE(238),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(238),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(238),
+    [sym_tex_inline_math] = STATE(238),
+    [sym_latex_inline_math] = STATE(238),
+    [sym_inline_math_env] = STATE(238),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(238),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(238),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(238),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(238),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(238),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(238),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(238),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(238),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(238),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(238),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(238),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(238),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(238),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(238),
+    [sym_opt_text_group] = STATE(238),
+    [sym_token] = STATE(238),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(238),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(375),
-    [sym_begin_group] = ACTIONS(375),
-    [sym_end_group] = ACTIONS(375),
-    [sym_math_shift] = ACTIONS(375),
-    [sym_alignment_tab] = ACTIONS(375),
-    [sym_parameter_char] = ACTIONS(375),
-    [sym_superscript] = ACTIONS(375),
-    [sym_subscript] = ACTIONS(375),
-    [sym_active_char] = ACTIONS(375),
-    [sym_text] = ACTIONS(375),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(401),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(403),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(403),
+    [sym_text] = ACTIONS(403),
   },
   [143] = {
-    [sym_verbatim_env_name] = ACTIONS(377),
+    [anon_sym_LBRACK] = ACTIONS(405),
+    [anon_sym_RBRACK] = ACTIONS(405),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(405),
+    [sym_begin_group] = ACTIONS(405),
+    [sym_end_group] = ACTIONS(405),
+    [sym_math_shift] = ACTIONS(405),
+    [sym_alignment_tab] = ACTIONS(405),
+    [sym_parameter_char] = ACTIONS(405),
+    [sym_superscript] = ACTIONS(405),
+    [sym_subscript] = ACTIONS(405),
+    [sym_active_char] = ACTIONS(405),
+    [sym_text] = ACTIONS(405),
   },
   [144] = {
-    [ts_builtin_sym_end] = ACTIONS(379),
-    [anon_sym_LBRACK] = ACTIONS(379),
-    [anon_sym_RBRACK] = ACTIONS(379),
+    [anon_sym_tag] = ACTIONS(191),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [anon_sym_end] = ACTIONS(233),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(379),
-    [sym_begin_group] = ACTIONS(379),
-    [sym_end_group] = ACTIONS(379),
-    [sym_math_shift] = ACTIONS(379),
-    [sym_alignment_tab] = ACTIONS(379),
-    [sym_parameter_char] = ACTIONS(379),
-    [sym_superscript] = ACTIONS(379),
-    [sym_subscript] = ACTIONS(379),
-    [sym_active_char] = ACTIONS(379),
-    [sym_text] = ACTIONS(379),
+    [sym__name] = ACTIONS(59),
   },
   [145] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(381),
+    [anon_sym_LBRACK] = ACTIONS(407),
+    [anon_sym_RBRACK] = ACTIONS(407),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(383),
-    [sym__end_of_line] = ACTIONS(383),
+    [sym__escape] = ACTIONS(407),
+    [sym_begin_group] = ACTIONS(407),
+    [sym_end_group] = ACTIONS(407),
+    [sym_math_shift] = ACTIONS(407),
+    [sym_alignment_tab] = ACTIONS(407),
+    [sym_parameter_char] = ACTIONS(407),
+    [sym_superscript] = ACTIONS(407),
+    [sym_subscript] = ACTIONS(407),
+    [sym_active_char] = ACTIONS(407),
+    [sym_text] = ACTIONS(407),
   },
   [146] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(146),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(385),
+    [sym__common] = STATE(152),
+    [sym__math_mode_common] = STATE(152),
+    [sym__math_mode] = STATE(152),
+    [sym_parameter] = STATE(152),
+    [sym_math_env] = STATE(152),
+    [sym_tag] = STATE(152),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(152),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_end] = STATE(239),
+    [sym_end_token] = STATE(74),
+    [sym_include] = STATE(152),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(152),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(152),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(152),
+    [sym_opt_math_group] = STATE(152),
+    [sym_token] = STATE(152),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(152),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(388),
+    [sym__escape] = ACTIONS(201),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(215),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(215),
+    [sym_subscript] = ACTIONS(215),
+    [sym_active_char] = ACTIONS(215),
+    [sym_text] = ACTIONS(215),
   },
   [147] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(68),
-    [aux_sym_verbatim_text_repeat2] = STATE(147),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(390),
+    [anon_sym_LBRACK] = ACTIONS(409),
+    [anon_sym_RBRACK] = ACTIONS(409),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(383),
-    [sym__end_of_line] = ACTIONS(393),
+    [sym__escape] = ACTIONS(409),
+    [sym_begin_group] = ACTIONS(409),
+    [sym_end_group] = ACTIONS(409),
+    [sym_math_shift] = ACTIONS(409),
+    [sym_alignment_tab] = ACTIONS(409),
+    [sym_parameter_char] = ACTIONS(409),
+    [sym_superscript] = ACTIONS(409),
+    [sym_subscript] = ACTIONS(409),
+    [sym_active_char] = ACTIONS(409),
+    [sym_text] = ACTIONS(409),
   },
   [148] = {
-    [ts_builtin_sym_end] = ACTIONS(396),
-    [anon_sym_LBRACK] = ACTIONS(396),
-    [anon_sym_RBRACK] = ACTIONS(396),
+    [sym__common] = STATE(241),
+    [sym__math_mode_common] = STATE(241),
+    [sym__math_mode] = STATE(241),
+    [sym_parameter] = STATE(241),
+    [sym_math_env] = STATE(241),
+    [sym_tag] = STATE(241),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(241),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(241),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(241),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(241),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(241),
+    [sym_opt_math_group] = STATE(241),
+    [sym_token] = STATE(241),
+    [sym_begin_opt] = STATE(58),
+    [sym_end_opt] = STATE(240),
+    [aux_sym_math_mode_repeat1] = STATE(241),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(396),
-    [sym_begin_group] = ACTIONS(396),
-    [sym_end_group] = ACTIONS(396),
-    [sym_math_shift] = ACTIONS(396),
-    [sym_alignment_tab] = ACTIONS(396),
-    [sym_parameter_char] = ACTIONS(396),
-    [sym_superscript] = ACTIONS(396),
-    [sym_subscript] = ACTIONS(396),
-    [sym_active_char] = ACTIONS(396),
-    [sym_text] = ACTIONS(396),
+    [sym__escape] = ACTIONS(65),
+    [sym_begin_group] = ACTIONS(67),
+    [sym_alignment_tab] = ACTIONS(411),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(411),
+    [sym_subscript] = ACTIONS(411),
+    [sym_active_char] = ACTIONS(411),
+    [sym_text] = ACTIONS(411),
   },
   [149] = {
-    [ts_builtin_sym_end] = ACTIONS(398),
-    [anon_sym_LBRACK] = ACTIONS(398),
-    [anon_sym_RBRACK] = ACTIONS(398),
+    [sym__common] = STATE(149),
+    [sym__math_mode_common] = STATE(149),
+    [sym__math_mode] = STATE(149),
+    [sym_parameter] = STATE(149),
+    [sym_math_env] = STATE(149),
+    [sym_tag] = STATE(149),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(149),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(149),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(149),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(149),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(149),
+    [sym_opt_math_group] = STATE(149),
+    [sym_token] = STATE(149),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(149),
+    [anon_sym_LBRACK] = ACTIONS(413),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(398),
-    [sym_begin_group] = ACTIONS(398),
-    [sym_end_group] = ACTIONS(398),
-    [sym_math_shift] = ACTIONS(398),
-    [sym_alignment_tab] = ACTIONS(398),
-    [sym_parameter_char] = ACTIONS(398),
-    [sym_superscript] = ACTIONS(398),
-    [sym_subscript] = ACTIONS(398),
-    [sym_active_char] = ACTIONS(398),
-    [sym_text] = ACTIONS(398),
+    [sym__escape] = ACTIONS(416),
+    [sym_begin_group] = ACTIONS(419),
+    [sym_math_shift] = ACTIONS(422),
+    [sym_alignment_tab] = ACTIONS(424),
+    [sym_parameter_char] = ACTIONS(427),
+    [sym_superscript] = ACTIONS(424),
+    [sym_subscript] = ACTIONS(424),
+    [sym_active_char] = ACTIONS(424),
+    [sym_text] = ACTIONS(424),
   },
   [150] = {
-    [sym__common] = STATE(150),
-    [sym__text_mode_common] = STATE(150),
-    [sym__text_mode] = STATE(150),
-    [sym_text_mode_at_region] = STATE(150),
-    [sym_parameter] = STATE(150),
-    [sym_text_env] = STATE(150),
-    [sym__display_math] = STATE(150),
-    [sym_tex_display_math] = STATE(150),
-    [sym_latex_display_math] = STATE(150),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(150),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(150),
-    [sym_tex_inline_math] = STATE(150),
-    [sym_latex_inline_math] = STATE(150),
-    [sym_inline_math_env] = STATE(150),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(150),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(150),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(150),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(150),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(150),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(150),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(150),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(150),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(150),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(150),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(150),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(150),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(150),
-    [sym_opt_text_group] = STATE(150),
-    [sym_token] = STATE(150),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(150),
-    [anon_sym_LBRACK] = ACTIONS(287),
+    [anon_sym_RBRACK] = ACTIONS(430),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(290),
-    [sym_begin_group] = ACTIONS(293),
-    [sym_math_shift] = ACTIONS(296),
-    [sym_alignment_tab] = ACTIONS(400),
-    [sym_parameter_char] = ACTIONS(302),
-    [sym_superscript] = ACTIONS(305),
-    [sym_subscript] = ACTIONS(305),
-    [sym_active_char] = ACTIONS(400),
-    [sym_text] = ACTIONS(400),
   },
   [151] = {
+    [ts_builtin_sym_end] = ACTIONS(432),
+    [anon_sym_LBRACK] = ACTIONS(432),
+    [anon_sym_RBRACK] = ACTIONS(432),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(403),
+    [sym__escape] = ACTIONS(432),
+    [sym_begin_group] = ACTIONS(432),
+    [sym_end_group] = ACTIONS(432),
+    [sym_math_shift] = ACTIONS(432),
+    [sym_alignment_tab] = ACTIONS(432),
+    [sym_parameter_char] = ACTIONS(432),
+    [sym_superscript] = ACTIONS(432),
+    [sym_subscript] = ACTIONS(432),
+    [sym_active_char] = ACTIONS(432),
+    [sym_text] = ACTIONS(432),
   },
   [152] = {
+    [sym__common] = STATE(152),
+    [sym__math_mode_common] = STATE(152),
+    [sym__math_mode] = STATE(152),
+    [sym_parameter] = STATE(152),
+    [sym_math_env] = STATE(152),
+    [sym_tag] = STATE(152),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(152),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(152),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(152),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(152),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(152),
+    [sym_opt_math_group] = STATE(152),
+    [sym_token] = STATE(152),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(152),
+    [anon_sym_LBRACK] = ACTIONS(413),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(405),
+    [sym__escape] = ACTIONS(416),
+    [sym_begin_group] = ACTIONS(419),
+    [sym_alignment_tab] = ACTIONS(434),
+    [sym_parameter_char] = ACTIONS(427),
+    [sym_superscript] = ACTIONS(434),
+    [sym_subscript] = ACTIONS(434),
+    [sym_active_char] = ACTIONS(434),
+    [sym_text] = ACTIONS(434),
   },
   [153] = {
+    [anon_sym_RPAREN] = ACTIONS(437),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(407),
   },
   [154] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(409),
-  },
-  [155] = {
-    [sym__common] = STATE(225),
-    [sym__text_mode_common] = STATE(225),
-    [sym__text_mode] = STATE(225),
-    [sym_text_mode_at_region] = STATE(225),
-    [sym_parameter] = STATE(225),
-    [sym_text_env] = STATE(225),
-    [sym__display_math] = STATE(225),
-    [sym_tex_display_math] = STATE(225),
-    [sym_latex_display_math] = STATE(225),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(225),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(225),
-    [sym_tex_inline_math] = STATE(225),
-    [sym_latex_inline_math] = STATE(225),
-    [sym_inline_math_env] = STATE(225),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(225),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(225),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(225),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(225),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(225),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(225),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(225),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(225),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(225),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(225),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(225),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(225),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(225),
-    [sym_opt_text_group] = STATE(225),
-    [sym_token] = STATE(225),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(225),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(411),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(413),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(413),
-    [sym_text] = ACTIONS(413),
-  },
-  [156] = {
-    [anon_sym_LBRACK] = ACTIONS(415),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(415),
-    [sym_begin_group] = ACTIONS(415),
-    [sym_alignment_tab] = ACTIONS(415),
-    [sym_parameter_char] = ACTIONS(415),
-    [sym_superscript] = ACTIONS(415),
-    [sym_subscript] = ACTIONS(415),
-    [sym_active_char] = ACTIONS(415),
-    [sym_text] = ACTIONS(415),
-  },
-  [157] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(417),
-  },
-  [158] = {
-    [sym_text_group] = STATE(227),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(211),
-    [sym__end_of_line] = ACTIONS(417),
-  },
-  [159] = {
-    [sym__common] = STATE(230),
-    [sym__text_mode_common] = STATE(230),
-    [sym__text_mode] = STATE(230),
-    [sym_text_mode_at_region] = STATE(230),
-    [sym_parameter] = STATE(230),
-    [sym_text_env] = STATE(230),
-    [sym__display_math] = STATE(230),
-    [sym_tex_display_math] = STATE(230),
-    [sym_latex_display_math] = STATE(230),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(230),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(230),
-    [sym_tex_inline_math] = STATE(230),
-    [sym_latex_inline_math] = STATE(230),
-    [sym_inline_math_env] = STATE(230),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(230),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(230),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(230),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(230),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(230),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(230),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(230),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(230),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(230),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(230),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(230),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(230),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(230),
-    [sym_opt_text_group] = STATE(230),
-    [sym_token] = STATE(230),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(229),
-    [aux_sym_text_mode_repeat1] = STATE(230),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(419),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(421),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(421),
-    [sym_text] = ACTIONS(421),
-  },
-  [160] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(423),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(425),
-    [sym__end_of_line] = ACTIONS(425),
-  },
-  [161] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(427),
-  },
-  [162] = {
-    [sym_text_group] = STATE(232),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(211),
-    [sym__end_of_line] = ACTIONS(427),
-  },
-  [163] = {
-    [ts_builtin_sym_end] = ACTIONS(429),
-    [anon_sym_LBRACK] = ACTIONS(429),
-    [anon_sym_RBRACK] = ACTIONS(429),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(429),
-    [sym_begin_group] = ACTIONS(429),
-    [sym_end_group] = ACTIONS(429),
-    [sym_math_shift] = ACTIONS(429),
-    [sym_alignment_tab] = ACTIONS(429),
-    [sym_parameter_char] = ACTIONS(429),
-    [sym_superscript] = ACTIONS(429),
-    [sym_subscript] = ACTIONS(429),
-    [sym_active_char] = ACTIONS(429),
-    [sym_text] = ACTIONS(429),
-  },
-  [164] = {
-    [ts_builtin_sym_end] = ACTIONS(431),
-    [anon_sym_LBRACK] = ACTIONS(431),
-    [anon_sym_RBRACK] = ACTIONS(431),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(431),
-    [sym_begin_group] = ACTIONS(431),
-    [sym_end_group] = ACTIONS(431),
-    [sym_math_shift] = ACTIONS(431),
-    [sym_alignment_tab] = ACTIONS(431),
-    [sym_parameter_char] = ACTIONS(431),
-    [sym_superscript] = ACTIONS(431),
-    [sym_subscript] = ACTIONS(431),
-    [sym_active_char] = ACTIONS(431),
-    [sym_text] = ACTIONS(431),
-  },
-  [165] = {
-    [ts_builtin_sym_end] = ACTIONS(433),
-    [anon_sym_LBRACK] = ACTIONS(433),
-    [anon_sym_RBRACK] = ACTIONS(433),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(433),
-    [sym_begin_group] = ACTIONS(433),
-    [sym_end_group] = ACTIONS(433),
-    [sym_math_shift] = ACTIONS(433),
-    [sym_alignment_tab] = ACTIONS(433),
-    [sym_parameter_char] = ACTIONS(433),
-    [sym_superscript] = ACTIONS(433),
-    [sym_subscript] = ACTIONS(433),
-    [sym_active_char] = ACTIONS(433),
-    [sym_text] = ACTIONS(433),
-  },
-  [166] = {
-    [anon_sym_EQ] = ACTIONS(121),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [167] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_number] = ACTIONS(435),
-  },
-  [168] = {
-    [ts_builtin_sym_end] = ACTIONS(437),
-    [anon_sym_LBRACK] = ACTIONS(437),
-    [anon_sym_RBRACK] = ACTIONS(437),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(437),
-    [sym_begin_group] = ACTIONS(437),
-    [sym_end_group] = ACTIONS(437),
-    [sym_math_shift] = ACTIONS(437),
-    [sym_alignment_tab] = ACTIONS(437),
-    [sym_parameter_char] = ACTIONS(437),
-    [sym_superscript] = ACTIONS(437),
-    [sym_subscript] = ACTIONS(437),
-    [sym_active_char] = ACTIONS(437),
-    [sym_text] = ACTIONS(437),
-  },
-  [169] = {
+    [ts_builtin_sym_end] = ACTIONS(439),
     [anon_sym_LBRACK] = ACTIONS(439),
     [anon_sym_RBRACK] = ACTIONS(439),
     [sym_magic_comment] = ACTIONS(9),
@@ -8717,26 +8756,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(439),
     [sym_text] = ACTIONS(439),
   },
-  [170] = {
-    [anon_sym_LBRACK] = ACTIONS(27),
-    [anon_sym_LPAREN] = ACTIONS(29),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_documentclass] = ACTIONS(35),
-    [anon_sym_usepackage] = ACTIONS(37),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
-    [anon_sym_emph] = ACTIONS(47),
-    [anon_sym_textbf] = ACTIONS(49),
-    [anon_sym_textit] = ACTIONS(51),
-    [anon_sym_texttt] = ACTIONS(53),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(245),
-  },
-  [171] = {
+  [155] = {
+    [ts_builtin_sym_end] = ACTIONS(441),
     [anon_sym_LBRACK] = ACTIONS(441),
     [anon_sym_RBRACK] = ACTIONS(441),
     [sym_magic_comment] = ACTIONS(9),
@@ -8752,632 +8773,283 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(441),
     [sym_text] = ACTIONS(441),
   },
-  [172] = {
-    [sym__common] = STATE(235),
-    [sym__text_mode_common] = STATE(235),
-    [sym__text_mode_at] = STATE(235),
-    [sym_parameter] = STATE(235),
-    [sym_text_env_at] = STATE(235),
-    [sym__display_math_at] = STATE(235),
-    [sym_tex_display_math_at] = STATE(235),
-    [sym_latex_display_math_at] = STATE(235),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(235),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(235),
-    [sym_tex_inline_math_at] = STATE(235),
-    [sym_latex_inline_math_at] = STATE(235),
-    [sym_inline_math_env_at] = STATE(235),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(235),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(235),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(235),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(235),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(235),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(235),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(235),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(235),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(235),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(235),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(235),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(235),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(235),
-    [sym_opt_text_group_at] = STATE(235),
-    [sym_token_at] = STATE(235),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(235),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [156] = {
+    [sym_display_math_env_group] = STATE(245),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_end_group] = ACTIONS(443),
-    [sym_math_shift] = ACTIONS(103),
+    [sym_begin_group] = ACTIONS(443),
+  },
+  [157] = {
+    [ts_builtin_sym_end] = ACTIONS(445),
+    [anon_sym_LBRACK] = ACTIONS(445),
+    [anon_sym_RBRACK] = ACTIONS(445),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(445),
+    [sym_begin_group] = ACTIONS(445),
+    [sym_end_group] = ACTIONS(445),
+    [sym_math_shift] = ACTIONS(445),
     [sym_alignment_tab] = ACTIONS(445),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(445),
+    [sym_superscript] = ACTIONS(445),
+    [sym_subscript] = ACTIONS(445),
     [sym_active_char] = ACTIONS(445),
     [sym_text] = ACTIONS(445),
   },
-  [173] = {
-    [anon_sym_tag] = ACTIONS(155),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+  [158] = {
+    [sym_inline_math_env_group] = STATE(247),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(245),
+    [sym_begin_group] = ACTIONS(447),
   },
-  [174] = {
-    [sym__common] = STATE(237),
-    [sym__math_mode_common] = STATE(237),
-    [sym__math_mode_at] = STATE(237),
-    [sym_parameter] = STATE(237),
-    [sym_math_env_at] = STATE(237),
-    [sym_tag_at] = STATE(237),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(237),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(237),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(237),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(237),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(237),
-    [sym_opt_math_group_at] = STATE(237),
-    [sym_token_at] = STATE(237),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(237),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [159] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_end_group] = ACTIONS(447),
-    [sym_alignment_tab] = ACTIONS(449),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(449),
-    [sym_subscript] = ACTIONS(449),
-    [sym_active_char] = ACTIONS(449),
-    [sym_text] = ACTIONS(449),
+    [sym_begin_group] = ACTIONS(449),
+    [sym__whitespace] = ACTIONS(451),
   },
-  [175] = {
-    [sym__common] = STATE(180),
-    [sym__math_mode_common] = STATE(180),
-    [sym__math_mode_at] = STATE(180),
-    [sym_math_mode_at] = STATE(238),
-    [sym_parameter] = STATE(180),
-    [sym_math_env_at] = STATE(180),
-    [sym_tag_at] = STATE(180),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(180),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(180),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(180),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(180),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(180),
-    [sym_opt_math_group_at] = STATE(180),
-    [sym_token_at] = STATE(180),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(180),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [160] = {
+    [ts_builtin_sym_end] = ACTIONS(453),
+    [anon_sym_LBRACK] = ACTIONS(453),
+    [anon_sym_RBRACK] = ACTIONS(453),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(259),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(259),
-    [sym_subscript] = ACTIONS(259),
-    [sym_active_char] = ACTIONS(259),
-    [sym_text] = ACTIONS(259),
-  },
-  [176] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(451),
-  },
-  [177] = {
-    [sym_math_text_group_at] = STATE(241),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(453),
     [sym_begin_group] = ACTIONS(453),
+    [sym_end_group] = ACTIONS(453),
+    [sym_math_shift] = ACTIONS(453),
+    [sym_alignment_tab] = ACTIONS(453),
+    [sym_parameter_char] = ACTIONS(453),
+    [sym_superscript] = ACTIONS(453),
+    [sym_subscript] = ACTIONS(453),
+    [sym_active_char] = ACTIONS(453),
+    [sym_text] = ACTIONS(453),
   },
-  [178] = {
-    [sym__common] = STATE(244),
-    [sym__math_mode_common] = STATE(244),
-    [sym__math_mode_at] = STATE(244),
-    [sym_parameter] = STATE(244),
-    [sym_math_env_at] = STATE(244),
-    [sym_tag_at] = STATE(244),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(244),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_end] = STATE(243),
-    [sym_end_token] = STATE(72),
-    [sym_include_at] = STATE(244),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(244),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(244),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(244),
-    [sym_opt_math_group_at] = STATE(244),
-    [sym_token_at] = STATE(244),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(244),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [161] = {
+    [sym_verbatim_env_name] = ACTIONS(455),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(455),
-    [sym_begin_group] = ACTIONS(255),
+  },
+  [162] = {
+    [ts_builtin_sym_end] = ACTIONS(457),
+    [anon_sym_LBRACK] = ACTIONS(457),
+    [anon_sym_RBRACK] = ACTIONS(457),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(457),
+    [sym_begin_group] = ACTIONS(457),
+    [sym_end_group] = ACTIONS(457),
+    [sym_math_shift] = ACTIONS(457),
     [sym_alignment_tab] = ACTIONS(457),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(457),
     [sym_superscript] = ACTIONS(457),
     [sym_subscript] = ACTIONS(457),
     [sym_active_char] = ACTIONS(457),
     [sym_text] = ACTIONS(457),
   },
-  [179] = {
-    [sym__common] = STATE(246),
-    [sym__math_mode_common] = STATE(246),
-    [sym__math_mode_at] = STATE(246),
-    [sym_parameter] = STATE(246),
-    [sym_math_env_at] = STATE(246),
-    [sym_tag_at] = STATE(246),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(246),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(246),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(246),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(246),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(246),
-    [sym_opt_math_group_at] = STATE(246),
-    [sym_token_at] = STATE(246),
-    [sym_begin_opt] = STATE(179),
-    [sym_end_opt] = STATE(245),
-    [aux_sym_math_mode_at_repeat1] = STATE(246),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(459),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(459),
-    [sym_subscript] = ACTIONS(459),
-    [sym_active_char] = ACTIONS(459),
-    [sym_text] = ACTIONS(459),
-  },
-  [180] = {
-    [sym__common] = STATE(247),
-    [sym__math_mode_common] = STATE(247),
-    [sym__math_mode_at] = STATE(247),
-    [sym_parameter] = STATE(247),
-    [sym_math_env_at] = STATE(247),
-    [sym_tag_at] = STATE(247),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(247),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(247),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(247),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(247),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(247),
-    [sym_opt_math_group_at] = STATE(247),
-    [sym_token_at] = STATE(247),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(247),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_math_shift] = ACTIONS(461),
-    [sym_alignment_tab] = ACTIONS(463),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(463),
-    [sym_subscript] = ACTIONS(463),
-    [sym_active_char] = ACTIONS(463),
-    [sym_text] = ACTIONS(463),
-  },
-  [181] = {
-    [anon_sym_makeatother] = ACTIONS(465),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [182] = {
-    [ts_builtin_sym_end] = ACTIONS(467),
-    [anon_sym_LBRACK] = ACTIONS(467),
-    [anon_sym_RBRACK] = ACTIONS(467),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(467),
-    [sym_begin_group] = ACTIONS(467),
-    [sym_end_group] = ACTIONS(467),
-    [sym_math_shift] = ACTIONS(467),
-    [sym_alignment_tab] = ACTIONS(467),
-    [sym_parameter_char] = ACTIONS(467),
-    [sym_superscript] = ACTIONS(467),
-    [sym_subscript] = ACTIONS(467),
-    [sym_active_char] = ACTIONS(467),
-    [sym_text] = ACTIONS(467),
-  },
-  [183] = {
-    [sym_end_display_math] = STATE(248),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(177),
-  },
-  [184] = {
-    [sym__common] = STATE(249),
-    [sym__math_mode_common] = STATE(249),
-    [sym__math_mode_at] = STATE(249),
-    [sym_parameter] = STATE(249),
-    [sym_math_env_at] = STATE(249),
-    [sym_tag_at] = STATE(249),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(249),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(249),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(249),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(249),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(249),
-    [sym_opt_math_group_at] = STATE(249),
-    [sym_token_at] = STATE(249),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(249),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [163] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(459),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(461),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(469),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(469),
-    [sym_subscript] = ACTIONS(469),
-    [sym_active_char] = ACTIONS(469),
-    [sym_text] = ACTIONS(469),
+    [sym__end_of_line] = ACTIONS(461),
   },
-  [185] = {
-    [sym_end_inline_math] = STATE(250),
+  [164] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(164),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(463),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(181),
+    [sym__end_of_line] = ACTIONS(466),
   },
-  [186] = {
-    [sym_display_math_end] = STATE(251),
-    [sym_end_token] = STATE(138),
+  [165] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(70),
+    [aux_sym_verbatim_text_repeat2] = STATE(165),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(468),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
+    [sym__escape] = ACTIONS(461),
+    [sym__end_of_line] = ACTIONS(471),
   },
-  [187] = {
-    [sym_inline_math_end] = STATE(252),
-    [sym_end_token] = STATE(140),
+  [166] = {
+    [ts_builtin_sym_end] = ACTIONS(474),
+    [anon_sym_LBRACK] = ACTIONS(474),
+    [anon_sym_RBRACK] = ACTIONS(474),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(83),
+    [sym__escape] = ACTIONS(474),
+    [sym_begin_group] = ACTIONS(474),
+    [sym_end_group] = ACTIONS(474),
+    [sym_math_shift] = ACTIONS(474),
+    [sym_alignment_tab] = ACTIONS(474),
+    [sym_parameter_char] = ACTIONS(474),
+    [sym_superscript] = ACTIONS(474),
+    [sym_subscript] = ACTIONS(474),
+    [sym_active_char] = ACTIONS(474),
+    [sym_text] = ACTIONS(474),
   },
-  [188] = {
-    [anon_sym_LBRACK] = ACTIONS(27),
-    [anon_sym_LPAREN] = ACTIONS(29),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
-    [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_end] = ACTIONS(197),
-    [anon_sym_documentclass] = ACTIONS(35),
-    [anon_sym_usepackage] = ACTIONS(37),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
-    [anon_sym_emph] = ACTIONS(47),
-    [anon_sym_textbf] = ACTIONS(49),
-    [anon_sym_textit] = ACTIONS(51),
-    [anon_sym_texttt] = ACTIONS(53),
+  [167] = {
+    [ts_builtin_sym_end] = ACTIONS(476),
+    [anon_sym_LBRACK] = ACTIONS(476),
+    [anon_sym_RBRACK] = ACTIONS(476),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(245),
+    [sym__escape] = ACTIONS(476),
+    [sym_begin_group] = ACTIONS(476),
+    [sym_end_group] = ACTIONS(476),
+    [sym_math_shift] = ACTIONS(476),
+    [sym_alignment_tab] = ACTIONS(476),
+    [sym_parameter_char] = ACTIONS(476),
+    [sym_superscript] = ACTIONS(476),
+    [sym_subscript] = ACTIONS(476),
+    [sym_active_char] = ACTIONS(476),
+    [sym_text] = ACTIONS(476),
   },
-  [189] = {
-    [anon_sym_LBRACK] = ACTIONS(471),
-    [anon_sym_RBRACK] = ACTIONS(471),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(471),
-    [sym_begin_group] = ACTIONS(471),
-    [sym_end_group] = ACTIONS(471),
-    [sym_math_shift] = ACTIONS(471),
-    [sym_alignment_tab] = ACTIONS(471),
-    [sym_parameter_char] = ACTIONS(471),
-    [sym_superscript] = ACTIONS(471),
-    [sym_subscript] = ACTIONS(471),
-    [sym_active_char] = ACTIONS(471),
-    [sym_text] = ACTIONS(471),
-  },
-  [190] = {
-    [sym__common] = STATE(201),
-    [sym__text_mode_common] = STATE(201),
-    [sym__text_mode_at] = STATE(201),
-    [sym_parameter] = STATE(201),
-    [sym_text_env_at] = STATE(201),
-    [sym__display_math_at] = STATE(201),
-    [sym_tex_display_math_at] = STATE(201),
-    [sym_latex_display_math_at] = STATE(201),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(201),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(201),
-    [sym_tex_inline_math_at] = STATE(201),
-    [sym_latex_inline_math_at] = STATE(201),
-    [sym_inline_math_env_at] = STATE(201),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(201),
+  [168] = {
+    [sym__common] = STATE(168),
+    [sym__text_mode_common] = STATE(168),
+    [sym__text_mode] = STATE(168),
+    [sym_text_mode_at_region] = STATE(168),
+    [sym_parameter] = STATE(168),
+    [sym_text_env] = STATE(168),
+    [sym__display_math] = STATE(168),
+    [sym_tex_display_math] = STATE(168),
+    [sym_latex_display_math] = STATE(168),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(168),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(168),
+    [sym_tex_inline_math] = STATE(168),
+    [sym_latex_inline_math] = STATE(168),
+    [sym_inline_math_env] = STATE(168),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(168),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(201),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_end] = STATE(253),
-    [sym_end_token] = STATE(72),
-    [sym_documentclass] = STATE(201),
+    [sym_escaped] = STATE(168),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(168),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(201),
+    [sym_usepackage] = STATE(168),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(201),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(201),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(201),
+    [sym_include] = STATE(168),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(168),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(168),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(201),
+    [sym_catcode] = STATE(168),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(201),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(201),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(201),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(201),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(201),
-    [sym_opt_text_group_at] = STATE(201),
-    [sym_token_at] = STATE(201),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(201),
-    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_emph] = STATE(168),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(168),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(168),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(168),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(168),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(168),
+    [sym_opt_text_group] = STATE(168),
+    [sym_token] = STATE(168),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(168),
+    [anon_sym_LBRACK] = ACTIONS(337),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(265),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(277),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(277),
-    [sym_text] = ACTIONS(277),
+    [sym__escape] = ACTIONS(340),
+    [sym_begin_group] = ACTIONS(343),
+    [sym_math_shift] = ACTIONS(346),
+    [sym_alignment_tab] = ACTIONS(478),
+    [sym_parameter_char] = ACTIONS(352),
+    [sym_superscript] = ACTIONS(355),
+    [sym_subscript] = ACTIONS(355),
+    [sym_active_char] = ACTIONS(478),
+    [sym_text] = ACTIONS(478),
   },
-  [191] = {
-    [sym_text_group_at] = STATE(256),
-    [sym_opt_text_group_at] = STATE(257),
-    [sym_begin_opt] = STATE(258),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [169] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(473),
-    [sym__end_of_line] = ACTIONS(475),
-  },
-  [192] = {
-    [anon_sym_LBRACK] = ACTIONS(477),
-    [anon_sym_RBRACK] = ACTIONS(477),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(477),
-    [sym_begin_group] = ACTIONS(477),
-    [sym_end_group] = ACTIONS(477),
-    [sym_math_shift] = ACTIONS(477),
-    [sym_alignment_tab] = ACTIONS(477),
-    [sym_parameter_char] = ACTIONS(477),
-    [sym_superscript] = ACTIONS(477),
-    [sym_subscript] = ACTIONS(477),
-    [sym_active_char] = ACTIONS(477),
-    [sym_text] = ACTIONS(477),
-  },
-  [193] = {
-    [anon_sym_LBRACK] = ACTIONS(479),
-    [anon_sym_RBRACK] = ACTIONS(479),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(479),
-    [sym_begin_group] = ACTIONS(479),
-    [sym_end_group] = ACTIONS(479),
-    [sym_math_shift] = ACTIONS(479),
-    [sym_alignment_tab] = ACTIONS(479),
-    [sym_parameter_char] = ACTIONS(479),
-    [sym_superscript] = ACTIONS(479),
-    [sym_subscript] = ACTIONS(479),
-    [sym_active_char] = ACTIONS(479),
-    [sym_text] = ACTIONS(479),
-  },
-  [194] = {
-    [sym_text_group_at] = STATE(259),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(101),
-  },
-  [195] = {
-    [anon_sym_LBRACK] = ACTIONS(481),
-    [anon_sym_RBRACK] = ACTIONS(481),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(481),
-    [sym_begin_group] = ACTIONS(481),
     [sym_end_group] = ACTIONS(481),
-    [sym_math_shift] = ACTIONS(481),
-    [sym_alignment_tab] = ACTIONS(481),
-    [sym_parameter_char] = ACTIONS(481),
-    [sym_superscript] = ACTIONS(481),
-    [sym_subscript] = ACTIONS(481),
-    [sym_active_char] = ACTIONS(481),
-    [sym_text] = ACTIONS(481),
   },
-  [196] = {
-    [anon_sym_LBRACK] = ACTIONS(483),
-    [anon_sym_RBRACK] = ACTIONS(483),
+  [170] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(483),
-    [sym_begin_group] = ACTIONS(483),
     [sym_end_group] = ACTIONS(483),
-    [sym_math_shift] = ACTIONS(483),
-    [sym_alignment_tab] = ACTIONS(483),
-    [sym_parameter_char] = ACTIONS(483),
-    [sym_superscript] = ACTIONS(483),
-    [sym_subscript] = ACTIONS(483),
-    [sym_active_char] = ACTIONS(483),
-    [sym_text] = ACTIONS(483),
   },
-  [197] = {
-    [anon_sym_LBRACK] = ACTIONS(485),
-    [anon_sym_RBRACK] = ACTIONS(485),
+  [171] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(485),
-    [sym_begin_group] = ACTIONS(485),
     [sym_end_group] = ACTIONS(485),
-    [sym_math_shift] = ACTIONS(485),
-    [sym_alignment_tab] = ACTIONS(485),
-    [sym_parameter_char] = ACTIONS(485),
-    [sym_superscript] = ACTIONS(485),
-    [sym_subscript] = ACTIONS(485),
-    [sym_active_char] = ACTIONS(485),
-    [sym_text] = ACTIONS(485),
   },
-  [198] = {
-    [anon_sym_LBRACK] = ACTIONS(487),
-    [anon_sym_RBRACK] = ACTIONS(487),
+  [172] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(487),
-    [sym_begin_group] = ACTIONS(487),
     [sym_end_group] = ACTIONS(487),
-    [sym_math_shift] = ACTIONS(487),
-    [sym_alignment_tab] = ACTIONS(487),
-    [sym_parameter_char] = ACTIONS(487),
-    [sym_superscript] = ACTIONS(487),
-    [sym_subscript] = ACTIONS(487),
-    [sym_active_char] = ACTIONS(487),
-    [sym_text] = ACTIONS(487),
   },
-  [199] = {
-    [anon_sym_LBRACK] = ACTIONS(489),
-    [anon_sym_RBRACK] = ACTIONS(489),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(489),
-    [sym_begin_group] = ACTIONS(489),
-    [sym_end_group] = ACTIONS(489),
-    [sym_math_shift] = ACTIONS(489),
-    [sym_alignment_tab] = ACTIONS(489),
-    [sym_parameter_char] = ACTIONS(489),
-    [sym_superscript] = ACTIONS(489),
-    [sym_subscript] = ACTIONS(489),
-    [sym_active_char] = ACTIONS(489),
-    [sym_text] = ACTIONS(489),
-  },
-  [200] = {
-    [sym__common] = STATE(261),
-    [sym__text_mode_common] = STATE(261),
-    [sym__text_mode_at] = STATE(261),
-    [sym_parameter] = STATE(261),
-    [sym_text_env_at] = STATE(261),
-    [sym__display_math_at] = STATE(261),
-    [sym_tex_display_math_at] = STATE(261),
-    [sym_latex_display_math_at] = STATE(261),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(261),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(261),
-    [sym_tex_inline_math_at] = STATE(261),
-    [sym_latex_inline_math_at] = STATE(261),
-    [sym_inline_math_env_at] = STATE(261),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(261),
+  [173] = {
+    [sym__common] = STATE(255),
+    [sym__text_mode_common] = STATE(255),
+    [sym__text_mode] = STATE(255),
+    [sym_text_mode_at_region] = STATE(255),
+    [sym_parameter] = STATE(255),
+    [sym_text_env] = STATE(255),
+    [sym__display_math] = STATE(255),
+    [sym_tex_display_math] = STATE(255),
+    [sym_latex_display_math] = STATE(255),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(255),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(255),
+    [sym_tex_inline_math] = STATE(255),
+    [sym_latex_inline_math] = STATE(255),
+    [sym_inline_math_env] = STATE(255),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(255),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(261),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(261),
+    [sym_escaped] = STATE(255),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(255),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(261),
+    [sym_usepackage] = STATE(255),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(261),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(261),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(261),
+    [sym_include] = STATE(255),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(255),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(255),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(261),
+    [sym_catcode] = STATE(255),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(261),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(261),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(261),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(261),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(261),
-    [sym_opt_text_group_at] = STATE(261),
-    [sym_token_at] = STATE(261),
-    [sym_begin_opt] = STATE(111),
-    [sym_end_opt] = STATE(260),
-    [aux_sym_text_mode_at_repeat1] = STATE(261),
+    [sym_emph] = STATE(255),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(255),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(255),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(255),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(255),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(255),
+    [sym_opt_text_group] = STATE(255),
+    [sym_token] = STATE(255),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(255),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(489),
+    [sym_math_shift] = ACTIONS(17),
     [sym_alignment_tab] = ACTIONS(491),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
@@ -9385,1461 +9057,576 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(491),
     [sym_text] = ACTIONS(491),
   },
-  [201] = {
-    [sym__common] = STATE(201),
-    [sym__text_mode_common] = STATE(201),
-    [sym__text_mode_at] = STATE(201),
-    [sym_parameter] = STATE(201),
-    [sym_text_env_at] = STATE(201),
-    [sym__display_math_at] = STATE(201),
-    [sym_tex_display_math_at] = STATE(201),
-    [sym_latex_display_math_at] = STATE(201),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(201),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(201),
-    [sym_tex_inline_math_at] = STATE(201),
-    [sym_latex_inline_math_at] = STATE(201),
-    [sym_inline_math_env_at] = STATE(201),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(201),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(201),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(201),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(201),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(201),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(201),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(201),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(201),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(201),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(201),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(201),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(201),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(201),
-    [sym_opt_text_group_at] = STATE(201),
-    [sym_token_at] = STATE(201),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(201),
+  [174] = {
     [anon_sym_LBRACK] = ACTIONS(493),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(496),
-    [sym_begin_group] = ACTIONS(499),
-    [sym_math_shift] = ACTIONS(502),
-    [sym_alignment_tab] = ACTIONS(505),
-    [sym_parameter_char] = ACTIONS(508),
-    [sym_superscript] = ACTIONS(511),
-    [sym_subscript] = ACTIONS(511),
-    [sym_active_char] = ACTIONS(505),
-    [sym_text] = ACTIONS(505),
+    [sym__escape] = ACTIONS(493),
+    [sym_begin_group] = ACTIONS(493),
+    [sym_alignment_tab] = ACTIONS(493),
+    [sym_parameter_char] = ACTIONS(493),
+    [sym_superscript] = ACTIONS(493),
+    [sym_subscript] = ACTIONS(493),
+    [sym_active_char] = ACTIONS(493),
+    [sym_text] = ACTIONS(493),
   },
-  [202] = {
-    [ts_builtin_sym_end] = ACTIONS(514),
-    [anon_sym_LBRACK] = ACTIONS(514),
-    [anon_sym_RBRACK] = ACTIONS(514),
+  [175] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(514),
-    [sym_begin_group] = ACTIONS(514),
-    [sym_end_group] = ACTIONS(514),
-    [sym_math_shift] = ACTIONS(514),
-    [sym_alignment_tab] = ACTIONS(514),
-    [sym_parameter_char] = ACTIONS(514),
-    [sym_superscript] = ACTIONS(514),
-    [sym_subscript] = ACTIONS(514),
-    [sym_active_char] = ACTIONS(514),
-    [sym_text] = ACTIONS(514),
+    [sym__end_of_line] = ACTIONS(495),
   },
-  [203] = {
-    [sym__common] = STATE(203),
-    [sym__text_mode_common] = STATE(203),
-    [sym__text_mode] = STATE(203),
-    [sym_text_mode_at_region] = STATE(203),
-    [sym_parameter] = STATE(203),
-    [sym_text_env] = STATE(203),
-    [sym__display_math] = STATE(203),
-    [sym_tex_display_math] = STATE(203),
-    [sym_latex_display_math] = STATE(203),
+  [176] = {
+    [sym_text_group] = STATE(258),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(495),
+    [sym__whitespace] = ACTIONS(497),
+  },
+  [177] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(499),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(501),
+    [sym__end_of_line] = ACTIONS(501),
+  },
+  [178] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(503),
+  },
+  [179] = {
+    [sym_text_group] = STATE(261),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(503),
+    [sym__whitespace] = ACTIONS(505),
+  },
+  [180] = {
+    [sym_simple_text_group] = STATE(262),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(95),
+  },
+  [181] = {
+    [ts_builtin_sym_end] = ACTIONS(507),
+    [anon_sym_LBRACK] = ACTIONS(507),
+    [anon_sym_RBRACK] = ACTIONS(507),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(507),
+    [sym_begin_group] = ACTIONS(507),
+    [sym_end_group] = ACTIONS(507),
+    [sym_math_shift] = ACTIONS(507),
+    [sym_alignment_tab] = ACTIONS(507),
+    [sym_parameter_char] = ACTIONS(507),
+    [sym_superscript] = ACTIONS(507),
+    [sym_subscript] = ACTIONS(507),
+    [sym_active_char] = ACTIONS(507),
+    [sym_text] = ACTIONS(507),
+  },
+  [182] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(329),
+    [sym__end_of_line] = ACTIONS(329),
+    [sym__whitespace] = ACTIONS(329),
+  },
+  [183] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(331),
+    [sym__end_of_line] = ACTIONS(331),
+    [sym__whitespace] = ACTIONS(331),
+  },
+  [184] = {
+    [sym__common] = STATE(231),
+    [sym__text_mode_common] = STATE(231),
+    [sym__text_mode] = STATE(231),
+    [sym_text_mode_at_region] = STATE(231),
+    [sym_parameter] = STATE(231),
+    [sym_text_env] = STATE(231),
+    [sym__display_math] = STATE(231),
+    [sym_tex_display_math] = STATE(231),
+    [sym_latex_display_math] = STATE(231),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(203),
+    [sym_display_math_env] = STATE(231),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(203),
-    [sym_tex_inline_math] = STATE(203),
-    [sym_latex_inline_math] = STATE(203),
-    [sym_inline_math_env] = STATE(203),
+    [sym__inline_math] = STATE(231),
+    [sym_tex_inline_math] = STATE(231),
+    [sym_latex_inline_math] = STATE(231),
+    [sym_inline_math_env] = STATE(231),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(203),
+    [sym_verbatim_env] = STATE(231),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(203),
+    [sym_escaped] = STATE(231),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(203),
+    [sym_documentclass] = STATE(231),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(203),
+    [sym_usepackage] = STATE(231),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(203),
+    [sym_include] = STATE(231),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(203),
+    [sym_section] = STATE(231),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(203),
+    [sym_storage] = STATE(231),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(203),
+    [sym_catcode] = STATE(231),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(203),
+    [sym_emph] = STATE(231),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(203),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(203),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(203),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(203),
-    [sym_opt_text_group] = STATE(203),
-    [sym_token] = STATE(203),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(203),
-    [anon_sym_LBRACK] = ACTIONS(287),
-    [anon_sym_RBRACK] = ACTIONS(285),
+    [sym_footnote] = STATE(231),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(231),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(231),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(231),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(231),
+    [sym_opt_text_group] = STATE(231),
+    [sym_token] = STATE(231),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(263),
+    [aux_sym_text_mode_repeat1] = STATE(231),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(263),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(290),
-    [sym_begin_group] = ACTIONS(293),
-    [sym_math_shift] = ACTIONS(296),
-    [sym_alignment_tab] = ACTIONS(516),
-    [sym_parameter_char] = ACTIONS(302),
-    [sym_superscript] = ACTIONS(305),
-    [sym_subscript] = ACTIONS(305),
-    [sym_active_char] = ACTIONS(516),
-    [sym_text] = ACTIONS(516),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(333),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(333),
+    [sym_text] = ACTIONS(333),
   },
-  [204] = {
-    [anon_sym_LBRACK] = ACTIONS(519),
-    [anon_sym_RBRACK] = ACTIONS(519),
+  [185] = {
+    [sym_simple_text_group] = STATE(264),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(519),
-    [sym_begin_group] = ACTIONS(519),
-    [sym_end_group] = ACTIONS(519),
-    [sym_math_shift] = ACTIONS(519),
-    [sym_alignment_tab] = ACTIONS(519),
-    [sym_parameter_char] = ACTIONS(519),
-    [sym_superscript] = ACTIONS(519),
-    [sym_subscript] = ACTIONS(519),
-    [sym_active_char] = ACTIONS(519),
-    [sym_text] = ACTIONS(519),
+    [sym_begin_group] = ACTIONS(95),
   },
-  [205] = {
-    [sym__common] = STATE(205),
-    [sym__math_mode_common] = STATE(205),
-    [sym__math_mode] = STATE(205),
-    [sym_parameter] = STATE(205),
-    [sym_math_env] = STATE(205),
-    [sym_tag] = STATE(205),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(205),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(205),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(205),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(205),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(205),
-    [sym_opt_math_group] = STATE(205),
-    [sym_token] = STATE(205),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(205),
-    [anon_sym_LBRACK] = ACTIONS(337),
+  [186] = {
+    [ts_builtin_sym_end] = ACTIONS(509),
+    [anon_sym_LBRACK] = ACTIONS(509),
+    [anon_sym_RBRACK] = ACTIONS(509),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(340),
-    [sym_begin_group] = ACTIONS(343),
-    [sym_end_group] = ACTIONS(346),
-    [sym_alignment_tab] = ACTIONS(521),
-    [sym_parameter_char] = ACTIONS(351),
-    [sym_superscript] = ACTIONS(521),
-    [sym_subscript] = ACTIONS(521),
-    [sym_active_char] = ACTIONS(521),
+    [sym__escape] = ACTIONS(509),
+    [sym_begin_group] = ACTIONS(509),
+    [sym_end_group] = ACTIONS(509),
+    [sym_math_shift] = ACTIONS(509),
+    [sym_alignment_tab] = ACTIONS(509),
+    [sym_parameter_char] = ACTIONS(509),
+    [sym_superscript] = ACTIONS(509),
+    [sym_subscript] = ACTIONS(509),
+    [sym_active_char] = ACTIONS(509),
+    [sym_text] = ACTIONS(509),
+  },
+  [187] = {
+    [sym_text_group] = STATE(265),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [188] = {
+    [ts_builtin_sym_end] = ACTIONS(511),
+    [anon_sym_LBRACK] = ACTIONS(511),
+    [anon_sym_RBRACK] = ACTIONS(511),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(511),
+    [sym_begin_group] = ACTIONS(511),
+    [sym_end_group] = ACTIONS(511),
+    [sym_math_shift] = ACTIONS(511),
+    [sym_alignment_tab] = ACTIONS(511),
+    [sym_parameter_char] = ACTIONS(511),
+    [sym_superscript] = ACTIONS(511),
+    [sym_subscript] = ACTIONS(511),
+    [sym_active_char] = ACTIONS(511),
+    [sym_text] = ACTIONS(511),
+  },
+  [189] = {
+    [anon_sym_EQ] = ACTIONS(131),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [190] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_number] = ACTIONS(513),
+  },
+  [191] = {
+    [sym_text_group] = STATE(267),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [192] = {
+    [ts_builtin_sym_end] = ACTIONS(515),
+    [anon_sym_LBRACK] = ACTIONS(515),
+    [anon_sym_RBRACK] = ACTIONS(515),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(515),
+    [sym_begin_group] = ACTIONS(515),
+    [sym_end_group] = ACTIONS(515),
+    [sym_math_shift] = ACTIONS(515),
+    [sym_alignment_tab] = ACTIONS(515),
+    [sym_parameter_char] = ACTIONS(515),
+    [sym_superscript] = ACTIONS(515),
+    [sym_subscript] = ACTIONS(515),
+    [sym_active_char] = ACTIONS(515),
+    [sym_text] = ACTIONS(515),
+  },
+  [193] = {
+    [ts_builtin_sym_end] = ACTIONS(517),
+    [anon_sym_LBRACK] = ACTIONS(517),
+    [anon_sym_RBRACK] = ACTIONS(517),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(517),
+    [sym_begin_group] = ACTIONS(517),
+    [sym_end_group] = ACTIONS(517),
+    [sym_math_shift] = ACTIONS(517),
+    [sym_alignment_tab] = ACTIONS(517),
+    [sym_parameter_char] = ACTIONS(517),
+    [sym_superscript] = ACTIONS(517),
+    [sym_subscript] = ACTIONS(517),
+    [sym__whitespace] = ACTIONS(519),
+    [sym_active_char] = ACTIONS(517),
     [sym_text] = ACTIONS(521),
   },
-  [206] = {
+  [194] = {
+    [anon_sym_LBRACK] = ACTIONS(523),
+    [anon_sym_RBRACK] = ACTIONS(523),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(524),
+    [sym__escape] = ACTIONS(523),
+    [sym_begin_group] = ACTIONS(523),
+    [sym_end_group] = ACTIONS(523),
+    [sym_math_shift] = ACTIONS(523),
+    [sym_alignment_tab] = ACTIONS(523),
+    [sym_parameter_char] = ACTIONS(523),
+    [sym_superscript] = ACTIONS(523),
+    [sym_subscript] = ACTIONS(523),
+    [sym__whitespace] = ACTIONS(525),
+    [sym_active_char] = ACTIONS(523),
+    [sym_text] = ACTIONS(527),
   },
-  [207] = {
-    [anon_sym_LBRACK] = ACTIONS(526),
-    [anon_sym_RBRACK] = ACTIONS(526),
+  [195] = {
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LPAREN] = ACTIONS(29),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [anon_sym_documentclass] = ACTIONS(35),
+    [anon_sym_usepackage] = ACTIONS(37),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+    [anon_sym_emph] = ACTIONS(47),
+    [anon_sym_footnote] = ACTIONS(49),
+    [anon_sym_textbf] = ACTIONS(51),
+    [anon_sym_textit] = ACTIONS(53),
+    [anon_sym_texttt] = ACTIONS(55),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(526),
-    [sym_begin_group] = ACTIONS(526),
-    [sym_end_group] = ACTIONS(526),
-    [sym_math_shift] = ACTIONS(526),
-    [sym_alignment_tab] = ACTIONS(526),
-    [sym_parameter_char] = ACTIONS(526),
-    [sym_superscript] = ACTIONS(526),
-    [sym_subscript] = ACTIONS(526),
-    [sym_active_char] = ACTIONS(526),
-    [sym_text] = ACTIONS(526),
+    [sym__name_at] = ACTIONS(295),
   },
-  [208] = {
+  [196] = {
+    [anon_sym_LBRACK] = ACTIONS(529),
+    [anon_sym_RBRACK] = ACTIONS(529),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(528),
+    [sym__escape] = ACTIONS(529),
+    [sym_begin_group] = ACTIONS(529),
+    [sym_end_group] = ACTIONS(529),
+    [sym_math_shift] = ACTIONS(529),
+    [sym_alignment_tab] = ACTIONS(529),
+    [sym_parameter_char] = ACTIONS(529),
+    [sym_superscript] = ACTIONS(529),
+    [sym_subscript] = ACTIONS(529),
+    [sym_active_char] = ACTIONS(529),
+    [sym_text] = ACTIONS(529),
   },
-  [209] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(113),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(153),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(153),
-    [sym_text] = ACTIONS(153),
-  },
-  [210] = {
-    [anon_sym_LBRACK] = ACTIONS(530),
-    [anon_sym_RBRACK] = ACTIONS(530),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(530),
-    [sym_begin_group] = ACTIONS(530),
-    [sym_end_group] = ACTIONS(530),
-    [sym_math_shift] = ACTIONS(530),
-    [sym_alignment_tab] = ACTIONS(530),
-    [sym_parameter_char] = ACTIONS(530),
-    [sym_superscript] = ACTIONS(530),
-    [sym_subscript] = ACTIONS(530),
-    [sym_active_char] = ACTIONS(530),
-    [sym_text] = ACTIONS(530),
-  },
-  [211] = {
-    [anon_sym_LBRACK] = ACTIONS(532),
-    [anon_sym_RBRACK] = ACTIONS(532),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(532),
-    [sym_begin_group] = ACTIONS(532),
-    [sym_end_group] = ACTIONS(532),
-    [sym_math_shift] = ACTIONS(532),
-    [sym_alignment_tab] = ACTIONS(532),
-    [sym_parameter_char] = ACTIONS(532),
-    [sym_superscript] = ACTIONS(532),
-    [sym_subscript] = ACTIONS(532),
-    [sym_active_char] = ACTIONS(532),
-    [sym_text] = ACTIONS(532),
-  },
-  [212] = {
-    [sym__common] = STATE(212),
-    [sym__math_mode_common] = STATE(212),
-    [sym__math_mode] = STATE(212),
-    [sym_parameter] = STATE(212),
-    [sym_math_env] = STATE(212),
-    [sym_tag] = STATE(212),
-    [sym_tag_token] = STATE(53),
-    [sym_escaped] = STATE(212),
-    [sym_begin] = STATE(54),
-    [sym_begin_token] = STATE(55),
-    [sym_include] = STATE(212),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(212),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(212),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(212),
-    [sym_opt_math_group] = STATE(212),
-    [sym_token] = STATE(212),
-    [sym_begin_opt] = STATE(56),
-    [aux_sym_math_mode_repeat1] = STATE(212),
-    [anon_sym_LBRACK] = ACTIONS(337),
-    [anon_sym_RBRACK] = ACTIONS(346),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(340),
-    [sym_begin_group] = ACTIONS(343),
-    [sym_alignment_tab] = ACTIONS(534),
-    [sym_parameter_char] = ACTIONS(351),
-    [sym_superscript] = ACTIONS(534),
-    [sym_subscript] = ACTIONS(534),
-    [sym_active_char] = ACTIONS(534),
-    [sym_text] = ACTIONS(534),
-  },
-  [213] = {
-    [ts_builtin_sym_end] = ACTIONS(537),
-    [anon_sym_LBRACK] = ACTIONS(537),
-    [anon_sym_RBRACK] = ACTIONS(537),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(537),
-    [sym_begin_group] = ACTIONS(537),
-    [sym_end_group] = ACTIONS(537),
-    [sym_math_shift] = ACTIONS(537),
-    [sym_alignment_tab] = ACTIONS(537),
-    [sym_parameter_char] = ACTIONS(537),
-    [sym_superscript] = ACTIONS(537),
-    [sym_subscript] = ACTIONS(537),
-    [sym_active_char] = ACTIONS(537),
-    [sym_text] = ACTIONS(537),
-  },
-  [214] = {
-    [ts_builtin_sym_end] = ACTIONS(539),
-    [anon_sym_LBRACK] = ACTIONS(539),
-    [anon_sym_RBRACK] = ACTIONS(539),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(539),
-    [sym_begin_group] = ACTIONS(539),
-    [sym_end_group] = ACTIONS(539),
-    [sym_math_shift] = ACTIONS(539),
-    [sym_alignment_tab] = ACTIONS(539),
-    [sym_parameter_char] = ACTIONS(539),
-    [sym_superscript] = ACTIONS(539),
-    [sym_subscript] = ACTIONS(539),
-    [sym_active_char] = ACTIONS(539),
-    [sym_text] = ACTIONS(539),
-  },
-  [215] = {
-    [sym_display_math_env_name] = ACTIONS(541),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [216] = {
-    [ts_builtin_sym_end] = ACTIONS(543),
-    [anon_sym_LBRACK] = ACTIONS(543),
-    [anon_sym_RBRACK] = ACTIONS(543),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(543),
-    [sym_begin_group] = ACTIONS(543),
-    [sym_end_group] = ACTIONS(543),
-    [sym_math_shift] = ACTIONS(543),
-    [sym_alignment_tab] = ACTIONS(543),
-    [sym_parameter_char] = ACTIONS(543),
-    [sym_superscript] = ACTIONS(543),
-    [sym_subscript] = ACTIONS(543),
-    [sym_active_char] = ACTIONS(543),
-    [sym_text] = ACTIONS(543),
-  },
-  [217] = {
-    [sym_inline_math_env_name] = ACTIONS(545),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [218] = {
-    [ts_builtin_sym_end] = ACTIONS(547),
-    [anon_sym_LBRACK] = ACTIONS(547),
-    [anon_sym_RBRACK] = ACTIONS(547),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(547),
-    [sym_begin_group] = ACTIONS(547),
-    [sym_end_group] = ACTIONS(547),
-    [sym_math_shift] = ACTIONS(547),
-    [sym_alignment_tab] = ACTIONS(547),
-    [sym_parameter_char] = ACTIONS(547),
-    [sym_superscript] = ACTIONS(547),
-    [sym_subscript] = ACTIONS(547),
-    [sym_active_char] = ACTIONS(547),
-    [sym_text] = ACTIONS(547),
-  },
-  [219] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(549),
-  },
-  [220] = {
-    [anon_sym_LBRACK] = ACTIONS(551),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(551),
-    [sym__end_of_line] = ACTIONS(551),
-  },
-  [221] = {
-    [ts_builtin_sym_end] = ACTIONS(553),
-    [anon_sym_LBRACK] = ACTIONS(553),
-    [anon_sym_RBRACK] = ACTIONS(553),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(553),
-    [sym_begin_group] = ACTIONS(553),
-    [sym_end_group] = ACTIONS(553),
-    [sym_math_shift] = ACTIONS(553),
-    [sym_alignment_tab] = ACTIONS(553),
-    [sym_parameter_char] = ACTIONS(553),
-    [sym_superscript] = ACTIONS(553),
-    [sym_subscript] = ACTIONS(553),
-    [sym_active_char] = ACTIONS(553),
-    [sym_text] = ACTIONS(553),
-  },
-  [222] = {
-    [anon_sym_LBRACK] = ACTIONS(555),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(555),
-    [sym__end_of_line] = ACTIONS(555),
-  },
-  [223] = {
-    [ts_builtin_sym_end] = ACTIONS(557),
-    [anon_sym_LBRACK] = ACTIONS(557),
-    [anon_sym_RBRACK] = ACTIONS(557),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(557),
-    [sym_begin_group] = ACTIONS(557),
-    [sym_end_group] = ACTIONS(557),
-    [sym_math_shift] = ACTIONS(557),
-    [sym_alignment_tab] = ACTIONS(557),
-    [sym_parameter_char] = ACTIONS(557),
-    [sym_superscript] = ACTIONS(557),
-    [sym_subscript] = ACTIONS(557),
-    [sym_active_char] = ACTIONS(557),
-    [sym_text] = ACTIONS(557),
-  },
-  [224] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(149),
-  },
-  [225] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(559),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(153),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(153),
-    [sym_text] = ACTIONS(153),
-  },
-  [226] = {
-    [anon_sym_LBRACK] = ACTIONS(561),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(561),
-    [sym_begin_group] = ACTIONS(561),
-    [sym_alignment_tab] = ACTIONS(561),
-    [sym_parameter_char] = ACTIONS(561),
-    [sym_superscript] = ACTIONS(561),
-    [sym_subscript] = ACTIONS(561),
-    [sym_active_char] = ACTIONS(561),
-    [sym_text] = ACTIONS(561),
-  },
-  [227] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(563),
-  },
-  [228] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(279),
-    [sym__end_of_line] = ACTIONS(279),
-  },
-  [229] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(281),
-    [sym__end_of_line] = ACTIONS(281),
-  },
-  [230] = {
-    [sym__common] = STATE(203),
-    [sym__text_mode_common] = STATE(203),
-    [sym__text_mode] = STATE(203),
-    [sym_text_mode_at_region] = STATE(203),
-    [sym_parameter] = STATE(203),
-    [sym_text_env] = STATE(203),
-    [sym__display_math] = STATE(203),
-    [sym_tex_display_math] = STATE(203),
-    [sym_latex_display_math] = STATE(203),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(203),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(203),
-    [sym_tex_inline_math] = STATE(203),
-    [sym_latex_inline_math] = STATE(203),
-    [sym_inline_math_env] = STATE(203),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(203),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(203),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(203),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(203),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(203),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(203),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(203),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(203),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(203),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(203),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(203),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(203),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(203),
-    [sym_opt_text_group] = STATE(203),
-    [sym_token] = STATE(203),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(268),
-    [aux_sym_text_mode_repeat1] = STATE(203),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(419),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(283),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(283),
-    [sym_text] = ACTIONS(283),
-  },
-  [231] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(565),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(567),
-    [sym__end_of_line] = ACTIONS(567),
-  },
-  [232] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(569),
-  },
-  [233] = {
-    [ts_builtin_sym_end] = ACTIONS(571),
-    [anon_sym_LBRACK] = ACTIONS(571),
-    [anon_sym_RBRACK] = ACTIONS(571),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(571),
-    [sym_begin_group] = ACTIONS(571),
-    [sym_end_group] = ACTIONS(571),
-    [sym_math_shift] = ACTIONS(571),
-    [sym_alignment_tab] = ACTIONS(571),
-    [sym_parameter_char] = ACTIONS(571),
-    [sym_superscript] = ACTIONS(571),
-    [sym_subscript] = ACTIONS(571),
-    [sym_active_char] = ACTIONS(571),
-    [sym_text] = ACTIONS(571),
-  },
-  [234] = {
-    [anon_sym_LBRACK] = ACTIONS(573),
-    [anon_sym_RBRACK] = ACTIONS(573),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(573),
-    [sym_begin_group] = ACTIONS(573),
-    [sym_end_group] = ACTIONS(573),
-    [sym_math_shift] = ACTIONS(573),
-    [sym_alignment_tab] = ACTIONS(573),
-    [sym_parameter_char] = ACTIONS(573),
-    [sym_superscript] = ACTIONS(573),
-    [sym_subscript] = ACTIONS(573),
-    [sym_active_char] = ACTIONS(573),
-    [sym_text] = ACTIONS(573),
-  },
-  [235] = {
-    [sym__common] = STATE(235),
-    [sym__text_mode_common] = STATE(235),
-    [sym__text_mode_at] = STATE(235),
-    [sym_parameter] = STATE(235),
-    [sym_text_env_at] = STATE(235),
-    [sym__display_math_at] = STATE(235),
-    [sym_tex_display_math_at] = STATE(235),
-    [sym_latex_display_math_at] = STATE(235),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(235),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(235),
-    [sym_tex_inline_math_at] = STATE(235),
-    [sym_latex_inline_math_at] = STATE(235),
-    [sym_inline_math_env_at] = STATE(235),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(235),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(235),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(235),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(235),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(235),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(235),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(235),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(235),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(235),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(235),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(235),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(235),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(235),
-    [sym_opt_text_group_at] = STATE(235),
-    [sym_token_at] = STATE(235),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(235),
-    [anon_sym_LBRACK] = ACTIONS(493),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(496),
-    [sym_begin_group] = ACTIONS(499),
-    [sym_end_group] = ACTIONS(575),
-    [sym_math_shift] = ACTIONS(502),
-    [sym_alignment_tab] = ACTIONS(577),
-    [sym_parameter_char] = ACTIONS(508),
-    [sym_superscript] = ACTIONS(511),
-    [sym_subscript] = ACTIONS(511),
-    [sym_active_char] = ACTIONS(577),
-    [sym_text] = ACTIONS(577),
-  },
-  [236] = {
-    [anon_sym_LBRACK] = ACTIONS(580),
-    [anon_sym_RBRACK] = ACTIONS(580),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(580),
-    [sym_begin_group] = ACTIONS(580),
-    [sym_end_group] = ACTIONS(580),
-    [sym_math_shift] = ACTIONS(580),
-    [sym_alignment_tab] = ACTIONS(580),
-    [sym_parameter_char] = ACTIONS(580),
-    [sym_superscript] = ACTIONS(580),
-    [sym_subscript] = ACTIONS(580),
-    [sym_active_char] = ACTIONS(580),
-    [sym_text] = ACTIONS(580),
-  },
-  [237] = {
+  [197] = {
     [sym__common] = STATE(271),
-    [sym__math_mode_common] = STATE(271),
-    [sym__math_mode_at] = STATE(271),
+    [sym__text_mode_common] = STATE(271),
+    [sym__text_mode_at] = STATE(271),
     [sym_parameter] = STATE(271),
-    [sym_math_env_at] = STATE(271),
-    [sym_tag_at] = STATE(271),
-    [sym_tag_token] = STATE(177),
+    [sym_text_env_at] = STATE(271),
+    [sym__display_math_at] = STATE(271),
+    [sym_tex_display_math_at] = STATE(271),
+    [sym_latex_display_math_at] = STATE(271),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(271),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(271),
+    [sym_tex_inline_math_at] = STATE(271),
+    [sym_latex_inline_math_at] = STATE(271),
+    [sym_inline_math_env_at] = STATE(271),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(271),
+    [sym_verbatim_begin] = STATE(14),
     [sym_escaped] = STATE(271),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(271),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(271),
+    [sym_usepackage_token] = STATE(18),
     [sym_include_at] = STATE(271),
-    [sym_include_token] = STATE(103),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(271),
+    [sym_section_token] = STATE(109),
     [sym_storage] = STATE(271),
     [sym_storage_token] = STATE(21),
     [sym_catcode] = STATE(271),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(271),
-    [sym_opt_math_group_at] = STATE(271),
+    [sym_emph_at] = STATE(271),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(271),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(271),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(271),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(271),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(271),
+    [sym_opt_text_group_at] = STATE(271),
     [sym_token_at] = STATE(271),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(271),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(271),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_end_group] = ACTIONS(582),
-    [sym_alignment_tab] = ACTIONS(584),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(584),
-    [sym_subscript] = ACTIONS(584),
-    [sym_active_char] = ACTIONS(584),
-    [sym_text] = ACTIONS(584),
-  },
-  [238] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(586),
-  },
-  [239] = {
-    [anon_sym_LBRACK] = ACTIONS(588),
-    [anon_sym_RBRACK] = ACTIONS(588),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(588),
-    [sym_begin_group] = ACTIONS(588),
-    [sym_end_group] = ACTIONS(588),
-    [sym_math_shift] = ACTIONS(588),
-    [sym_alignment_tab] = ACTIONS(588),
-    [sym_parameter_char] = ACTIONS(588),
-    [sym_superscript] = ACTIONS(588),
-    [sym_subscript] = ACTIONS(588),
-    [sym_active_char] = ACTIONS(588),
-    [sym_text] = ACTIONS(588),
-  },
-  [240] = {
-    [sym__common] = STATE(275),
-    [sym__text_mode_common] = STATE(275),
-    [sym__text_mode_at] = STATE(275),
-    [sym_text_mode_at] = STATE(274),
-    [sym_parameter] = STATE(275),
-    [sym_text_env_at] = STATE(275),
-    [sym__display_math_at] = STATE(275),
-    [sym_tex_display_math_at] = STATE(275),
-    [sym_latex_display_math_at] = STATE(275),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(275),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(275),
-    [sym_tex_inline_math_at] = STATE(275),
-    [sym_latex_inline_math_at] = STATE(275),
-    [sym_inline_math_env_at] = STATE(275),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(275),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(275),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(275),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(275),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(275),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(275),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(275),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(275),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(275),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(275),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(275),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(275),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(275),
-    [sym_opt_text_group_at] = STATE(275),
-    [sym_token_at] = STATE(275),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(275),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_end_group] = ACTIONS(590),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(592),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(531),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(533),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(592),
-    [sym_text] = ACTIONS(592),
+    [sym_active_char] = ACTIONS(533),
+    [sym_text] = ACTIONS(533),
   },
-  [241] = {
-    [anon_sym_LBRACK] = ACTIONS(594),
-    [anon_sym_RBRACK] = ACTIONS(594),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(594),
-    [sym_begin_group] = ACTIONS(594),
-    [sym_end_group] = ACTIONS(594),
-    [sym_math_shift] = ACTIONS(594),
-    [sym_alignment_tab] = ACTIONS(594),
-    [sym_parameter_char] = ACTIONS(594),
-    [sym_superscript] = ACTIONS(594),
-    [sym_subscript] = ACTIONS(594),
-    [sym_active_char] = ACTIONS(594),
-    [sym_text] = ACTIONS(594),
-  },
-  [242] = {
-    [anon_sym_tag] = ACTIONS(155),
+  [198] = {
+    [anon_sym_tag] = ACTIONS(191),
     [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
     [anon_sym_begin] = ACTIONS(33),
-    [anon_sym_end] = ACTIONS(197),
     [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(245),
+    [sym__name_at] = ACTIONS(295),
   },
-  [243] = {
-    [anon_sym_LBRACK] = ACTIONS(596),
-    [anon_sym_RBRACK] = ACTIONS(596),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(596),
-    [sym_begin_group] = ACTIONS(596),
-    [sym_end_group] = ACTIONS(596),
-    [sym_math_shift] = ACTIONS(596),
-    [sym_alignment_tab] = ACTIONS(596),
-    [sym_parameter_char] = ACTIONS(596),
-    [sym_superscript] = ACTIONS(596),
-    [sym_subscript] = ACTIONS(596),
-    [sym_active_char] = ACTIONS(596),
-    [sym_text] = ACTIONS(596),
-  },
-  [244] = {
-    [sym__common] = STATE(249),
-    [sym__math_mode_common] = STATE(249),
-    [sym__math_mode_at] = STATE(249),
-    [sym_parameter] = STATE(249),
-    [sym_math_env_at] = STATE(249),
-    [sym_tag_at] = STATE(249),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(249),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_end] = STATE(276),
-    [sym_end_token] = STATE(72),
-    [sym_include_at] = STATE(249),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(249),
+  [199] = {
+    [sym__common] = STATE(273),
+    [sym__math_mode_common] = STATE(273),
+    [sym__math_mode_at] = STATE(273),
+    [sym_parameter] = STATE(273),
+    [sym_math_env_at] = STATE(273),
+    [sym_tag_at] = STATE(273),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(273),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(273),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(273),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(249),
+    [sym_catcode] = STATE(273),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(249),
-    [sym_opt_math_group_at] = STATE(249),
-    [sym_token_at] = STATE(249),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(249),
+    [sym_math_group_at] = STATE(273),
+    [sym_opt_math_group_at] = STATE(273),
+    [sym_token_at] = STATE(273),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(273),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(455),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(469),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_end_group] = ACTIONS(535),
+    [sym_alignment_tab] = ACTIONS(537),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(469),
-    [sym_subscript] = ACTIONS(469),
-    [sym_active_char] = ACTIONS(469),
-    [sym_text] = ACTIONS(469),
+    [sym_superscript] = ACTIONS(537),
+    [sym_subscript] = ACTIONS(537),
+    [sym_active_char] = ACTIONS(537),
+    [sym_text] = ACTIONS(537),
   },
-  [245] = {
-    [anon_sym_LBRACK] = ACTIONS(598),
-    [anon_sym_RBRACK] = ACTIONS(598),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(598),
-    [sym_begin_group] = ACTIONS(598),
-    [sym_end_group] = ACTIONS(598),
-    [sym_math_shift] = ACTIONS(598),
-    [sym_alignment_tab] = ACTIONS(598),
-    [sym_parameter_char] = ACTIONS(598),
-    [sym_superscript] = ACTIONS(598),
-    [sym_subscript] = ACTIONS(598),
-    [sym_active_char] = ACTIONS(598),
-    [sym_text] = ACTIONS(598),
-  },
-  [246] = {
-    [sym__common] = STATE(278),
-    [sym__math_mode_common] = STATE(278),
-    [sym__math_mode_at] = STATE(278),
-    [sym_parameter] = STATE(278),
-    [sym_math_env_at] = STATE(278),
-    [sym_tag_at] = STATE(278),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(278),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(278),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(278),
+  [200] = {
+    [sym__common] = STATE(205),
+    [sym__math_mode_common] = STATE(205),
+    [sym__math_mode_at] = STATE(205),
+    [sym_math_mode_at] = STATE(274),
+    [sym_parameter] = STATE(205),
+    [sym_math_env_at] = STATE(205),
+    [sym_tag_at] = STATE(205),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(205),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(205),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(205),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(278),
+    [sym_catcode] = STATE(205),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(278),
-    [sym_opt_math_group_at] = STATE(278),
-    [sym_token_at] = STATE(278),
-    [sym_begin_opt] = STATE(179),
-    [sym_end_opt] = STATE(277),
-    [aux_sym_math_mode_at_repeat1] = STATE(278),
+    [sym_math_group_at] = STATE(205),
+    [sym_opt_math_group_at] = STATE(205),
+    [sym_token_at] = STATE(205),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(205),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(109),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(253),
-    [sym_begin_group] = ACTIONS(255),
-    [sym_alignment_tab] = ACTIONS(600),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(309),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(600),
-    [sym_subscript] = ACTIONS(600),
-    [sym_active_char] = ACTIONS(600),
-    [sym_text] = ACTIONS(600),
+    [sym_superscript] = ACTIONS(309),
+    [sym_subscript] = ACTIONS(309),
+    [sym_active_char] = ACTIONS(309),
+    [sym_text] = ACTIONS(309),
   },
-  [247] = {
-    [sym__common] = STATE(247),
-    [sym__math_mode_common] = STATE(247),
-    [sym__math_mode_at] = STATE(247),
-    [sym_parameter] = STATE(247),
-    [sym_math_env_at] = STATE(247),
-    [sym_tag_at] = STATE(247),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(247),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(247),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(247),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(247),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(247),
-    [sym_opt_math_group_at] = STATE(247),
-    [sym_token_at] = STATE(247),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(247),
-    [anon_sym_LBRACK] = ACTIONS(602),
+  [201] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(605),
-    [sym_begin_group] = ACTIONS(608),
-    [sym_math_shift] = ACTIONS(611),
-    [sym_alignment_tab] = ACTIONS(613),
-    [sym_parameter_char] = ACTIONS(616),
-    [sym_superscript] = ACTIONS(613),
-    [sym_subscript] = ACTIONS(613),
-    [sym_active_char] = ACTIONS(613),
-    [sym_text] = ACTIONS(613),
+    [sym_math_shift] = ACTIONS(539),
   },
-  [248] = {
-    [anon_sym_LBRACK] = ACTIONS(619),
-    [anon_sym_RBRACK] = ACTIONS(619),
+  [202] = {
+    [sym_math_text_group_at] = STATE(277),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(619),
-    [sym_begin_group] = ACTIONS(619),
-    [sym_end_group] = ACTIONS(619),
-    [sym_math_shift] = ACTIONS(619),
-    [sym_alignment_tab] = ACTIONS(619),
-    [sym_parameter_char] = ACTIONS(619),
-    [sym_superscript] = ACTIONS(619),
-    [sym_subscript] = ACTIONS(619),
-    [sym_active_char] = ACTIONS(619),
-    [sym_text] = ACTIONS(619),
+    [sym_begin_group] = ACTIONS(541),
   },
-  [249] = {
-    [sym__common] = STATE(249),
-    [sym__math_mode_common] = STATE(249),
-    [sym__math_mode_at] = STATE(249),
-    [sym_parameter] = STATE(249),
-    [sym_math_env_at] = STATE(249),
-    [sym_tag_at] = STATE(249),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(249),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(249),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(249),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(249),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(249),
-    [sym_opt_math_group_at] = STATE(249),
-    [sym_token_at] = STATE(249),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(249),
-    [anon_sym_LBRACK] = ACTIONS(602),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(605),
-    [sym_begin_group] = ACTIONS(608),
-    [sym_alignment_tab] = ACTIONS(621),
-    [sym_parameter_char] = ACTIONS(616),
-    [sym_superscript] = ACTIONS(621),
-    [sym_subscript] = ACTIONS(621),
-    [sym_active_char] = ACTIONS(621),
-    [sym_text] = ACTIONS(621),
-  },
-  [250] = {
-    [anon_sym_LBRACK] = ACTIONS(624),
-    [anon_sym_RBRACK] = ACTIONS(624),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(624),
-    [sym_begin_group] = ACTIONS(624),
-    [sym_end_group] = ACTIONS(624),
-    [sym_math_shift] = ACTIONS(624),
-    [sym_alignment_tab] = ACTIONS(624),
-    [sym_parameter_char] = ACTIONS(624),
-    [sym_superscript] = ACTIONS(624),
-    [sym_subscript] = ACTIONS(624),
-    [sym_active_char] = ACTIONS(624),
-    [sym_text] = ACTIONS(624),
-  },
-  [251] = {
-    [anon_sym_LBRACK] = ACTIONS(626),
-    [anon_sym_RBRACK] = ACTIONS(626),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(626),
-    [sym_begin_group] = ACTIONS(626),
-    [sym_end_group] = ACTIONS(626),
-    [sym_math_shift] = ACTIONS(626),
-    [sym_alignment_tab] = ACTIONS(626),
-    [sym_parameter_char] = ACTIONS(626),
-    [sym_superscript] = ACTIONS(626),
-    [sym_subscript] = ACTIONS(626),
-    [sym_active_char] = ACTIONS(626),
-    [sym_text] = ACTIONS(626),
-  },
-  [252] = {
-    [anon_sym_LBRACK] = ACTIONS(628),
-    [anon_sym_RBRACK] = ACTIONS(628),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(628),
-    [sym_begin_group] = ACTIONS(628),
-    [sym_end_group] = ACTIONS(628),
-    [sym_math_shift] = ACTIONS(628),
-    [sym_alignment_tab] = ACTIONS(628),
-    [sym_parameter_char] = ACTIONS(628),
-    [sym_superscript] = ACTIONS(628),
-    [sym_subscript] = ACTIONS(628),
-    [sym_active_char] = ACTIONS(628),
-    [sym_text] = ACTIONS(628),
-  },
-  [253] = {
-    [anon_sym_LBRACK] = ACTIONS(630),
-    [anon_sym_RBRACK] = ACTIONS(630),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(630),
-    [sym_begin_group] = ACTIONS(630),
-    [sym_end_group] = ACTIONS(630),
-    [sym_math_shift] = ACTIONS(630),
-    [sym_alignment_tab] = ACTIONS(630),
-    [sym_parameter_char] = ACTIONS(630),
-    [sym_superscript] = ACTIONS(630),
-    [sym_subscript] = ACTIONS(630),
-    [sym_active_char] = ACTIONS(630),
-    [sym_text] = ACTIONS(630),
-  },
-  [254] = {
+  [203] = {
     [sym__common] = STATE(280),
-    [sym__text_mode_common] = STATE(280),
-    [sym__text_mode_at] = STATE(280),
+    [sym__math_mode_common] = STATE(280),
+    [sym__math_mode_at] = STATE(280),
     [sym_parameter] = STATE(280),
-    [sym_text_env_at] = STATE(280),
-    [sym__display_math_at] = STATE(280),
-    [sym_tex_display_math_at] = STATE(280),
-    [sym_latex_display_math_at] = STATE(280),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(280),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(280),
-    [sym_tex_inline_math_at] = STATE(280),
-    [sym_latex_inline_math_at] = STATE(280),
-    [sym_inline_math_env_at] = STATE(280),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(280),
-    [sym_verbatim_begin] = STATE(14),
+    [sym_math_env_at] = STATE(280),
+    [sym_tag_at] = STATE(280),
+    [sym_tag_token] = STATE(202),
     [sym_escaped] = STATE(280),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(280),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(280),
-    [sym_usepackage_token] = STATE(18),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_end] = STATE(279),
+    [sym_end_token] = STATE(74),
     [sym_include_at] = STATE(280),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(280),
-    [sym_section_token] = STATE(104),
+    [sym_include_token] = STATE(108),
     [sym_storage] = STATE(280),
     [sym_storage_token] = STATE(21),
     [sym_catcode] = STATE(280),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(280),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(280),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(280),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(280),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(280),
-    [sym_opt_text_group_at] = STATE(280),
+    [sym_math_group_at] = STATE(280),
+    [sym_opt_math_group_at] = STATE(280),
     [sym_token_at] = STATE(280),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(280),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(280),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_end_group] = ACTIONS(632),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(634),
+    [sym__escape] = ACTIONS(543),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(545),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(634),
-    [sym_text] = ACTIONS(634),
+    [sym_superscript] = ACTIONS(545),
+    [sym_subscript] = ACTIONS(545),
+    [sym_active_char] = ACTIONS(545),
+    [sym_text] = ACTIONS(545),
   },
-  [255] = {
-    [anon_sym_LBRACK] = ACTIONS(636),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(636),
-    [sym_begin_group] = ACTIONS(636),
-    [sym_alignment_tab] = ACTIONS(636),
-    [sym_parameter_char] = ACTIONS(636),
-    [sym_superscript] = ACTIONS(636),
-    [sym_subscript] = ACTIONS(636),
-    [sym_active_char] = ACTIONS(636),
-    [sym_text] = ACTIONS(636),
-  },
-  [256] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(638),
-  },
-  [257] = {
-    [sym_text_group_at] = STATE(282),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(473),
-    [sym__end_of_line] = ACTIONS(638),
-  },
-  [258] = {
-    [sym__common] = STATE(284),
-    [sym__text_mode_common] = STATE(284),
-    [sym__text_mode_at] = STATE(284),
-    [sym_parameter] = STATE(284),
-    [sym_text_env_at] = STATE(284),
-    [sym__display_math_at] = STATE(284),
-    [sym_tex_display_math_at] = STATE(284),
-    [sym_latex_display_math_at] = STATE(284),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(284),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(284),
-    [sym_tex_inline_math_at] = STATE(284),
-    [sym_latex_inline_math_at] = STATE(284),
-    [sym_inline_math_env_at] = STATE(284),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(284),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(284),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(284),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(284),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(284),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(284),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(284),
+  [204] = {
+    [sym__common] = STATE(282),
+    [sym__math_mode_common] = STATE(282),
+    [sym__math_mode_at] = STATE(282),
+    [sym_parameter] = STATE(282),
+    [sym_math_env_at] = STATE(282),
+    [sym_tag_at] = STATE(282),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(282),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(282),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(282),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(284),
+    [sym_catcode] = STATE(282),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(284),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(284),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(284),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(284),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(284),
-    [sym_opt_text_group_at] = STATE(284),
-    [sym_token_at] = STATE(284),
-    [sym_begin_opt] = STATE(111),
-    [sym_end_opt] = STATE(283),
-    [aux_sym_text_mode_at_repeat1] = STATE(284),
+    [sym_math_group_at] = STATE(282),
+    [sym_opt_math_group_at] = STATE(282),
+    [sym_token_at] = STATE(282),
+    [sym_begin_opt] = STATE(204),
+    [sym_end_opt] = STATE(281),
+    [aux_sym_math_mode_at_repeat1] = STATE(282),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(419),
+    [anon_sym_RBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(640),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(547),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(640),
-    [sym_text] = ACTIONS(640),
+    [sym_superscript] = ACTIONS(547),
+    [sym_subscript] = ACTIONS(547),
+    [sym_active_char] = ACTIONS(547),
+    [sym_text] = ACTIONS(547),
   },
-  [259] = {
-    [anon_sym_LBRACK] = ACTIONS(642),
-    [anon_sym_RBRACK] = ACTIONS(642),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(642),
-    [sym_begin_group] = ACTIONS(642),
-    [sym_end_group] = ACTIONS(642),
-    [sym_math_shift] = ACTIONS(642),
-    [sym_alignment_tab] = ACTIONS(642),
-    [sym_parameter_char] = ACTIONS(642),
-    [sym_superscript] = ACTIONS(642),
-    [sym_subscript] = ACTIONS(642),
-    [sym_active_char] = ACTIONS(642),
-    [sym_text] = ACTIONS(642),
-  },
-  [260] = {
-    [anon_sym_LBRACK] = ACTIONS(644),
-    [anon_sym_RBRACK] = ACTIONS(644),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(644),
-    [sym_begin_group] = ACTIONS(644),
-    [sym_end_group] = ACTIONS(644),
-    [sym_math_shift] = ACTIONS(644),
-    [sym_alignment_tab] = ACTIONS(644),
-    [sym_parameter_char] = ACTIONS(644),
-    [sym_superscript] = ACTIONS(644),
-    [sym_subscript] = ACTIONS(644),
-    [sym_active_char] = ACTIONS(644),
-    [sym_text] = ACTIONS(644),
-  },
-  [261] = {
-    [sym__common] = STATE(261),
-    [sym__text_mode_common] = STATE(261),
-    [sym__text_mode_at] = STATE(261),
-    [sym_parameter] = STATE(261),
-    [sym_text_env_at] = STATE(261),
-    [sym__display_math_at] = STATE(261),
-    [sym_tex_display_math_at] = STATE(261),
-    [sym_latex_display_math_at] = STATE(261),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(261),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(261),
-    [sym_tex_inline_math_at] = STATE(261),
-    [sym_latex_inline_math_at] = STATE(261),
-    [sym_inline_math_env_at] = STATE(261),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(261),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(261),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(261),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(261),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(261),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(261),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(261),
+  [205] = {
+    [sym__common] = STATE(283),
+    [sym__math_mode_common] = STATE(283),
+    [sym__math_mode_at] = STATE(283),
+    [sym_parameter] = STATE(283),
+    [sym_math_env_at] = STATE(283),
+    [sym_tag_at] = STATE(283),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(283),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(283),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(283),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(261),
+    [sym_catcode] = STATE(283),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(261),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(261),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(261),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(261),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(261),
-    [sym_opt_text_group_at] = STATE(261),
-    [sym_token_at] = STATE(261),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(261),
-    [anon_sym_LBRACK] = ACTIONS(493),
-    [anon_sym_RBRACK] = ACTIONS(575),
+    [sym_math_group_at] = STATE(283),
+    [sym_opt_math_group_at] = STATE(283),
+    [sym_token_at] = STATE(283),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(283),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(496),
-    [sym_begin_group] = ACTIONS(499),
-    [sym_math_shift] = ACTIONS(502),
-    [sym_alignment_tab] = ACTIONS(646),
-    [sym_parameter_char] = ACTIONS(508),
-    [sym_superscript] = ACTIONS(511),
-    [sym_subscript] = ACTIONS(511),
-    [sym_active_char] = ACTIONS(646),
-    [sym_text] = ACTIONS(646),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_math_shift] = ACTIONS(549),
+    [sym_alignment_tab] = ACTIONS(551),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(551),
+    [sym_subscript] = ACTIONS(551),
+    [sym_active_char] = ACTIONS(551),
+    [sym_text] = ACTIONS(551),
   },
-  [262] = {
-    [ts_builtin_sym_end] = ACTIONS(649),
-    [anon_sym_LBRACK] = ACTIONS(649),
-    [anon_sym_RBRACK] = ACTIONS(649),
+  [206] = {
+    [anon_sym_makeatother] = ACTIONS(553),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(649),
-    [sym_begin_group] = ACTIONS(649),
-    [sym_end_group] = ACTIONS(649),
-    [sym_math_shift] = ACTIONS(649),
-    [sym_alignment_tab] = ACTIONS(649),
-    [sym_parameter_char] = ACTIONS(649),
-    [sym_superscript] = ACTIONS(649),
-    [sym_subscript] = ACTIONS(649),
-    [sym_active_char] = ACTIONS(649),
-    [sym_text] = ACTIONS(649),
   },
-  [263] = {
-    [anon_sym_LBRACK] = ACTIONS(651),
-    [anon_sym_RBRACK] = ACTIONS(651),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(651),
-    [sym_begin_group] = ACTIONS(651),
-    [sym_end_group] = ACTIONS(651),
-    [sym_math_shift] = ACTIONS(651),
-    [sym_alignment_tab] = ACTIONS(651),
-    [sym_parameter_char] = ACTIONS(651),
-    [sym_superscript] = ACTIONS(651),
-    [sym_subscript] = ACTIONS(651),
-    [sym_active_char] = ACTIONS(651),
-    [sym_text] = ACTIONS(651),
-  },
-  [264] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(653),
-  },
-  [265] = {
+  [207] = {
     [ts_builtin_sym_end] = ACTIONS(555),
     [anon_sym_LBRACK] = ACTIONS(555),
     [anon_sym_RBRACK] = ACTIONS(555),
@@ -10856,38 +9643,912 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(555),
     [sym_text] = ACTIONS(555),
   },
-  [266] = {
+  [208] = {
+    [sym_end_display_math] = STATE(284),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(308),
+    [sym__escape] = ACTIONS(213),
   },
-  [267] = {
-    [anon_sym_LBRACK] = ACTIONS(655),
+  [209] = {
+    [sym__common] = STATE(285),
+    [sym__math_mode_common] = STATE(285),
+    [sym__math_mode_at] = STATE(285),
+    [sym_parameter] = STATE(285),
+    [sym_math_env_at] = STATE(285),
+    [sym_tag_at] = STATE(285),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(285),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(285),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(285),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(285),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(285),
+    [sym_opt_math_group_at] = STATE(285),
+    [sym_token_at] = STATE(285),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(285),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(655),
+    [sym__escape] = ACTIONS(549),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(557),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(557),
+    [sym_subscript] = ACTIONS(557),
+    [sym_active_char] = ACTIONS(557),
+    [sym_text] = ACTIONS(557),
+  },
+  [210] = {
+    [sym_end_inline_math] = STATE(286),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(217),
+  },
+  [211] = {
+    [sym_display_math_end] = STATE(287),
+    [sym_end_token] = STATE(156),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(85),
+  },
+  [212] = {
+    [sym_inline_math_end] = STATE(288),
+    [sym_end_token] = STATE(158),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(85),
+  },
+  [213] = {
+    [anon_sym_LBRACK] = ACTIONS(27),
+    [anon_sym_LPAREN] = ACTIONS(29),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [anon_sym_end] = ACTIONS(233),
+    [anon_sym_documentclass] = ACTIONS(35),
+    [anon_sym_usepackage] = ACTIONS(37),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+    [anon_sym_emph] = ACTIONS(47),
+    [anon_sym_footnote] = ACTIONS(49),
+    [anon_sym_textbf] = ACTIONS(51),
+    [anon_sym_textit] = ACTIONS(53),
+    [anon_sym_texttt] = ACTIONS(55),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(295),
+  },
+  [214] = {
+    [anon_sym_LBRACK] = ACTIONS(559),
+    [anon_sym_RBRACK] = ACTIONS(559),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(559),
+    [sym_begin_group] = ACTIONS(559),
+    [sym_end_group] = ACTIONS(559),
+    [sym_math_shift] = ACTIONS(559),
+    [sym_alignment_tab] = ACTIONS(559),
+    [sym_parameter_char] = ACTIONS(559),
+    [sym_superscript] = ACTIONS(559),
+    [sym_subscript] = ACTIONS(559),
+    [sym_active_char] = ACTIONS(559),
+    [sym_text] = ACTIONS(559),
+  },
+  [215] = {
+    [sym__common] = STATE(229),
+    [sym__text_mode_common] = STATE(229),
+    [sym__text_mode_at] = STATE(229),
+    [sym_parameter] = STATE(229),
+    [sym_text_env_at] = STATE(229),
+    [sym__display_math_at] = STATE(229),
+    [sym_tex_display_math_at] = STATE(229),
+    [sym_latex_display_math_at] = STATE(229),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(229),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(229),
+    [sym_tex_inline_math_at] = STATE(229),
+    [sym_latex_inline_math_at] = STATE(229),
+    [sym_inline_math_env_at] = STATE(229),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(229),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(229),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_end] = STATE(289),
+    [sym_end_token] = STATE(74),
+    [sym_documentclass] = STATE(229),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(229),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(229),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(229),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(229),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(229),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(229),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(229),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(229),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(229),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(229),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(229),
+    [sym_opt_text_group_at] = STATE(229),
+    [sym_token_at] = STATE(229),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(229),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(315),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(327),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(327),
+    [sym_text] = ACTIONS(327),
+  },
+  [216] = {
+    [sym_text_group_at] = STATE(292),
+    [sym_opt_text_group_at] = STATE(293),
+    [sym_begin_opt] = STATE(220),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(561),
+    [sym__end_of_line] = ACTIONS(563),
+  },
+  [217] = {
+    [anon_sym_LBRACK] = ACTIONS(565),
+    [anon_sym_RBRACK] = ACTIONS(565),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(565),
+    [sym_begin_group] = ACTIONS(565),
+    [sym_end_group] = ACTIONS(565),
+    [sym_math_shift] = ACTIONS(565),
+    [sym_alignment_tab] = ACTIONS(565),
+    [sym_parameter_char] = ACTIONS(565),
+    [sym_superscript] = ACTIONS(565),
+    [sym_subscript] = ACTIONS(565),
+    [sym_active_char] = ACTIONS(565),
+    [sym_text] = ACTIONS(565),
+  },
+  [218] = {
+    [anon_sym_LBRACK] = ACTIONS(567),
+    [anon_sym_RBRACK] = ACTIONS(567),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(567),
+    [sym_begin_group] = ACTIONS(567),
+    [sym_end_group] = ACTIONS(567),
+    [sym_math_shift] = ACTIONS(567),
+    [sym_alignment_tab] = ACTIONS(567),
+    [sym_parameter_char] = ACTIONS(567),
+    [sym_superscript] = ACTIONS(567),
+    [sym_subscript] = ACTIONS(567),
+    [sym_active_char] = ACTIONS(567),
+    [sym_text] = ACTIONS(567),
+  },
+  [219] = {
+    [sym_text_group_at] = STATE(295),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+    [sym__whitespace] = ACTIONS(569),
+  },
+  [220] = {
+    [sym__common] = STATE(297),
+    [sym__text_mode_common] = STATE(297),
+    [sym__text_mode_at] = STATE(297),
+    [sym_parameter] = STATE(297),
+    [sym_text_env_at] = STATE(297),
+    [sym__display_math_at] = STATE(297),
+    [sym_tex_display_math_at] = STATE(297),
+    [sym_latex_display_math_at] = STATE(297),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(297),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(297),
+    [sym_tex_inline_math_at] = STATE(297),
+    [sym_latex_inline_math_at] = STATE(297),
+    [sym_inline_math_env_at] = STATE(297),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(297),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(297),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(297),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(297),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(297),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(297),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(297),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(297),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(297),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(297),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(297),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(297),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(297),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(297),
+    [sym_opt_text_group_at] = STATE(297),
+    [sym_token_at] = STATE(297),
+    [sym_begin_opt] = STATE(117),
+    [sym_end_opt] = STATE(296),
+    [aux_sym_text_mode_at_repeat1] = STATE(297),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(263),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(571),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(571),
+    [sym_text] = ACTIONS(571),
+  },
+  [221] = {
+    [anon_sym_LBRACK] = ACTIONS(573),
+    [anon_sym_RBRACK] = ACTIONS(573),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(573),
+    [sym_begin_group] = ACTIONS(573),
+    [sym_end_group] = ACTIONS(573),
+    [sym_math_shift] = ACTIONS(573),
+    [sym_alignment_tab] = ACTIONS(573),
+    [sym_parameter_char] = ACTIONS(573),
+    [sym_superscript] = ACTIONS(573),
+    [sym_subscript] = ACTIONS(573),
+    [sym_active_char] = ACTIONS(573),
+    [sym_text] = ACTIONS(573),
+  },
+  [222] = {
+    [anon_sym_LBRACK] = ACTIONS(575),
+    [anon_sym_RBRACK] = ACTIONS(575),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(575),
+    [sym_begin_group] = ACTIONS(575),
+    [sym_end_group] = ACTIONS(575),
+    [sym_math_shift] = ACTIONS(575),
+    [sym_alignment_tab] = ACTIONS(575),
+    [sym_parameter_char] = ACTIONS(575),
+    [sym_superscript] = ACTIONS(575),
+    [sym_subscript] = ACTIONS(575),
+    [sym_active_char] = ACTIONS(575),
+    [sym_text] = ACTIONS(575),
+  },
+  [223] = {
+    [sym_text_group_at] = STATE(299),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+    [sym__whitespace] = ACTIONS(577),
+  },
+  [224] = {
+    [anon_sym_LBRACK] = ACTIONS(579),
+    [anon_sym_RBRACK] = ACTIONS(579),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(579),
+    [sym_begin_group] = ACTIONS(579),
+    [sym_end_group] = ACTIONS(579),
+    [sym_math_shift] = ACTIONS(579),
+    [sym_alignment_tab] = ACTIONS(579),
+    [sym_parameter_char] = ACTIONS(579),
+    [sym_superscript] = ACTIONS(579),
+    [sym_subscript] = ACTIONS(579),
+    [sym_active_char] = ACTIONS(579),
+    [sym_text] = ACTIONS(579),
+  },
+  [225] = {
+    [anon_sym_LBRACK] = ACTIONS(581),
+    [anon_sym_RBRACK] = ACTIONS(581),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(581),
+    [sym_begin_group] = ACTIONS(581),
+    [sym_end_group] = ACTIONS(581),
+    [sym_math_shift] = ACTIONS(581),
+    [sym_alignment_tab] = ACTIONS(581),
+    [sym_parameter_char] = ACTIONS(581),
+    [sym_superscript] = ACTIONS(581),
+    [sym_subscript] = ACTIONS(581),
+    [sym_active_char] = ACTIONS(581),
+    [sym_text] = ACTIONS(581),
+  },
+  [226] = {
+    [anon_sym_LBRACK] = ACTIONS(583),
+    [anon_sym_RBRACK] = ACTIONS(583),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(583),
+    [sym_begin_group] = ACTIONS(583),
+    [sym_end_group] = ACTIONS(583),
+    [sym_math_shift] = ACTIONS(583),
+    [sym_alignment_tab] = ACTIONS(583),
+    [sym_parameter_char] = ACTIONS(583),
+    [sym_superscript] = ACTIONS(583),
+    [sym_subscript] = ACTIONS(583),
+    [sym_active_char] = ACTIONS(583),
+    [sym_text] = ACTIONS(583),
+  },
+  [227] = {
+    [anon_sym_LBRACK] = ACTIONS(585),
+    [anon_sym_RBRACK] = ACTIONS(585),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(585),
+    [sym_begin_group] = ACTIONS(585),
+    [sym_end_group] = ACTIONS(585),
+    [sym_math_shift] = ACTIONS(585),
+    [sym_alignment_tab] = ACTIONS(585),
+    [sym_parameter_char] = ACTIONS(585),
+    [sym_superscript] = ACTIONS(585),
+    [sym_subscript] = ACTIONS(585),
+    [sym_active_char] = ACTIONS(585),
+    [sym_text] = ACTIONS(585),
+  },
+  [228] = {
+    [sym__common] = STATE(301),
+    [sym__text_mode_common] = STATE(301),
+    [sym__text_mode_at] = STATE(301),
+    [sym_parameter] = STATE(301),
+    [sym_text_env_at] = STATE(301),
+    [sym__display_math_at] = STATE(301),
+    [sym_tex_display_math_at] = STATE(301),
+    [sym_latex_display_math_at] = STATE(301),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(301),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(301),
+    [sym_tex_inline_math_at] = STATE(301),
+    [sym_latex_inline_math_at] = STATE(301),
+    [sym_inline_math_env_at] = STATE(301),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(301),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(301),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(301),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(301),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(301),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(301),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(301),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(301),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(301),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(301),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(301),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(301),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(301),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(301),
+    [sym_opt_text_group_at] = STATE(301),
+    [sym_token_at] = STATE(301),
+    [sym_begin_opt] = STATE(117),
+    [sym_end_opt] = STATE(300),
+    [aux_sym_text_mode_at_repeat1] = STATE(301),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(587),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(587),
+    [sym_text] = ACTIONS(587),
+  },
+  [229] = {
+    [sym__common] = STATE(229),
+    [sym__text_mode_common] = STATE(229),
+    [sym__text_mode_at] = STATE(229),
+    [sym_parameter] = STATE(229),
+    [sym_text_env_at] = STATE(229),
+    [sym__display_math_at] = STATE(229),
+    [sym_tex_display_math_at] = STATE(229),
+    [sym_latex_display_math_at] = STATE(229),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(229),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(229),
+    [sym_tex_inline_math_at] = STATE(229),
+    [sym_latex_inline_math_at] = STATE(229),
+    [sym_inline_math_env_at] = STATE(229),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(229),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(229),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(229),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(229),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(229),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(229),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(229),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(229),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(229),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(229),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(229),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(229),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(229),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(229),
+    [sym_opt_text_group_at] = STATE(229),
+    [sym_token_at] = STATE(229),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(229),
+    [anon_sym_LBRACK] = ACTIONS(589),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(592),
+    [sym_begin_group] = ACTIONS(595),
+    [sym_math_shift] = ACTIONS(598),
+    [sym_alignment_tab] = ACTIONS(601),
+    [sym_parameter_char] = ACTIONS(604),
+    [sym_superscript] = ACTIONS(607),
+    [sym_subscript] = ACTIONS(607),
+    [sym_active_char] = ACTIONS(601),
+    [sym_text] = ACTIONS(601),
+  },
+  [230] = {
+    [ts_builtin_sym_end] = ACTIONS(610),
+    [anon_sym_LBRACK] = ACTIONS(610),
+    [anon_sym_RBRACK] = ACTIONS(610),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(610),
+    [sym_begin_group] = ACTIONS(610),
+    [sym_end_group] = ACTIONS(610),
+    [sym_math_shift] = ACTIONS(610),
+    [sym_alignment_tab] = ACTIONS(610),
+    [sym_parameter_char] = ACTIONS(610),
+    [sym_superscript] = ACTIONS(610),
+    [sym_subscript] = ACTIONS(610),
+    [sym_active_char] = ACTIONS(610),
+    [sym_text] = ACTIONS(610),
+  },
+  [231] = {
+    [sym__common] = STATE(231),
+    [sym__text_mode_common] = STATE(231),
+    [sym__text_mode] = STATE(231),
+    [sym_text_mode_at_region] = STATE(231),
+    [sym_parameter] = STATE(231),
+    [sym_text_env] = STATE(231),
+    [sym__display_math] = STATE(231),
+    [sym_tex_display_math] = STATE(231),
+    [sym_latex_display_math] = STATE(231),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(231),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(231),
+    [sym_tex_inline_math] = STATE(231),
+    [sym_latex_inline_math] = STATE(231),
+    [sym_inline_math_env] = STATE(231),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(231),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(231),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(231),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(231),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(231),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(231),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(231),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(231),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(231),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(231),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(231),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(231),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(231),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(231),
+    [sym_opt_text_group] = STATE(231),
+    [sym_token] = STATE(231),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(231),
+    [anon_sym_LBRACK] = ACTIONS(337),
+    [anon_sym_RBRACK] = ACTIONS(335),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(340),
+    [sym_begin_group] = ACTIONS(343),
+    [sym_math_shift] = ACTIONS(346),
+    [sym_alignment_tab] = ACTIONS(612),
+    [sym_parameter_char] = ACTIONS(352),
+    [sym_superscript] = ACTIONS(355),
+    [sym_subscript] = ACTIONS(355),
+    [sym_active_char] = ACTIONS(612),
+    [sym_text] = ACTIONS(612),
+  },
+  [232] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(615),
+  },
+  [233] = {
+    [anon_sym_LBRACK] = ACTIONS(617),
+    [anon_sym_RBRACK] = ACTIONS(617),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(617),
+    [sym_begin_group] = ACTIONS(617),
+    [sym_end_group] = ACTIONS(617),
+    [sym_math_shift] = ACTIONS(617),
+    [sym_alignment_tab] = ACTIONS(617),
+    [sym_parameter_char] = ACTIONS(617),
+    [sym_superscript] = ACTIONS(617),
+    [sym_subscript] = ACTIONS(617),
+    [sym_active_char] = ACTIONS(617),
+    [sym_text] = ACTIONS(617),
+  },
+  [234] = {
+    [sym__common] = STATE(234),
+    [sym__math_mode_common] = STATE(234),
+    [sym__math_mode] = STATE(234),
+    [sym_parameter] = STATE(234),
+    [sym_math_env] = STATE(234),
+    [sym_tag] = STATE(234),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(234),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(234),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(234),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(234),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(234),
+    [sym_opt_math_group] = STATE(234),
+    [sym_token] = STATE(234),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(234),
+    [anon_sym_LBRACK] = ACTIONS(413),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(416),
+    [sym_begin_group] = ACTIONS(419),
+    [sym_end_group] = ACTIONS(422),
+    [sym_alignment_tab] = ACTIONS(619),
+    [sym_parameter_char] = ACTIONS(427),
+    [sym_superscript] = ACTIONS(619),
+    [sym_subscript] = ACTIONS(619),
+    [sym_active_char] = ACTIONS(619),
+    [sym_text] = ACTIONS(619),
+  },
+  [235] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(622),
+  },
+  [236] = {
+    [anon_sym_LBRACK] = ACTIONS(624),
+    [anon_sym_RBRACK] = ACTIONS(624),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(624),
+    [sym_begin_group] = ACTIONS(624),
+    [sym_end_group] = ACTIONS(624),
+    [sym_math_shift] = ACTIONS(624),
+    [sym_alignment_tab] = ACTIONS(624),
+    [sym_parameter_char] = ACTIONS(624),
+    [sym_superscript] = ACTIONS(624),
+    [sym_subscript] = ACTIONS(624),
+    [sym_active_char] = ACTIONS(624),
+    [sym_text] = ACTIONS(624),
+  },
+  [237] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(626),
+  },
+  [238] = {
+    [sym__common] = STATE(136),
+    [sym__text_mode_common] = STATE(136),
+    [sym__text_mode] = STATE(136),
+    [sym_text_mode_at_region] = STATE(136),
+    [sym_parameter] = STATE(136),
+    [sym_text_env] = STATE(136),
+    [sym__display_math] = STATE(136),
+    [sym_tex_display_math] = STATE(136),
+    [sym_latex_display_math] = STATE(136),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(136),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(136),
+    [sym_tex_inline_math] = STATE(136),
+    [sym_latex_inline_math] = STATE(136),
+    [sym_inline_math_env] = STATE(136),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(136),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(136),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(136),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(136),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(136),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(136),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(136),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(136),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(136),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(136),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(136),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(136),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(136),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(136),
+    [sym_opt_text_group] = STATE(136),
+    [sym_token] = STATE(136),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(136),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(115),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(189),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(189),
+    [sym_text] = ACTIONS(189),
+  },
+  [239] = {
+    [anon_sym_LBRACK] = ACTIONS(628),
+    [anon_sym_RBRACK] = ACTIONS(628),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(628),
+    [sym_begin_group] = ACTIONS(628),
+    [sym_end_group] = ACTIONS(628),
+    [sym_math_shift] = ACTIONS(628),
+    [sym_alignment_tab] = ACTIONS(628),
+    [sym_parameter_char] = ACTIONS(628),
+    [sym_superscript] = ACTIONS(628),
+    [sym_subscript] = ACTIONS(628),
+    [sym_active_char] = ACTIONS(628),
+    [sym_text] = ACTIONS(628),
+  },
+  [240] = {
+    [anon_sym_LBRACK] = ACTIONS(630),
+    [anon_sym_RBRACK] = ACTIONS(630),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(630),
+    [sym_begin_group] = ACTIONS(630),
+    [sym_end_group] = ACTIONS(630),
+    [sym_math_shift] = ACTIONS(630),
+    [sym_alignment_tab] = ACTIONS(630),
+    [sym_parameter_char] = ACTIONS(630),
+    [sym_superscript] = ACTIONS(630),
+    [sym_subscript] = ACTIONS(630),
+    [sym_active_char] = ACTIONS(630),
+    [sym_text] = ACTIONS(630),
+  },
+  [241] = {
+    [sym__common] = STATE(241),
+    [sym__math_mode_common] = STATE(241),
+    [sym__math_mode] = STATE(241),
+    [sym_parameter] = STATE(241),
+    [sym_math_env] = STATE(241),
+    [sym_tag] = STATE(241),
+    [sym_tag_token] = STATE(55),
+    [sym_escaped] = STATE(241),
+    [sym_begin] = STATE(56),
+    [sym_begin_token] = STATE(57),
+    [sym_include] = STATE(241),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(241),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(241),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(241),
+    [sym_opt_math_group] = STATE(241),
+    [sym_token] = STATE(241),
+    [sym_begin_opt] = STATE(58),
+    [aux_sym_math_mode_repeat1] = STATE(241),
+    [anon_sym_LBRACK] = ACTIONS(413),
+    [anon_sym_RBRACK] = ACTIONS(422),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(416),
+    [sym_begin_group] = ACTIONS(419),
+    [sym_alignment_tab] = ACTIONS(632),
+    [sym_parameter_char] = ACTIONS(427),
+    [sym_superscript] = ACTIONS(632),
+    [sym_subscript] = ACTIONS(632),
+    [sym_active_char] = ACTIONS(632),
+    [sym_text] = ACTIONS(632),
+  },
+  [242] = {
+    [ts_builtin_sym_end] = ACTIONS(635),
+    [anon_sym_LBRACK] = ACTIONS(635),
+    [anon_sym_RBRACK] = ACTIONS(635),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(635),
+    [sym_begin_group] = ACTIONS(635),
+    [sym_end_group] = ACTIONS(635),
+    [sym_math_shift] = ACTIONS(635),
+    [sym_alignment_tab] = ACTIONS(635),
+    [sym_parameter_char] = ACTIONS(635),
+    [sym_superscript] = ACTIONS(635),
+    [sym_subscript] = ACTIONS(635),
+    [sym__whitespace] = ACTIONS(637),
+    [sym_active_char] = ACTIONS(635),
+    [sym_text] = ACTIONS(639),
+  },
+  [243] = {
+    [ts_builtin_sym_end] = ACTIONS(641),
+    [anon_sym_LBRACK] = ACTIONS(641),
+    [anon_sym_RBRACK] = ACTIONS(641),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(641),
+    [sym_begin_group] = ACTIONS(641),
+    [sym_end_group] = ACTIONS(641),
+    [sym_math_shift] = ACTIONS(641),
+    [sym_alignment_tab] = ACTIONS(641),
+    [sym_parameter_char] = ACTIONS(641),
+    [sym_superscript] = ACTIONS(641),
+    [sym_subscript] = ACTIONS(641),
+    [sym__whitespace] = ACTIONS(643),
+    [sym_active_char] = ACTIONS(641),
+    [sym_text] = ACTIONS(645),
+  },
+  [244] = {
+    [sym_display_math_env_name] = ACTIONS(647),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [245] = {
+    [ts_builtin_sym_end] = ACTIONS(649),
+    [anon_sym_LBRACK] = ACTIONS(649),
+    [anon_sym_RBRACK] = ACTIONS(649),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(649),
+    [sym_begin_group] = ACTIONS(649),
+    [sym_end_group] = ACTIONS(649),
+    [sym_math_shift] = ACTIONS(649),
+    [sym_alignment_tab] = ACTIONS(649),
+    [sym_parameter_char] = ACTIONS(649),
+    [sym_superscript] = ACTIONS(649),
+    [sym_subscript] = ACTIONS(649),
+    [sym_active_char] = ACTIONS(649),
+    [sym_text] = ACTIONS(649),
+  },
+  [246] = {
+    [sym_inline_math_env_name] = ACTIONS(651),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [247] = {
+    [ts_builtin_sym_end] = ACTIONS(653),
+    [anon_sym_LBRACK] = ACTIONS(653),
+    [anon_sym_RBRACK] = ACTIONS(653),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(653),
+    [sym_begin_group] = ACTIONS(653),
+    [sym_end_group] = ACTIONS(653),
+    [sym_math_shift] = ACTIONS(653),
+    [sym_alignment_tab] = ACTIONS(653),
+    [sym_parameter_char] = ACTIONS(653),
+    [sym_superscript] = ACTIONS(653),
+    [sym_subscript] = ACTIONS(653),
+    [sym_active_char] = ACTIONS(653),
+    [sym_text] = ACTIONS(653),
+  },
+  [248] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(655),
-    [sym_alignment_tab] = ACTIONS(655),
-    [sym_parameter_char] = ACTIONS(655),
-    [sym_superscript] = ACTIONS(655),
-    [sym_subscript] = ACTIONS(655),
-    [sym_active_char] = ACTIONS(655),
-    [sym_text] = ACTIONS(655),
   },
-  [268] = {
+  [249] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(514),
-    [sym__end_of_line] = ACTIONS(514),
+    [sym_end_group] = ACTIONS(657),
   },
-  [269] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(657),
+  [250] = {
+    [anon_sym_LBRACK] = ACTIONS(659),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(659),
+    [sym_begin_group] = ACTIONS(659),
     [sym__end_of_line] = ACTIONS(659),
   },
-  [270] = {
+  [251] = {
+    [ts_builtin_sym_end] = ACTIONS(661),
     [anon_sym_LBRACK] = ACTIONS(661),
     [anon_sym_RBRACK] = ACTIONS(661),
     [sym_magic_comment] = ACTIONS(9),
@@ -10903,269 +10564,180 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(661),
     [sym_text] = ACTIONS(661),
   },
-  [271] = {
-    [sym__common] = STATE(271),
-    [sym__math_mode_common] = STATE(271),
-    [sym__math_mode_at] = STATE(271),
-    [sym_parameter] = STATE(271),
-    [sym_math_env_at] = STATE(271),
-    [sym_tag_at] = STATE(271),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(271),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(271),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(271),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(271),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(271),
-    [sym_opt_math_group_at] = STATE(271),
-    [sym_token_at] = STATE(271),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(271),
-    [anon_sym_LBRACK] = ACTIONS(602),
+  [252] = {
+    [anon_sym_LBRACK] = ACTIONS(663),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(605),
-    [sym_begin_group] = ACTIONS(608),
-    [sym_end_group] = ACTIONS(611),
-    [sym_alignment_tab] = ACTIONS(663),
-    [sym_parameter_char] = ACTIONS(616),
-    [sym_superscript] = ACTIONS(663),
-    [sym_subscript] = ACTIONS(663),
-    [sym_active_char] = ACTIONS(663),
-    [sym_text] = ACTIONS(663),
+    [sym_begin_group] = ACTIONS(663),
+    [sym__end_of_line] = ACTIONS(663),
   },
-  [272] = {
+  [253] = {
+    [ts_builtin_sym_end] = ACTIONS(665),
+    [anon_sym_LBRACK] = ACTIONS(665),
+    [anon_sym_RBRACK] = ACTIONS(665),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(666),
+    [sym__escape] = ACTIONS(665),
+    [sym_begin_group] = ACTIONS(665),
+    [sym_end_group] = ACTIONS(665),
+    [sym_math_shift] = ACTIONS(665),
+    [sym_alignment_tab] = ACTIONS(665),
+    [sym_parameter_char] = ACTIONS(665),
+    [sym_superscript] = ACTIONS(665),
+    [sym_subscript] = ACTIONS(665),
+    [sym_active_char] = ACTIONS(665),
+    [sym_text] = ACTIONS(665),
   },
-  [273] = {
-    [anon_sym_LBRACK] = ACTIONS(668),
-    [anon_sym_RBRACK] = ACTIONS(668),
+  [254] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(668),
-    [sym_begin_group] = ACTIONS(668),
-    [sym_end_group] = ACTIONS(668),
-    [sym_math_shift] = ACTIONS(668),
-    [sym_alignment_tab] = ACTIONS(668),
-    [sym_parameter_char] = ACTIONS(668),
-    [sym_superscript] = ACTIONS(668),
-    [sym_subscript] = ACTIONS(668),
-    [sym_active_char] = ACTIONS(668),
-    [sym_text] = ACTIONS(668),
+    [sym__end_of_line] = ACTIONS(185),
   },
-  [274] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(670),
-  },
-  [275] = {
-    [sym__common] = STATE(235),
-    [sym__text_mode_common] = STATE(235),
-    [sym__text_mode_at] = STATE(235),
-    [sym_parameter] = STATE(235),
-    [sym_text_env_at] = STATE(235),
-    [sym__display_math_at] = STATE(235),
-    [sym_tex_display_math_at] = STATE(235),
-    [sym_latex_display_math_at] = STATE(235),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(235),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(235),
-    [sym_tex_inline_math_at] = STATE(235),
-    [sym_latex_inline_math_at] = STATE(235),
-    [sym_inline_math_env_at] = STATE(235),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(235),
+  [255] = {
+    [sym__common] = STATE(136),
+    [sym__text_mode_common] = STATE(136),
+    [sym__text_mode] = STATE(136),
+    [sym_text_mode_at_region] = STATE(136),
+    [sym_parameter] = STATE(136),
+    [sym_text_env] = STATE(136),
+    [sym__display_math] = STATE(136),
+    [sym_tex_display_math] = STATE(136),
+    [sym_latex_display_math] = STATE(136),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(136),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(136),
+    [sym_tex_inline_math] = STATE(136),
+    [sym_latex_inline_math] = STATE(136),
+    [sym_inline_math_env] = STATE(136),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(136),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(235),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(235),
+    [sym_escaped] = STATE(136),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(136),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(235),
+    [sym_usepackage] = STATE(136),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(235),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(235),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(235),
+    [sym_include] = STATE(136),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(136),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(136),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(235),
+    [sym_catcode] = STATE(136),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(235),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(235),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(235),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(235),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(235),
-    [sym_opt_text_group_at] = STATE(235),
-    [sym_token_at] = STATE(235),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(235),
+    [sym_emph] = STATE(136),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(136),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(136),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(136),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(136),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(136),
+    [sym_opt_text_group] = STATE(136),
+    [sym_token] = STATE(136),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(136),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_end_group] = ACTIONS(275),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(445),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(667),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(189),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(445),
-    [sym_text] = ACTIONS(445),
+    [sym_active_char] = ACTIONS(189),
+    [sym_text] = ACTIONS(189),
   },
-  [276] = {
-    [anon_sym_LBRACK] = ACTIONS(672),
-    [anon_sym_RBRACK] = ACTIONS(672),
+  [256] = {
+    [anon_sym_LBRACK] = ACTIONS(669),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(672),
-    [sym_begin_group] = ACTIONS(672),
-    [sym_end_group] = ACTIONS(672),
-    [sym_math_shift] = ACTIONS(672),
-    [sym_alignment_tab] = ACTIONS(672),
-    [sym_parameter_char] = ACTIONS(672),
-    [sym_superscript] = ACTIONS(672),
-    [sym_subscript] = ACTIONS(672),
-    [sym_active_char] = ACTIONS(672),
-    [sym_text] = ACTIONS(672),
+    [sym__escape] = ACTIONS(669),
+    [sym_begin_group] = ACTIONS(669),
+    [sym_alignment_tab] = ACTIONS(669),
+    [sym_parameter_char] = ACTIONS(669),
+    [sym_superscript] = ACTIONS(669),
+    [sym_subscript] = ACTIONS(669),
+    [sym_active_char] = ACTIONS(669),
+    [sym_text] = ACTIONS(669),
   },
-  [277] = {
-    [anon_sym_LBRACK] = ACTIONS(674),
-    [anon_sym_RBRACK] = ACTIONS(674),
+  [257] = {
+    [sym_text_group] = STATE(310),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(674),
-    [sym_begin_group] = ACTIONS(674),
-    [sym_end_group] = ACTIONS(674),
-    [sym_math_shift] = ACTIONS(674),
-    [sym_alignment_tab] = ACTIONS(674),
-    [sym_parameter_char] = ACTIONS(674),
-    [sym_superscript] = ACTIONS(674),
-    [sym_subscript] = ACTIONS(674),
-    [sym_active_char] = ACTIONS(674),
-    [sym_text] = ACTIONS(674),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(671),
   },
-  [278] = {
-    [sym__common] = STATE(278),
-    [sym__math_mode_common] = STATE(278),
-    [sym__math_mode_at] = STATE(278),
-    [sym_parameter] = STATE(278),
-    [sym_math_env_at] = STATE(278),
-    [sym_tag_at] = STATE(278),
-    [sym_tag_token] = STATE(177),
-    [sym_escaped] = STATE(278),
-    [sym_begin] = STATE(178),
-    [sym_begin_token] = STATE(55),
-    [sym_include_at] = STATE(278),
-    [sym_include_token] = STATE(103),
-    [sym_storage] = STATE(278),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(278),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(278),
-    [sym_opt_math_group_at] = STATE(278),
-    [sym_token_at] = STATE(278),
-    [sym_begin_opt] = STATE(179),
-    [aux_sym_math_mode_at_repeat1] = STATE(278),
-    [anon_sym_LBRACK] = ACTIONS(602),
-    [anon_sym_RBRACK] = ACTIONS(611),
+  [258] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(605),
-    [sym_begin_group] = ACTIONS(608),
-    [sym_alignment_tab] = ACTIONS(676),
-    [sym_parameter_char] = ACTIONS(616),
-    [sym_superscript] = ACTIONS(676),
-    [sym_subscript] = ACTIONS(676),
-    [sym_active_char] = ACTIONS(676),
-    [sym_text] = ACTIONS(676),
+    [sym__end_of_line] = ACTIONS(671),
   },
-  [279] = {
+  [259] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(673),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(441),
+    [sym__escape] = ACTIONS(675),
+    [sym__end_of_line] = ACTIONS(675),
   },
-  [280] = {
-    [sym__common] = STATE(235),
-    [sym__text_mode_common] = STATE(235),
-    [sym__text_mode_at] = STATE(235),
-    [sym_parameter] = STATE(235),
-    [sym_text_env_at] = STATE(235),
-    [sym__display_math_at] = STATE(235),
-    [sym_tex_display_math_at] = STATE(235),
-    [sym_latex_display_math_at] = STATE(235),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(235),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(235),
-    [sym_tex_inline_math_at] = STATE(235),
-    [sym_latex_inline_math_at] = STATE(235),
-    [sym_inline_math_env_at] = STATE(235),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(235),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(235),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(235),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(235),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(235),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(235),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(235),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(235),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(235),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(235),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(235),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(235),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(235),
-    [sym_opt_text_group_at] = STATE(235),
-    [sym_token_at] = STATE(235),
-    [sym_begin_opt] = STATE(111),
-    [aux_sym_text_mode_at_repeat1] = STATE(235),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [260] = {
+    [sym_text_group] = STATE(312),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
+    [sym_begin_group] = ACTIONS(247),
+    [sym__end_of_line] = ACTIONS(677),
+  },
+  [261] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(677),
+  },
+  [262] = {
+    [ts_builtin_sym_end] = ACTIONS(679),
+    [anon_sym_LBRACK] = ACTIONS(679),
+    [anon_sym_RBRACK] = ACTIONS(679),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(679),
+    [sym_begin_group] = ACTIONS(679),
     [sym_end_group] = ACTIONS(679),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(445),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(445),
-    [sym_text] = ACTIONS(445),
+    [sym_math_shift] = ACTIONS(679),
+    [sym_alignment_tab] = ACTIONS(679),
+    [sym_parameter_char] = ACTIONS(679),
+    [sym_superscript] = ACTIONS(679),
+    [sym_subscript] = ACTIONS(679),
+    [sym_active_char] = ACTIONS(679),
+    [sym_text] = ACTIONS(679),
   },
-  [281] = {
+  [263] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(610),
+    [sym__end_of_line] = ACTIONS(610),
+    [sym__whitespace] = ACTIONS(610),
+  },
+  [264] = {
+    [ts_builtin_sym_end] = ACTIONS(681),
     [anon_sym_LBRACK] = ACTIONS(681),
+    [anon_sym_RBRACK] = ACTIONS(681),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(681),
     [sym_begin_group] = ACTIONS(681),
+    [sym_end_group] = ACTIONS(681),
+    [sym_math_shift] = ACTIONS(681),
     [sym_alignment_tab] = ACTIONS(681),
     [sym_parameter_char] = ACTIONS(681),
     [sym_superscript] = ACTIONS(681),
@@ -11173,98 +10745,25 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(681),
     [sym_text] = ACTIONS(681),
   },
-  [282] = {
+  [265] = {
+    [ts_builtin_sym_end] = ACTIONS(683),
+    [anon_sym_LBRACK] = ACTIONS(683),
+    [anon_sym_RBRACK] = ACTIONS(683),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(683),
+    [sym__escape] = ACTIONS(683),
+    [sym_begin_group] = ACTIONS(683),
+    [sym_end_group] = ACTIONS(683),
+    [sym_math_shift] = ACTIONS(683),
+    [sym_alignment_tab] = ACTIONS(683),
+    [sym_parameter_char] = ACTIONS(683),
+    [sym_superscript] = ACTIONS(683),
+    [sym_subscript] = ACTIONS(683),
+    [sym_active_char] = ACTIONS(683),
+    [sym_text] = ACTIONS(683),
   },
-  [283] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(489),
-    [sym__end_of_line] = ACTIONS(489),
-  },
-  [284] = {
-    [sym__common] = STATE(261),
-    [sym__text_mode_common] = STATE(261),
-    [sym__text_mode_at] = STATE(261),
-    [sym_parameter] = STATE(261),
-    [sym_text_env_at] = STATE(261),
-    [sym__display_math_at] = STATE(261),
-    [sym_tex_display_math_at] = STATE(261),
-    [sym_latex_display_math_at] = STATE(261),
-    [sym_begin_display_math] = STATE(97),
-    [sym_begin_inline_math] = STATE(98),
-    [sym_display_math_env_at] = STATE(261),
-    [sym_display_math_begin_at] = STATE(99),
-    [sym__inline_math_at] = STATE(261),
-    [sym_tex_inline_math_at] = STATE(261),
-    [sym_latex_inline_math_at] = STATE(261),
-    [sym_inline_math_env_at] = STATE(261),
-    [sym_inline_math_begin] = STATE(100),
-    [sym_verbatim_env] = STATE(261),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(261),
-    [sym_begin] = STATE(101),
-    [sym_begin_token] = STATE(102),
-    [sym_documentclass] = STATE(261),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(261),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(261),
-    [sym_include_token] = STATE(103),
-    [sym_section_at] = STATE(261),
-    [sym_section_token] = STATE(104),
-    [sym_storage] = STATE(261),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(261),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(261),
-    [sym_emph_token] = STATE(105),
-    [sym_textbf_at] = STATE(261),
-    [sym_textbf_token] = STATE(106),
-    [sym_textit_at] = STATE(261),
-    [sym_textit_token] = STATE(107),
-    [sym_texttt_at] = STATE(261),
-    [sym_texttt_token] = STATE(108),
-    [sym_text_group_at] = STATE(261),
-    [sym_opt_text_group_at] = STATE(261),
-    [sym_token_at] = STATE(261),
-    [sym_begin_opt] = STATE(111),
-    [sym_end_opt] = STATE(290),
-    [aux_sym_text_mode_at_repeat1] = STATE(261),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(419),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(101),
-    [sym_math_shift] = ACTIONS(103),
-    [sym_alignment_tab] = ACTIONS(491),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(491),
-    [sym_text] = ACTIONS(491),
-  },
-  [285] = {
-    [ts_builtin_sym_end] = ACTIONS(551),
-    [anon_sym_LBRACK] = ACTIONS(551),
-    [anon_sym_RBRACK] = ACTIONS(551),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(551),
-    [sym_begin_group] = ACTIONS(551),
-    [sym_end_group] = ACTIONS(551),
-    [sym_math_shift] = ACTIONS(551),
-    [sym_alignment_tab] = ACTIONS(551),
-    [sym_parameter_char] = ACTIONS(551),
-    [sym_superscript] = ACTIONS(551),
-    [sym_subscript] = ACTIONS(551),
-    [sym_active_char] = ACTIONS(551),
-    [sym_text] = ACTIONS(551),
-  },
-  [286] = {
+  [266] = {
+    [ts_builtin_sym_end] = ACTIONS(685),
     [anon_sym_LBRACK] = ACTIONS(685),
     [anon_sym_RBRACK] = ACTIONS(685),
     [sym_magic_comment] = ACTIONS(9),
@@ -11280,7 +10779,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(685),
     [sym_text] = ACTIONS(685),
   },
-  [287] = {
+  [267] = {
+    [ts_builtin_sym_end] = ACTIONS(687),
     [anon_sym_LBRACK] = ACTIONS(687),
     [anon_sym_RBRACK] = ACTIONS(687),
     [sym_magic_comment] = ACTIONS(9),
@@ -11296,17 +10796,16 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(687),
     [sym_text] = ACTIONS(687),
   },
-  [288] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(573),
-  },
-  [289] = {
+  [268] = {
+    [ts_builtin_sym_end] = ACTIONS(689),
     [anon_sym_LBRACK] = ACTIONS(689),
+    [anon_sym_RBRACK] = ACTIONS(689),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(689),
     [sym_begin_group] = ACTIONS(689),
+    [sym_end_group] = ACTIONS(689),
+    [sym_math_shift] = ACTIONS(689),
     [sym_alignment_tab] = ACTIONS(689),
     [sym_parameter_char] = ACTIONS(689),
     [sym_superscript] = ACTIONS(689),
@@ -11314,11 +10813,1375 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(689),
     [sym_text] = ACTIONS(689),
   },
-  [290] = {
+  [269] = {
+    [anon_sym_LBRACK] = ACTIONS(691),
+    [anon_sym_RBRACK] = ACTIONS(691),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(644),
-    [sym__end_of_line] = ACTIONS(644),
+    [sym__escape] = ACTIONS(691),
+    [sym_begin_group] = ACTIONS(691),
+    [sym_end_group] = ACTIONS(691),
+    [sym_math_shift] = ACTIONS(691),
+    [sym_alignment_tab] = ACTIONS(691),
+    [sym_parameter_char] = ACTIONS(691),
+    [sym_superscript] = ACTIONS(691),
+    [sym_subscript] = ACTIONS(691),
+    [sym_active_char] = ACTIONS(691),
+    [sym_text] = ACTIONS(691),
+  },
+  [270] = {
+    [anon_sym_LBRACK] = ACTIONS(693),
+    [anon_sym_RBRACK] = ACTIONS(693),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(693),
+    [sym_begin_group] = ACTIONS(693),
+    [sym_end_group] = ACTIONS(693),
+    [sym_math_shift] = ACTIONS(693),
+    [sym_alignment_tab] = ACTIONS(693),
+    [sym_parameter_char] = ACTIONS(693),
+    [sym_superscript] = ACTIONS(693),
+    [sym_subscript] = ACTIONS(693),
+    [sym_active_char] = ACTIONS(693),
+    [sym_text] = ACTIONS(693),
+  },
+  [271] = {
+    [sym__common] = STATE(271),
+    [sym__text_mode_common] = STATE(271),
+    [sym__text_mode_at] = STATE(271),
+    [sym_parameter] = STATE(271),
+    [sym_text_env_at] = STATE(271),
+    [sym__display_math_at] = STATE(271),
+    [sym_tex_display_math_at] = STATE(271),
+    [sym_latex_display_math_at] = STATE(271),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(271),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(271),
+    [sym_tex_inline_math_at] = STATE(271),
+    [sym_latex_inline_math_at] = STATE(271),
+    [sym_inline_math_env_at] = STATE(271),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(271),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(271),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(271),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(271),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(271),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(271),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(271),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(271),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(271),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(271),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(271),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(271),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(271),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(271),
+    [sym_opt_text_group_at] = STATE(271),
+    [sym_token_at] = STATE(271),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(271),
+    [anon_sym_LBRACK] = ACTIONS(589),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(592),
+    [sym_begin_group] = ACTIONS(595),
+    [sym_end_group] = ACTIONS(695),
+    [sym_math_shift] = ACTIONS(598),
+    [sym_alignment_tab] = ACTIONS(697),
+    [sym_parameter_char] = ACTIONS(604),
+    [sym_superscript] = ACTIONS(607),
+    [sym_subscript] = ACTIONS(607),
+    [sym_active_char] = ACTIONS(697),
+    [sym_text] = ACTIONS(697),
+  },
+  [272] = {
+    [anon_sym_LBRACK] = ACTIONS(700),
+    [anon_sym_RBRACK] = ACTIONS(700),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(700),
+    [sym_begin_group] = ACTIONS(700),
+    [sym_end_group] = ACTIONS(700),
+    [sym_math_shift] = ACTIONS(700),
+    [sym_alignment_tab] = ACTIONS(700),
+    [sym_parameter_char] = ACTIONS(700),
+    [sym_superscript] = ACTIONS(700),
+    [sym_subscript] = ACTIONS(700),
+    [sym_active_char] = ACTIONS(700),
+    [sym_text] = ACTIONS(700),
+  },
+  [273] = {
+    [sym__common] = STATE(314),
+    [sym__math_mode_common] = STATE(314),
+    [sym__math_mode_at] = STATE(314),
+    [sym_parameter] = STATE(314),
+    [sym_math_env_at] = STATE(314),
+    [sym_tag_at] = STATE(314),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(314),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(314),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(314),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(314),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(314),
+    [sym_opt_math_group_at] = STATE(314),
+    [sym_token_at] = STATE(314),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(314),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_end_group] = ACTIONS(702),
+    [sym_alignment_tab] = ACTIONS(704),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(704),
+    [sym_subscript] = ACTIONS(704),
+    [sym_active_char] = ACTIONS(704),
+    [sym_text] = ACTIONS(704),
+  },
+  [274] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(706),
+  },
+  [275] = {
+    [anon_sym_LBRACK] = ACTIONS(708),
+    [anon_sym_RBRACK] = ACTIONS(708),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(708),
+    [sym_begin_group] = ACTIONS(708),
+    [sym_end_group] = ACTIONS(708),
+    [sym_math_shift] = ACTIONS(708),
+    [sym_alignment_tab] = ACTIONS(708),
+    [sym_parameter_char] = ACTIONS(708),
+    [sym_superscript] = ACTIONS(708),
+    [sym_subscript] = ACTIONS(708),
+    [sym_active_char] = ACTIONS(708),
+    [sym_text] = ACTIONS(708),
+  },
+  [276] = {
+    [sym__common] = STATE(318),
+    [sym__text_mode_common] = STATE(318),
+    [sym__text_mode_at] = STATE(318),
+    [sym_text_mode_at] = STATE(317),
+    [sym_parameter] = STATE(318),
+    [sym_text_env_at] = STATE(318),
+    [sym__display_math_at] = STATE(318),
+    [sym_tex_display_math_at] = STATE(318),
+    [sym_latex_display_math_at] = STATE(318),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(318),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(318),
+    [sym_tex_inline_math_at] = STATE(318),
+    [sym_latex_inline_math_at] = STATE(318),
+    [sym_inline_math_env_at] = STATE(318),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(318),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(318),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(318),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(318),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(318),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(318),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(318),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(318),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(318),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(318),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(318),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(318),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(318),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(318),
+    [sym_opt_text_group_at] = STATE(318),
+    [sym_token_at] = STATE(318),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(318),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(710),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(712),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(712),
+    [sym_text] = ACTIONS(712),
+  },
+  [277] = {
+    [anon_sym_LBRACK] = ACTIONS(714),
+    [anon_sym_RBRACK] = ACTIONS(714),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(714),
+    [sym_begin_group] = ACTIONS(714),
+    [sym_end_group] = ACTIONS(714),
+    [sym_math_shift] = ACTIONS(714),
+    [sym_alignment_tab] = ACTIONS(714),
+    [sym_parameter_char] = ACTIONS(714),
+    [sym_superscript] = ACTIONS(714),
+    [sym_subscript] = ACTIONS(714),
+    [sym_active_char] = ACTIONS(714),
+    [sym_text] = ACTIONS(714),
+  },
+  [278] = {
+    [anon_sym_tag] = ACTIONS(191),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(31),
+    [anon_sym_begin] = ACTIONS(33),
+    [anon_sym_end] = ACTIONS(233),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(39),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(43),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(45),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(295),
+  },
+  [279] = {
+    [anon_sym_LBRACK] = ACTIONS(716),
+    [anon_sym_RBRACK] = ACTIONS(716),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(716),
+    [sym_begin_group] = ACTIONS(716),
+    [sym_end_group] = ACTIONS(716),
+    [sym_math_shift] = ACTIONS(716),
+    [sym_alignment_tab] = ACTIONS(716),
+    [sym_parameter_char] = ACTIONS(716),
+    [sym_superscript] = ACTIONS(716),
+    [sym_subscript] = ACTIONS(716),
+    [sym_active_char] = ACTIONS(716),
+    [sym_text] = ACTIONS(716),
+  },
+  [280] = {
+    [sym__common] = STATE(285),
+    [sym__math_mode_common] = STATE(285),
+    [sym__math_mode_at] = STATE(285),
+    [sym_parameter] = STATE(285),
+    [sym_math_env_at] = STATE(285),
+    [sym_tag_at] = STATE(285),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(285),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_end] = STATE(319),
+    [sym_end_token] = STATE(74),
+    [sym_include_at] = STATE(285),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(285),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(285),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(285),
+    [sym_opt_math_group_at] = STATE(285),
+    [sym_token_at] = STATE(285),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(285),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(543),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(557),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(557),
+    [sym_subscript] = ACTIONS(557),
+    [sym_active_char] = ACTIONS(557),
+    [sym_text] = ACTIONS(557),
+  },
+  [281] = {
+    [anon_sym_LBRACK] = ACTIONS(718),
+    [anon_sym_RBRACK] = ACTIONS(718),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(718),
+    [sym_begin_group] = ACTIONS(718),
+    [sym_end_group] = ACTIONS(718),
+    [sym_math_shift] = ACTIONS(718),
+    [sym_alignment_tab] = ACTIONS(718),
+    [sym_parameter_char] = ACTIONS(718),
+    [sym_superscript] = ACTIONS(718),
+    [sym_subscript] = ACTIONS(718),
+    [sym_active_char] = ACTIONS(718),
+    [sym_text] = ACTIONS(718),
+  },
+  [282] = {
+    [sym__common] = STATE(321),
+    [sym__math_mode_common] = STATE(321),
+    [sym__math_mode_at] = STATE(321),
+    [sym_parameter] = STATE(321),
+    [sym_math_env_at] = STATE(321),
+    [sym_tag_at] = STATE(321),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(321),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(321),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(321),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(321),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(321),
+    [sym_opt_math_group_at] = STATE(321),
+    [sym_token_at] = STATE(321),
+    [sym_begin_opt] = STATE(204),
+    [sym_end_opt] = STATE(320),
+    [aux_sym_math_mode_at_repeat1] = STATE(321),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(111),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(303),
+    [sym_begin_group] = ACTIONS(305),
+    [sym_alignment_tab] = ACTIONS(720),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(720),
+    [sym_subscript] = ACTIONS(720),
+    [sym_active_char] = ACTIONS(720),
+    [sym_text] = ACTIONS(720),
+  },
+  [283] = {
+    [sym__common] = STATE(283),
+    [sym__math_mode_common] = STATE(283),
+    [sym__math_mode_at] = STATE(283),
+    [sym_parameter] = STATE(283),
+    [sym_math_env_at] = STATE(283),
+    [sym_tag_at] = STATE(283),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(283),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(283),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(283),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(283),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(283),
+    [sym_opt_math_group_at] = STATE(283),
+    [sym_token_at] = STATE(283),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(283),
+    [anon_sym_LBRACK] = ACTIONS(722),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(725),
+    [sym_begin_group] = ACTIONS(728),
+    [sym_math_shift] = ACTIONS(731),
+    [sym_alignment_tab] = ACTIONS(733),
+    [sym_parameter_char] = ACTIONS(736),
+    [sym_superscript] = ACTIONS(733),
+    [sym_subscript] = ACTIONS(733),
+    [sym_active_char] = ACTIONS(733),
+    [sym_text] = ACTIONS(733),
+  },
+  [284] = {
+    [anon_sym_LBRACK] = ACTIONS(739),
+    [anon_sym_RBRACK] = ACTIONS(739),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(739),
+    [sym_begin_group] = ACTIONS(739),
+    [sym_end_group] = ACTIONS(739),
+    [sym_math_shift] = ACTIONS(739),
+    [sym_alignment_tab] = ACTIONS(739),
+    [sym_parameter_char] = ACTIONS(739),
+    [sym_superscript] = ACTIONS(739),
+    [sym_subscript] = ACTIONS(739),
+    [sym_active_char] = ACTIONS(739),
+    [sym_text] = ACTIONS(739),
+  },
+  [285] = {
+    [sym__common] = STATE(285),
+    [sym__math_mode_common] = STATE(285),
+    [sym__math_mode_at] = STATE(285),
+    [sym_parameter] = STATE(285),
+    [sym_math_env_at] = STATE(285),
+    [sym_tag_at] = STATE(285),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(285),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(285),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(285),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(285),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(285),
+    [sym_opt_math_group_at] = STATE(285),
+    [sym_token_at] = STATE(285),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(285),
+    [anon_sym_LBRACK] = ACTIONS(722),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(725),
+    [sym_begin_group] = ACTIONS(728),
+    [sym_alignment_tab] = ACTIONS(741),
+    [sym_parameter_char] = ACTIONS(736),
+    [sym_superscript] = ACTIONS(741),
+    [sym_subscript] = ACTIONS(741),
+    [sym_active_char] = ACTIONS(741),
+    [sym_text] = ACTIONS(741),
+  },
+  [286] = {
+    [anon_sym_LBRACK] = ACTIONS(744),
+    [anon_sym_RBRACK] = ACTIONS(744),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(744),
+    [sym_begin_group] = ACTIONS(744),
+    [sym_end_group] = ACTIONS(744),
+    [sym_math_shift] = ACTIONS(744),
+    [sym_alignment_tab] = ACTIONS(744),
+    [sym_parameter_char] = ACTIONS(744),
+    [sym_superscript] = ACTIONS(744),
+    [sym_subscript] = ACTIONS(744),
+    [sym_active_char] = ACTIONS(744),
+    [sym_text] = ACTIONS(744),
+  },
+  [287] = {
+    [anon_sym_LBRACK] = ACTIONS(746),
+    [anon_sym_RBRACK] = ACTIONS(746),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(746),
+    [sym_begin_group] = ACTIONS(746),
+    [sym_end_group] = ACTIONS(746),
+    [sym_math_shift] = ACTIONS(746),
+    [sym_alignment_tab] = ACTIONS(746),
+    [sym_parameter_char] = ACTIONS(746),
+    [sym_superscript] = ACTIONS(746),
+    [sym_subscript] = ACTIONS(746),
+    [sym_active_char] = ACTIONS(746),
+    [sym_text] = ACTIONS(746),
+  },
+  [288] = {
+    [anon_sym_LBRACK] = ACTIONS(748),
+    [anon_sym_RBRACK] = ACTIONS(748),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(748),
+    [sym_begin_group] = ACTIONS(748),
+    [sym_end_group] = ACTIONS(748),
+    [sym_math_shift] = ACTIONS(748),
+    [sym_alignment_tab] = ACTIONS(748),
+    [sym_parameter_char] = ACTIONS(748),
+    [sym_superscript] = ACTIONS(748),
+    [sym_subscript] = ACTIONS(748),
+    [sym_active_char] = ACTIONS(748),
+    [sym_text] = ACTIONS(748),
+  },
+  [289] = {
+    [anon_sym_LBRACK] = ACTIONS(750),
+    [anon_sym_RBRACK] = ACTIONS(750),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(750),
+    [sym_begin_group] = ACTIONS(750),
+    [sym_end_group] = ACTIONS(750),
+    [sym_math_shift] = ACTIONS(750),
+    [sym_alignment_tab] = ACTIONS(750),
+    [sym_parameter_char] = ACTIONS(750),
+    [sym_superscript] = ACTIONS(750),
+    [sym_subscript] = ACTIONS(750),
+    [sym_active_char] = ACTIONS(750),
+    [sym_text] = ACTIONS(750),
+  },
+  [290] = {
+    [sym__common] = STATE(323),
+    [sym__text_mode_common] = STATE(323),
+    [sym__text_mode_at] = STATE(323),
+    [sym_parameter] = STATE(323),
+    [sym_text_env_at] = STATE(323),
+    [sym__display_math_at] = STATE(323),
+    [sym_tex_display_math_at] = STATE(323),
+    [sym_latex_display_math_at] = STATE(323),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(323),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(323),
+    [sym_tex_inline_math_at] = STATE(323),
+    [sym_latex_inline_math_at] = STATE(323),
+    [sym_inline_math_env_at] = STATE(323),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(323),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(323),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(323),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(323),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(323),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(323),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(323),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(323),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(323),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(323),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(323),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(323),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(323),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(323),
+    [sym_opt_text_group_at] = STATE(323),
+    [sym_token_at] = STATE(323),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(323),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(752),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(754),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(754),
+    [sym_text] = ACTIONS(754),
+  },
+  [291] = {
+    [anon_sym_LBRACK] = ACTIONS(756),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(756),
+    [sym_begin_group] = ACTIONS(756),
+    [sym_alignment_tab] = ACTIONS(756),
+    [sym_parameter_char] = ACTIONS(756),
+    [sym_superscript] = ACTIONS(756),
+    [sym_subscript] = ACTIONS(756),
+    [sym_active_char] = ACTIONS(756),
+    [sym_text] = ACTIONS(756),
+  },
+  [292] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(758),
+  },
+  [293] = {
+    [sym_text_group_at] = STATE(326),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(561),
+    [sym__end_of_line] = ACTIONS(758),
+    [sym__whitespace] = ACTIONS(760),
+  },
+  [294] = {
+    [sym_text_group_at] = STATE(327),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [295] = {
+    [anon_sym_LBRACK] = ACTIONS(762),
+    [anon_sym_RBRACK] = ACTIONS(762),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(762),
+    [sym_begin_group] = ACTIONS(762),
+    [sym_end_group] = ACTIONS(762),
+    [sym_math_shift] = ACTIONS(762),
+    [sym_alignment_tab] = ACTIONS(762),
+    [sym_parameter_char] = ACTIONS(762),
+    [sym_superscript] = ACTIONS(762),
+    [sym_subscript] = ACTIONS(762),
+    [sym_active_char] = ACTIONS(762),
+    [sym_text] = ACTIONS(762),
+  },
+  [296] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(585),
+    [sym__end_of_line] = ACTIONS(585),
+    [sym__whitespace] = ACTIONS(585),
+  },
+  [297] = {
+    [sym__common] = STATE(301),
+    [sym__text_mode_common] = STATE(301),
+    [sym__text_mode_at] = STATE(301),
+    [sym_parameter] = STATE(301),
+    [sym_text_env_at] = STATE(301),
+    [sym__display_math_at] = STATE(301),
+    [sym_tex_display_math_at] = STATE(301),
+    [sym_latex_display_math_at] = STATE(301),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(301),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(301),
+    [sym_tex_inline_math_at] = STATE(301),
+    [sym_latex_inline_math_at] = STATE(301),
+    [sym_inline_math_env_at] = STATE(301),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(301),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(301),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(301),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(301),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(301),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(301),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(301),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(301),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(301),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(301),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(301),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(301),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(301),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(301),
+    [sym_opt_text_group_at] = STATE(301),
+    [sym_token_at] = STATE(301),
+    [sym_begin_opt] = STATE(117),
+    [sym_end_opt] = STATE(328),
+    [aux_sym_text_mode_at_repeat1] = STATE(301),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(263),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(587),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(587),
+    [sym_text] = ACTIONS(587),
+  },
+  [298] = {
+    [sym_text_group_at] = STATE(329),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(103),
+  },
+  [299] = {
+    [anon_sym_LBRACK] = ACTIONS(764),
+    [anon_sym_RBRACK] = ACTIONS(764),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(764),
+    [sym_begin_group] = ACTIONS(764),
+    [sym_end_group] = ACTIONS(764),
+    [sym_math_shift] = ACTIONS(764),
+    [sym_alignment_tab] = ACTIONS(764),
+    [sym_parameter_char] = ACTIONS(764),
+    [sym_superscript] = ACTIONS(764),
+    [sym_subscript] = ACTIONS(764),
+    [sym_active_char] = ACTIONS(764),
+    [sym_text] = ACTIONS(764),
+  },
+  [300] = {
+    [anon_sym_LBRACK] = ACTIONS(766),
+    [anon_sym_RBRACK] = ACTIONS(766),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(766),
+    [sym_begin_group] = ACTIONS(766),
+    [sym_end_group] = ACTIONS(766),
+    [sym_math_shift] = ACTIONS(766),
+    [sym_alignment_tab] = ACTIONS(766),
+    [sym_parameter_char] = ACTIONS(766),
+    [sym_superscript] = ACTIONS(766),
+    [sym_subscript] = ACTIONS(766),
+    [sym_active_char] = ACTIONS(766),
+    [sym_text] = ACTIONS(766),
+  },
+  [301] = {
+    [sym__common] = STATE(301),
+    [sym__text_mode_common] = STATE(301),
+    [sym__text_mode_at] = STATE(301),
+    [sym_parameter] = STATE(301),
+    [sym_text_env_at] = STATE(301),
+    [sym__display_math_at] = STATE(301),
+    [sym_tex_display_math_at] = STATE(301),
+    [sym_latex_display_math_at] = STATE(301),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(301),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(301),
+    [sym_tex_inline_math_at] = STATE(301),
+    [sym_latex_inline_math_at] = STATE(301),
+    [sym_inline_math_env_at] = STATE(301),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(301),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(301),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(301),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(301),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(301),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(301),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(301),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(301),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(301),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(301),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(301),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(301),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(301),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(301),
+    [sym_opt_text_group_at] = STATE(301),
+    [sym_token_at] = STATE(301),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(301),
+    [anon_sym_LBRACK] = ACTIONS(589),
+    [anon_sym_RBRACK] = ACTIONS(695),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(592),
+    [sym_begin_group] = ACTIONS(595),
+    [sym_math_shift] = ACTIONS(598),
+    [sym_alignment_tab] = ACTIONS(768),
+    [sym_parameter_char] = ACTIONS(604),
+    [sym_superscript] = ACTIONS(607),
+    [sym_subscript] = ACTIONS(607),
+    [sym_active_char] = ACTIONS(768),
+    [sym_text] = ACTIONS(768),
+  },
+  [302] = {
+    [ts_builtin_sym_end] = ACTIONS(771),
+    [anon_sym_LBRACK] = ACTIONS(771),
+    [anon_sym_RBRACK] = ACTIONS(771),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(771),
+    [sym_begin_group] = ACTIONS(771),
+    [sym_end_group] = ACTIONS(771),
+    [sym_math_shift] = ACTIONS(771),
+    [sym_alignment_tab] = ACTIONS(771),
+    [sym_parameter_char] = ACTIONS(771),
+    [sym_superscript] = ACTIONS(771),
+    [sym_subscript] = ACTIONS(771),
+    [sym_active_char] = ACTIONS(771),
+    [sym_text] = ACTIONS(771),
+  },
+  [303] = {
+    [anon_sym_LBRACK] = ACTIONS(773),
+    [anon_sym_RBRACK] = ACTIONS(773),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(773),
+    [sym_begin_group] = ACTIONS(773),
+    [sym_end_group] = ACTIONS(773),
+    [sym_math_shift] = ACTIONS(773),
+    [sym_alignment_tab] = ACTIONS(773),
+    [sym_parameter_char] = ACTIONS(773),
+    [sym_superscript] = ACTIONS(773),
+    [sym_subscript] = ACTIONS(773),
+    [sym_active_char] = ACTIONS(773),
+    [sym_text] = ACTIONS(773),
+  },
+  [304] = {
+    [ts_builtin_sym_end] = ACTIONS(775),
+    [anon_sym_LBRACK] = ACTIONS(775),
+    [anon_sym_RBRACK] = ACTIONS(775),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(775),
+    [sym_begin_group] = ACTIONS(775),
+    [sym_end_group] = ACTIONS(775),
+    [sym_math_shift] = ACTIONS(775),
+    [sym_alignment_tab] = ACTIONS(775),
+    [sym_parameter_char] = ACTIONS(775),
+    [sym_superscript] = ACTIONS(775),
+    [sym_subscript] = ACTIONS(775),
+    [sym_active_char] = ACTIONS(775),
+    [sym_text] = ACTIONS(775),
+  },
+  [305] = {
+    [ts_builtin_sym_end] = ACTIONS(777),
+    [anon_sym_LBRACK] = ACTIONS(777),
+    [anon_sym_RBRACK] = ACTIONS(777),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(777),
+    [sym_begin_group] = ACTIONS(777),
+    [sym_end_group] = ACTIONS(777),
+    [sym_math_shift] = ACTIONS(777),
+    [sym_alignment_tab] = ACTIONS(777),
+    [sym_parameter_char] = ACTIONS(777),
+    [sym_superscript] = ACTIONS(777),
+    [sym_subscript] = ACTIONS(777),
+    [sym_active_char] = ACTIONS(777),
+    [sym_text] = ACTIONS(777),
+  },
+  [306] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(779),
+  },
+  [307] = {
+    [ts_builtin_sym_end] = ACTIONS(663),
+    [anon_sym_LBRACK] = ACTIONS(663),
+    [anon_sym_RBRACK] = ACTIONS(663),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(663),
+    [sym_begin_group] = ACTIONS(663),
+    [sym_end_group] = ACTIONS(663),
+    [sym_math_shift] = ACTIONS(663),
+    [sym_alignment_tab] = ACTIONS(663),
+    [sym_parameter_char] = ACTIONS(663),
+    [sym_superscript] = ACTIONS(663),
+    [sym_subscript] = ACTIONS(663),
+    [sym_active_char] = ACTIONS(663),
+    [sym_text] = ACTIONS(663),
+  },
+  [308] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(382),
+  },
+  [309] = {
+    [anon_sym_LBRACK] = ACTIONS(781),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(781),
+    [sym_begin_group] = ACTIONS(781),
+    [sym_alignment_tab] = ACTIONS(781),
+    [sym_parameter_char] = ACTIONS(781),
+    [sym_superscript] = ACTIONS(781),
+    [sym_subscript] = ACTIONS(781),
+    [sym_active_char] = ACTIONS(781),
+    [sym_text] = ACTIONS(781),
+  },
+  [310] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(783),
+  },
+  [311] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(785),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(787),
+    [sym__end_of_line] = ACTIONS(787),
+  },
+  [312] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(789),
+  },
+  [313] = {
+    [anon_sym_LBRACK] = ACTIONS(791),
+    [anon_sym_RBRACK] = ACTIONS(791),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(791),
+    [sym_begin_group] = ACTIONS(791),
+    [sym_end_group] = ACTIONS(791),
+    [sym_math_shift] = ACTIONS(791),
+    [sym_alignment_tab] = ACTIONS(791),
+    [sym_parameter_char] = ACTIONS(791),
+    [sym_superscript] = ACTIONS(791),
+    [sym_subscript] = ACTIONS(791),
+    [sym_active_char] = ACTIONS(791),
+    [sym_text] = ACTIONS(791),
+  },
+  [314] = {
+    [sym__common] = STATE(314),
+    [sym__math_mode_common] = STATE(314),
+    [sym__math_mode_at] = STATE(314),
+    [sym_parameter] = STATE(314),
+    [sym_math_env_at] = STATE(314),
+    [sym_tag_at] = STATE(314),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(314),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(314),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(314),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(314),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(314),
+    [sym_opt_math_group_at] = STATE(314),
+    [sym_token_at] = STATE(314),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(314),
+    [anon_sym_LBRACK] = ACTIONS(722),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(725),
+    [sym_begin_group] = ACTIONS(728),
+    [sym_end_group] = ACTIONS(731),
+    [sym_alignment_tab] = ACTIONS(793),
+    [sym_parameter_char] = ACTIONS(736),
+    [sym_superscript] = ACTIONS(793),
+    [sym_subscript] = ACTIONS(793),
+    [sym_active_char] = ACTIONS(793),
+    [sym_text] = ACTIONS(793),
+  },
+  [315] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(796),
+  },
+  [316] = {
+    [anon_sym_LBRACK] = ACTIONS(798),
+    [anon_sym_RBRACK] = ACTIONS(798),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(798),
+    [sym_begin_group] = ACTIONS(798),
+    [sym_end_group] = ACTIONS(798),
+    [sym_math_shift] = ACTIONS(798),
+    [sym_alignment_tab] = ACTIONS(798),
+    [sym_parameter_char] = ACTIONS(798),
+    [sym_superscript] = ACTIONS(798),
+    [sym_subscript] = ACTIONS(798),
+    [sym_active_char] = ACTIONS(798),
+    [sym_text] = ACTIONS(798),
+  },
+  [317] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(800),
+  },
+  [318] = {
+    [sym__common] = STATE(271),
+    [sym__text_mode_common] = STATE(271),
+    [sym__text_mode_at] = STATE(271),
+    [sym_parameter] = STATE(271),
+    [sym_text_env_at] = STATE(271),
+    [sym__display_math_at] = STATE(271),
+    [sym_tex_display_math_at] = STATE(271),
+    [sym_latex_display_math_at] = STATE(271),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(271),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(271),
+    [sym_tex_inline_math_at] = STATE(271),
+    [sym_latex_inline_math_at] = STATE(271),
+    [sym_inline_math_env_at] = STATE(271),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(271),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(271),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(271),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(271),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(271),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(271),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(271),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(271),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(271),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(271),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(271),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(271),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(271),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(271),
+    [sym_opt_text_group_at] = STATE(271),
+    [sym_token_at] = STATE(271),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(271),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(325),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(533),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(533),
+    [sym_text] = ACTIONS(533),
+  },
+  [319] = {
+    [anon_sym_LBRACK] = ACTIONS(802),
+    [anon_sym_RBRACK] = ACTIONS(802),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(802),
+    [sym_begin_group] = ACTIONS(802),
+    [sym_end_group] = ACTIONS(802),
+    [sym_math_shift] = ACTIONS(802),
+    [sym_alignment_tab] = ACTIONS(802),
+    [sym_parameter_char] = ACTIONS(802),
+    [sym_superscript] = ACTIONS(802),
+    [sym_subscript] = ACTIONS(802),
+    [sym_active_char] = ACTIONS(802),
+    [sym_text] = ACTIONS(802),
+  },
+  [320] = {
+    [anon_sym_LBRACK] = ACTIONS(804),
+    [anon_sym_RBRACK] = ACTIONS(804),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(804),
+    [sym_begin_group] = ACTIONS(804),
+    [sym_end_group] = ACTIONS(804),
+    [sym_math_shift] = ACTIONS(804),
+    [sym_alignment_tab] = ACTIONS(804),
+    [sym_parameter_char] = ACTIONS(804),
+    [sym_superscript] = ACTIONS(804),
+    [sym_subscript] = ACTIONS(804),
+    [sym_active_char] = ACTIONS(804),
+    [sym_text] = ACTIONS(804),
+  },
+  [321] = {
+    [sym__common] = STATE(321),
+    [sym__math_mode_common] = STATE(321),
+    [sym__math_mode_at] = STATE(321),
+    [sym_parameter] = STATE(321),
+    [sym_math_env_at] = STATE(321),
+    [sym_tag_at] = STATE(321),
+    [sym_tag_token] = STATE(202),
+    [sym_escaped] = STATE(321),
+    [sym_begin] = STATE(203),
+    [sym_begin_token] = STATE(57),
+    [sym_include_at] = STATE(321),
+    [sym_include_token] = STATE(108),
+    [sym_storage] = STATE(321),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(321),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(321),
+    [sym_opt_math_group_at] = STATE(321),
+    [sym_token_at] = STATE(321),
+    [sym_begin_opt] = STATE(204),
+    [aux_sym_math_mode_at_repeat1] = STATE(321),
+    [anon_sym_LBRACK] = ACTIONS(722),
+    [anon_sym_RBRACK] = ACTIONS(731),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(725),
+    [sym_begin_group] = ACTIONS(728),
+    [sym_alignment_tab] = ACTIONS(806),
+    [sym_parameter_char] = ACTIONS(736),
+    [sym_superscript] = ACTIONS(806),
+    [sym_subscript] = ACTIONS(806),
+    [sym_active_char] = ACTIONS(806),
+    [sym_text] = ACTIONS(806),
+  },
+  [322] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(529),
+  },
+  [323] = {
+    [sym__common] = STATE(271),
+    [sym__text_mode_common] = STATE(271),
+    [sym__text_mode_at] = STATE(271),
+    [sym_parameter] = STATE(271),
+    [sym_text_env_at] = STATE(271),
+    [sym__display_math_at] = STATE(271),
+    [sym_tex_display_math_at] = STATE(271),
+    [sym_latex_display_math_at] = STATE(271),
+    [sym_begin_display_math] = STATE(102),
+    [sym_begin_inline_math] = STATE(103),
+    [sym_display_math_env_at] = STATE(271),
+    [sym_display_math_begin_at] = STATE(104),
+    [sym__inline_math_at] = STATE(271),
+    [sym_tex_inline_math_at] = STATE(271),
+    [sym_latex_inline_math_at] = STATE(271),
+    [sym_inline_math_env_at] = STATE(271),
+    [sym_inline_math_begin] = STATE(105),
+    [sym_verbatim_env] = STATE(271),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(271),
+    [sym_begin] = STATE(106),
+    [sym_begin_token] = STATE(107),
+    [sym_documentclass] = STATE(271),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(271),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(271),
+    [sym_include_token] = STATE(108),
+    [sym_section_at] = STATE(271),
+    [sym_section_token] = STATE(109),
+    [sym_storage] = STATE(271),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(271),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(271),
+    [sym_emph_token] = STATE(110),
+    [sym_footnote_at] = STATE(271),
+    [sym_footnote_token] = STATE(111),
+    [sym_textbf_at] = STATE(271),
+    [sym_textbf_token] = STATE(112),
+    [sym_textit_at] = STATE(271),
+    [sym_textit_token] = STATE(113),
+    [sym_texttt_at] = STATE(271),
+    [sym_texttt_token] = STATE(114),
+    [sym_text_group_at] = STATE(271),
+    [sym_opt_text_group_at] = STATE(271),
+    [sym_token_at] = STATE(271),
+    [sym_begin_opt] = STATE(117),
+    [aux_sym_text_mode_at_repeat1] = STATE(271),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(103),
+    [sym_end_group] = ACTIONS(809),
+    [sym_math_shift] = ACTIONS(105),
+    [sym_alignment_tab] = ACTIONS(533),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(533),
+    [sym_text] = ACTIONS(533),
+  },
+  [324] = {
+    [anon_sym_LBRACK] = ACTIONS(811),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(811),
+    [sym_begin_group] = ACTIONS(811),
+    [sym_alignment_tab] = ACTIONS(811),
+    [sym_parameter_char] = ACTIONS(811),
+    [sym_superscript] = ACTIONS(811),
+    [sym_subscript] = ACTIONS(811),
+    [sym_active_char] = ACTIONS(811),
+    [sym_text] = ACTIONS(811),
+  },
+  [325] = {
+    [sym_text_group_at] = STATE(337),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(561),
+    [sym__end_of_line] = ACTIONS(813),
+  },
+  [326] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(813),
+  },
+  [327] = {
+    [anon_sym_LBRACK] = ACTIONS(815),
+    [anon_sym_RBRACK] = ACTIONS(815),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(815),
+    [sym_begin_group] = ACTIONS(815),
+    [sym_end_group] = ACTIONS(815),
+    [sym_math_shift] = ACTIONS(815),
+    [sym_alignment_tab] = ACTIONS(815),
+    [sym_parameter_char] = ACTIONS(815),
+    [sym_superscript] = ACTIONS(815),
+    [sym_subscript] = ACTIONS(815),
+    [sym_active_char] = ACTIONS(815),
+    [sym_text] = ACTIONS(815),
+  },
+  [328] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(766),
+    [sym__end_of_line] = ACTIONS(766),
+    [sym__whitespace] = ACTIONS(766),
+  },
+  [329] = {
+    [anon_sym_LBRACK] = ACTIONS(817),
+    [anon_sym_RBRACK] = ACTIONS(817),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(817),
+    [sym_begin_group] = ACTIONS(817),
+    [sym_end_group] = ACTIONS(817),
+    [sym_math_shift] = ACTIONS(817),
+    [sym_alignment_tab] = ACTIONS(817),
+    [sym_parameter_char] = ACTIONS(817),
+    [sym_superscript] = ACTIONS(817),
+    [sym_subscript] = ACTIONS(817),
+    [sym_active_char] = ACTIONS(817),
+    [sym_text] = ACTIONS(817),
+  },
+  [330] = {
+    [ts_builtin_sym_end] = ACTIONS(659),
+    [anon_sym_LBRACK] = ACTIONS(659),
+    [anon_sym_RBRACK] = ACTIONS(659),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(659),
+    [sym_begin_group] = ACTIONS(659),
+    [sym_end_group] = ACTIONS(659),
+    [sym_math_shift] = ACTIONS(659),
+    [sym_alignment_tab] = ACTIONS(659),
+    [sym_parameter_char] = ACTIONS(659),
+    [sym_superscript] = ACTIONS(659),
+    [sym_subscript] = ACTIONS(659),
+    [sym_active_char] = ACTIONS(659),
+    [sym_text] = ACTIONS(659),
+  },
+  [331] = {
+    [anon_sym_LBRACK] = ACTIONS(819),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(819),
+    [sym_begin_group] = ACTIONS(819),
+    [sym_alignment_tab] = ACTIONS(819),
+    [sym_parameter_char] = ACTIONS(819),
+    [sym_superscript] = ACTIONS(819),
+    [sym_subscript] = ACTIONS(819),
+    [sym_active_char] = ACTIONS(819),
+    [sym_text] = ACTIONS(819),
+  },
+  [332] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(821),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(823),
+    [sym__end_of_line] = ACTIONS(823),
+  },
+  [333] = {
+    [anon_sym_LBRACK] = ACTIONS(825),
+    [anon_sym_RBRACK] = ACTIONS(825),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(825),
+    [sym_begin_group] = ACTIONS(825),
+    [sym_end_group] = ACTIONS(825),
+    [sym_math_shift] = ACTIONS(825),
+    [sym_alignment_tab] = ACTIONS(825),
+    [sym_parameter_char] = ACTIONS(825),
+    [sym_superscript] = ACTIONS(825),
+    [sym_subscript] = ACTIONS(825),
+    [sym_active_char] = ACTIONS(825),
+    [sym_text] = ACTIONS(825),
+  },
+  [334] = {
+    [anon_sym_LBRACK] = ACTIONS(827),
+    [anon_sym_RBRACK] = ACTIONS(827),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(827),
+    [sym_begin_group] = ACTIONS(827),
+    [sym_end_group] = ACTIONS(827),
+    [sym_math_shift] = ACTIONS(827),
+    [sym_alignment_tab] = ACTIONS(827),
+    [sym_parameter_char] = ACTIONS(827),
+    [sym_superscript] = ACTIONS(827),
+    [sym_subscript] = ACTIONS(827),
+    [sym_active_char] = ACTIONS(827),
+    [sym_text] = ACTIONS(827),
+  },
+  [335] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(693),
+  },
+  [336] = {
+    [anon_sym_LBRACK] = ACTIONS(829),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(829),
+    [sym_begin_group] = ACTIONS(829),
+    [sym_alignment_tab] = ACTIONS(829),
+    [sym_parameter_char] = ACTIONS(829),
+    [sym_superscript] = ACTIONS(829),
+    [sym_subscript] = ACTIONS(829),
+    [sym_active_char] = ACTIONS(829),
+    [sym_text] = ACTIONS(829),
+  },
+  [337] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(831),
+  },
+  [338] = {
+    [anon_sym_LBRACK] = ACTIONS(833),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(833),
+    [sym_begin_group] = ACTIONS(833),
+    [sym_alignment_tab] = ACTIONS(833),
+    [sym_parameter_char] = ACTIONS(833),
+    [sym_superscript] = ACTIONS(833),
+    [sym_subscript] = ACTIONS(833),
+    [sym_active_char] = ACTIONS(833),
+    [sym_text] = ACTIONS(833),
   },
 };
 
@@ -11333,323 +12196,395 @@ static TSParseActionEntry ts_parse_actions[] = {
   [13] = {.count = 1, .reusable = true}, SHIFT(3),
   [15] = {.count = 1, .reusable = true}, SHIFT(4),
   [17] = {.count = 1, .reusable = true}, SHIFT(5),
-  [19] = {.count = 1, .reusable = true}, SHIFT(30),
+  [19] = {.count = 1, .reusable = true}, SHIFT(31),
   [21] = {.count = 1, .reusable = true}, SHIFT(6),
   [23] = {.count = 1, .reusable = true}, SHIFT(7),
   [25] = {.count = 1, .reusable = true}, REDUCE(sym_begin_opt, 1),
-  [27] = {.count = 1, .reusable = true}, SHIFT(31),
-  [29] = {.count = 1, .reusable = true}, SHIFT(32),
-  [31] = {.count = 1, .reusable = false}, SHIFT(33),
-  [33] = {.count = 1, .reusable = false}, SHIFT(34),
-  [35] = {.count = 1, .reusable = false}, SHIFT(35),
-  [37] = {.count = 1, .reusable = false}, SHIFT(36),
-  [39] = {.count = 1, .reusable = false}, SHIFT(37),
-  [41] = {.count = 1, .reusable = false}, SHIFT(38),
-  [43] = {.count = 1, .reusable = false}, SHIFT(39),
-  [45] = {.count = 1, .reusable = true}, SHIFT(40),
-  [47] = {.count = 1, .reusable = false}, SHIFT(41),
-  [49] = {.count = 1, .reusable = false}, SHIFT(42),
-  [51] = {.count = 1, .reusable = false}, SHIFT(43),
-  [53] = {.count = 1, .reusable = false}, SHIFT(44),
-  [55] = {.count = 1, .reusable = false}, SHIFT(45),
-  [57] = {.count = 1, .reusable = false}, SHIFT(46),
-  [59] = {.count = 1, .reusable = true}, SHIFT(47),
-  [61] = {.count = 1, .reusable = true}, SHIFT(48),
-  [63] = {.count = 1, .reusable = true}, SHIFT(49),
-  [65] = {.count = 1, .reusable = true}, SHIFT(50),
-  [67] = {.count = 1, .reusable = true}, SHIFT(51),
-  [69] = {.count = 1, .reusable = true}, SHIFT(57),
-  [71] = {.count = 1, .reusable = true}, SHIFT(58),
-  [73] = {.count = 1, .reusable = true}, REDUCE(sym__text_mode_common, 1, .alias_sequence_id = 1),
-  [75] = {.count = 1, .reusable = true}, ACCEPT_INPUT(),
-  [77] = {.count = 1, .reusable = true}, REDUCE(sym_document, 1),
-  [79] = {.count = 1, .reusable = true}, SHIFT(60),
-  [81] = {.count = 1, .reusable = false}, SHIFT(68),
-  [83] = {.count = 1, .reusable = true}, SHIFT(64),
-  [85] = {.count = 1, .reusable = true}, SHIFT(69),
-  [87] = {.count = 1, .reusable = true}, SHIFT(70),
-  [89] = {.count = 1, .reusable = true}, SHIFT(73),
-  [91] = {.count = 1, .reusable = true}, SHIFT(74),
-  [93] = {.count = 1, .reusable = true}, SHIFT(79),
-  [95] = {.count = 1, .reusable = true}, REDUCE(sym_storage, 1),
-  [97] = {.count = 1, .reusable = true}, SHIFT(87),
-  [99] = {.count = 1, .reusable = true}, SHIFT(93),
-  [101] = {.count = 1, .reusable = true}, SHIFT(94),
-  [103] = {.count = 1, .reusable = true}, SHIFT(95),
-  [105] = {.count = 1, .reusable = true}, SHIFT(112),
-  [107] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter, 1),
-  [109] = {.count = 1, .reusable = true}, SHIFT(113),
-  [111] = {.count = 1, .reusable = true}, SHIFT(115),
-  [113] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode, 1),
-  [115] = {.count = 1, .reusable = true}, SHIFT(116),
-  [117] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 2),
-  [119] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 2),
-  [121] = {.count = 1, .reusable = true}, REDUCE(sym_escaped, 2),
-  [123] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 2),
-  [125] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 2),
-  [127] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 2),
-  [129] = {.count = 1, .reusable = true}, REDUCE(sym_include_token, 2),
-  [131] = {.count = 1, .reusable = true}, REDUCE(sym_section_token, 2),
-  [133] = {.count = 1, .reusable = true}, REDUCE(sym_storage_token, 2),
-  [135] = {.count = 1, .reusable = true}, REDUCE(sym_catcode_token, 2),
-  [137] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 2),
-  [139] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 2),
-  [141] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 2),
-  [143] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 2),
-  [145] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 2),
-  [147] = {.count = 1, .reusable = true}, REDUCE(sym_token, 2),
-  [149] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 2),
-  [151] = {.count = 1, .reusable = true}, SHIFT(117),
-  [153] = {.count = 1, .reusable = true}, SHIFT(118),
-  [155] = {.count = 1, .reusable = false}, SHIFT(119),
-  [157] = {.count = 1, .reusable = true}, SHIFT(120),
-  [159] = {.count = 1, .reusable = true}, SHIFT(121),
-  [161] = {.count = 1, .reusable = true}, SHIFT(123),
-  [163] = {.count = 1, .reusable = true}, SHIFT(124),
-  [165] = {.count = 1, .reusable = true}, SHIFT(126),
-  [167] = {.count = 1, .reusable = true}, SHIFT(128),
-  [169] = {.count = 1, .reusable = true}, SHIFT(130),
-  [171] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode, 1),
-  [173] = {.count = 1, .reusable = true}, SHIFT(131),
-  [175] = {.count = 1, .reusable = true}, REDUCE(sym_parameter, 2),
-  [177] = {.count = 1, .reusable = true}, SHIFT(132),
-  [179] = {.count = 1, .reusable = true}, SHIFT(134),
-  [181] = {.count = 1, .reusable = true}, SHIFT(135),
-  [183] = {.count = 1, .reusable = true}, SHIFT(141),
-  [185] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 2),
-  [187] = {.count = 1, .reusable = true}, SHIFT(143),
-  [189] = {.count = 1, .reusable = false}, SHIFT(146),
-  [191] = {.count = 1, .reusable = true}, SHIFT(145),
-  [193] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_text, 1),
-  [195] = {.count = 1, .reusable = true}, SHIFT(147),
-  [197] = {.count = 1, .reusable = false}, SHIFT(141),
-  [199] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 2),
-  [201] = {.count = 1, .reusable = true}, SHIFT(150),
-  [203] = {.count = 1, .reusable = false}, SHIFT(151),
-  [205] = {.count = 1, .reusable = false}, SHIFT(152),
-  [207] = {.count = 1, .reusable = false}, SHIFT(153),
-  [209] = {.count = 1, .reusable = false}, SHIFT(154),
-  [211] = {.count = 1, .reusable = true}, SHIFT(155),
-  [213] = {.count = 1, .reusable = true}, SHIFT(156),
-  [215] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_begin, 2),
-  [217] = {.count = 1, .reusable = true}, SHIFT(160),
-  [219] = {.count = 1, .reusable = true}, REDUCE(sym_begin, 2, .alias_sequence_id = 2),
-  [221] = {.count = 1, .reusable = true}, SHIFT(154),
-  [223] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 2, .alias_sequence_id = 3),
-  [225] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 2, .alias_sequence_id = 4),
-  [227] = {.count = 1, .reusable = true}, REDUCE(sym_include, 2),
-  [229] = {.count = 1, .reusable = true}, REDUCE(sym_section, 2),
-  [231] = {.count = 1, .reusable = false}, SHIFT(166),
-  [233] = {.count = 1, .reusable = true}, SHIFT(167),
-  [235] = {.count = 1, .reusable = true}, REDUCE(sym_emph, 2),
-  [237] = {.count = 1, .reusable = true}, REDUCE(sym_textbf, 2),
-  [239] = {.count = 1, .reusable = true}, REDUCE(sym_textit, 2),
-  [241] = {.count = 1, .reusable = true}, REDUCE(sym_texttt, 2),
-  [243] = {.count = 1, .reusable = false}, SHIFT(168),
-  [245] = {.count = 1, .reusable = false}, SHIFT(169),
-  [247] = {.count = 1, .reusable = true}, SHIFT(170),
-  [249] = {.count = 1, .reusable = true}, SHIFT(171),
-  [251] = {.count = 1, .reusable = true}, SHIFT(172),
-  [253] = {.count = 1, .reusable = true}, SHIFT(173),
-  [255] = {.count = 1, .reusable = true}, SHIFT(174),
-  [257] = {.count = 1, .reusable = true}, SHIFT(175),
-  [259] = {.count = 1, .reusable = true}, SHIFT(180),
-  [261] = {.count = 1, .reusable = true}, SHIFT(181),
-  [263] = {.count = 1, .reusable = true}, SHIFT(184),
-  [265] = {.count = 1, .reusable = true}, SHIFT(188),
-  [267] = {.count = 1, .reusable = true}, SHIFT(190),
-  [269] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 2),
-  [271] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother, 1),
-  [273] = {.count = 1, .reusable = true}, SHIFT(200),
-  [275] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at, 1),
-  [277] = {.count = 1, .reusable = true}, SHIFT(201),
-  [279] = {.count = 1, .reusable = true}, REDUCE(sym_end_opt, 1),
-  [281] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 2),
-  [283] = {.count = 1, .reusable = true}, SHIFT(203),
-  [285] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2),
-  [287] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(2),
-  [290] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(3),
-  [293] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(4),
-  [296] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(5),
-  [299] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(116),
-  [302] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(6),
-  [305] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(7),
-  [308] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 3),
-  [310] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(118),
-  [313] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 2),
-  [315] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 2),
-  [317] = {.count = 1, .reusable = true}, SHIFT(204),
-  [319] = {.count = 1, .reusable = true}, SHIFT(205),
-  [321] = {.count = 1, .reusable = true}, SHIFT(206),
-  [323] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math, 3),
-  [325] = {.count = 1, .reusable = true}, SHIFT(207),
-  [327] = {.count = 1, .reusable = true}, SHIFT(209),
-  [329] = {.count = 1, .reusable = true}, REDUCE(sym_tag, 2),
-  [331] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 2),
-  [333] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 2),
-  [335] = {.count = 1, .reusable = true}, SHIFT(212),
-  [337] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(2),
-  [340] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(49),
-  [343] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(50),
-  [346] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2),
-  [348] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(131),
-  [351] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(6),
-  [354] = {.count = 1, .reusable = true}, SHIFT(213),
-  [356] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math, 3),
-  [358] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(134),
-  [361] = {.count = 1, .reusable = true}, SHIFT(214),
-  [363] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math, 3),
-  [365] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env, 3),
-  [367] = {.count = 1, .reusable = true}, SHIFT(215),
-  [369] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env, 3),
-  [371] = {.count = 1, .reusable = true}, SHIFT(217),
-  [373] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 2),
-  [375] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 3),
-  [377] = {.count = 1, .reusable = true}, SHIFT(219),
-  [379] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_end, 2),
-  [381] = {.count = 1, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
-  [383] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
-  [385] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat1, 2), SHIFT_REPEAT(146),
-  [388] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat1, 2),
-  [390] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(68),
-  [393] = {.count = 2, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(147),
-  [396] = {.count = 1, .reusable = true}, REDUCE(sym_end, 2, .alias_sequence_id = 2),
-  [398] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 3),
-  [400] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(150),
-  [403] = {.count = 1, .reusable = true}, SHIFT(220),
-  [405] = {.count = 1, .reusable = true}, SHIFT(221),
-  [407] = {.count = 1, .reusable = true}, SHIFT(222),
-  [409] = {.count = 1, .reusable = true}, SHIFT(223),
-  [411] = {.count = 1, .reusable = true}, SHIFT(224),
-  [413] = {.count = 1, .reusable = true}, SHIFT(225),
-  [415] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 3),
-  [417] = {.count = 1, .reusable = true}, SHIFT(226),
-  [419] = {.count = 1, .reusable = true}, SHIFT(228),
-  [421] = {.count = 1, .reusable = true}, SHIFT(230),
-  [423] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 3),
-  [425] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 3),
-  [427] = {.count = 1, .reusable = true}, SHIFT(231),
-  [429] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 3, .alias_sequence_id = 5),
-  [431] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 3, .alias_sequence_id = 6),
-  [433] = {.count = 1, .reusable = true}, REDUCE(sym_section, 3),
-  [435] = {.count = 1, .reusable = true}, SHIFT(233),
-  [437] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 2),
-  [439] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 2),
-  [441] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 2),
-  [443] = {.count = 1, .reusable = true}, SHIFT(234),
-  [445] = {.count = 1, .reusable = true}, SHIFT(235),
-  [447] = {.count = 1, .reusable = true}, SHIFT(236),
-  [449] = {.count = 1, .reusable = true}, SHIFT(237),
-  [451] = {.count = 1, .reusable = true}, SHIFT(239),
-  [453] = {.count = 1, .reusable = true}, SHIFT(240),
-  [455] = {.count = 1, .reusable = true}, SHIFT(242),
-  [457] = {.count = 1, .reusable = true}, SHIFT(244),
-  [459] = {.count = 1, .reusable = true}, SHIFT(246),
-  [461] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode_at, 1),
-  [463] = {.count = 1, .reusable = true}, SHIFT(247),
-  [465] = {.count = 1, .reusable = true}, SHIFT(168),
-  [467] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 3),
-  [469] = {.count = 1, .reusable = true}, SHIFT(249),
-  [471] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 2),
-  [473] = {.count = 1, .reusable = true}, SHIFT(254),
-  [475] = {.count = 1, .reusable = true}, SHIFT(255),
-  [477] = {.count = 1, .reusable = true}, REDUCE(sym_include_at, 2),
-  [479] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 2),
-  [481] = {.count = 1, .reusable = true}, REDUCE(sym_emph_at, 2),
-  [483] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_at, 2),
-  [485] = {.count = 1, .reusable = true}, REDUCE(sym_textit_at, 2),
-  [487] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_at, 2),
-  [489] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 2),
-  [491] = {.count = 1, .reusable = true}, SHIFT(261),
-  [493] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(2),
-  [496] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(170),
-  [499] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(94),
-  [502] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(95),
-  [505] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(201),
-  [508] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(6),
-  [511] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(7),
-  [514] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 3),
-  [516] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(203),
-  [519] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 3),
-  [521] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(205),
-  [524] = {.count = 1, .reusable = true}, SHIFT(262),
-  [526] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 2),
-  [528] = {.count = 1, .reusable = true}, SHIFT(263),
-  [530] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 3),
-  [532] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 3),
-  [534] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(212),
-  [537] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 2),
-  [539] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 2),
-  [541] = {.count = 1, .reusable = true}, SHIFT(264),
-  [543] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_end, 2),
-  [545] = {.count = 1, .reusable = true}, SHIFT(152),
-  [547] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_end, 2),
-  [549] = {.count = 1, .reusable = true}, SHIFT(265),
-  [551] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_group, 3),
-  [553] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_group, 3),
-  [555] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env_group, 3),
-  [557] = {.count = 1, .reusable = true}, REDUCE(sym_simple_text_group, 3),
-  [559] = {.count = 1, .reusable = true}, SHIFT(266),
-  [561] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 4),
-  [563] = {.count = 1, .reusable = true}, SHIFT(267),
-  [565] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 4),
-  [567] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 4),
-  [569] = {.count = 1, .reusable = true}, SHIFT(269),
-  [571] = {.count = 1, .reusable = true}, REDUCE(sym_catcode, 4),
-  [573] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 3),
-  [575] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2),
-  [577] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(235),
-  [580] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 2),
-  [582] = {.count = 1, .reusable = true}, SHIFT(270),
-  [584] = {.count = 1, .reusable = true}, SHIFT(271),
-  [586] = {.count = 1, .reusable = true}, SHIFT(272),
-  [588] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math_at, 3),
-  [590] = {.count = 1, .reusable = true}, SHIFT(273),
-  [592] = {.count = 1, .reusable = true}, SHIFT(275),
-  [594] = {.count = 1, .reusable = true}, REDUCE(sym_tag_at, 2),
-  [596] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 2),
-  [598] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 2),
-  [600] = {.count = 1, .reusable = true}, SHIFT(278),
-  [602] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(2),
-  [605] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(173),
-  [608] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(174),
-  [611] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2),
-  [613] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(247),
-  [616] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(6),
-  [619] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math_at, 3),
-  [621] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(249),
-  [624] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math_at, 3),
-  [626] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_at, 3),
-  [628] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_at, 3),
-  [630] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 3),
-  [632] = {.count = 1, .reusable = true}, SHIFT(279),
-  [634] = {.count = 1, .reusable = true}, SHIFT(280),
-  [636] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 3),
-  [638] = {.count = 1, .reusable = true}, SHIFT(281),
-  [640] = {.count = 1, .reusable = true}, SHIFT(284),
-  [642] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 3),
-  [644] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 3),
-  [646] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(261),
-  [649] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math, 5),
-  [651] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 3),
-  [653] = {.count = 1, .reusable = true}, SHIFT(285),
-  [655] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 5),
-  [657] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 5),
-  [659] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 5),
-  [661] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 3),
-  [663] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(271),
-  [666] = {.count = 1, .reusable = true}, SHIFT(286),
-  [668] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 2),
-  [670] = {.count = 1, .reusable = true}, SHIFT(287),
-  [672] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 3),
-  [674] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 3),
-  [676] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(278),
-  [679] = {.count = 1, .reusable = true}, SHIFT(288),
-  [681] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 4),
-  [683] = {.count = 1, .reusable = true}, SHIFT(289),
-  [685] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math_at, 5),
-  [687] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 3),
-  [689] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 5),
+  [27] = {.count = 1, .reusable = true}, SHIFT(32),
+  [29] = {.count = 1, .reusable = true}, SHIFT(33),
+  [31] = {.count = 1, .reusable = false}, SHIFT(34),
+  [33] = {.count = 1, .reusable = false}, SHIFT(35),
+  [35] = {.count = 1, .reusable = false}, SHIFT(36),
+  [37] = {.count = 1, .reusable = false}, SHIFT(37),
+  [39] = {.count = 1, .reusable = false}, SHIFT(38),
+  [41] = {.count = 1, .reusable = false}, SHIFT(39),
+  [43] = {.count = 1, .reusable = false}, SHIFT(40),
+  [45] = {.count = 1, .reusable = true}, SHIFT(41),
+  [47] = {.count = 1, .reusable = false}, SHIFT(42),
+  [49] = {.count = 1, .reusable = false}, SHIFT(43),
+  [51] = {.count = 1, .reusable = false}, SHIFT(44),
+  [53] = {.count = 1, .reusable = false}, SHIFT(45),
+  [55] = {.count = 1, .reusable = false}, SHIFT(46),
+  [57] = {.count = 1, .reusable = false}, SHIFT(47),
+  [59] = {.count = 1, .reusable = false}, SHIFT(48),
+  [61] = {.count = 1, .reusable = true}, SHIFT(49),
+  [63] = {.count = 1, .reusable = true}, SHIFT(50),
+  [65] = {.count = 1, .reusable = true}, SHIFT(51),
+  [67] = {.count = 1, .reusable = true}, SHIFT(52),
+  [69] = {.count = 1, .reusable = true}, SHIFT(53),
+  [71] = {.count = 1, .reusable = true}, SHIFT(59),
+  [73] = {.count = 1, .reusable = true}, SHIFT(60),
+  [75] = {.count = 1, .reusable = true}, REDUCE(sym__text_mode_common, 1, .alias_sequence_id = 1),
+  [77] = {.count = 1, .reusable = true}, ACCEPT_INPUT(),
+  [79] = {.count = 1, .reusable = true}, REDUCE(sym_document, 1),
+  [81] = {.count = 1, .reusable = true}, SHIFT(62),
+  [83] = {.count = 1, .reusable = false}, SHIFT(70),
+  [85] = {.count = 1, .reusable = true}, SHIFT(66),
+  [87] = {.count = 1, .reusable = true}, SHIFT(71),
+  [89] = {.count = 1, .reusable = true}, SHIFT(72),
+  [91] = {.count = 1, .reusable = true}, SHIFT(75),
+  [93] = {.count = 1, .reusable = true}, SHIFT(76),
+  [95] = {.count = 1, .reusable = true}, SHIFT(81),
+  [97] = {.count = 1, .reusable = true}, REDUCE(sym_storage, 1),
+  [99] = {.count = 1, .reusable = true}, SHIFT(90),
+  [101] = {.count = 1, .reusable = true}, SHIFT(98),
+  [103] = {.count = 1, .reusable = true}, SHIFT(99),
+  [105] = {.count = 1, .reusable = true}, SHIFT(100),
+  [107] = {.count = 1, .reusable = true}, SHIFT(118),
+  [109] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter, 1),
+  [111] = {.count = 1, .reusable = true}, SHIFT(119),
+  [113] = {.count = 1, .reusable = true}, SHIFT(121),
+  [115] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode, 1),
+  [117] = {.count = 1, .reusable = true}, SHIFT(122),
+  [119] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 2),
+  [121] = {.count = 1, .reusable = false}, SHIFT(123),
+  [123] = {.count = 1, .reusable = false}, REDUCE(sym_begin_display_math, 2),
+  [125] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 2),
+  [127] = {.count = 1, .reusable = false}, SHIFT(124),
+  [129] = {.count = 1, .reusable = false}, REDUCE(sym_begin_inline_math, 2),
+  [131] = {.count = 1, .reusable = true}, REDUCE(sym_escaped, 2),
+  [133] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 2),
+  [135] = {.count = 1, .reusable = true}, SHIFT(125),
+  [137] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 2),
+  [139] = {.count = 1, .reusable = true}, SHIFT(126),
+  [141] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 2),
+  [143] = {.count = 1, .reusable = true}, SHIFT(127),
+  [145] = {.count = 1, .reusable = true}, REDUCE(sym_include_token, 2),
+  [147] = {.count = 1, .reusable = true}, REDUCE(sym_section_token, 2),
+  [149] = {.count = 1, .reusable = true}, REDUCE(sym_storage_token, 2),
+  [151] = {.count = 1, .reusable = true}, REDUCE(sym_catcode_token, 2),
+  [153] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 2),
+  [155] = {.count = 1, .reusable = true}, SHIFT(128),
+  [157] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_token, 2),
+  [159] = {.count = 1, .reusable = true}, SHIFT(129),
+  [161] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 2),
+  [163] = {.count = 1, .reusable = true}, SHIFT(130),
+  [165] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 2),
+  [167] = {.count = 1, .reusable = true}, SHIFT(131),
+  [169] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 2),
+  [171] = {.count = 1, .reusable = true}, SHIFT(132),
+  [173] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 2),
+  [175] = {.count = 1, .reusable = false}, SHIFT(133),
+  [177] = {.count = 1, .reusable = false}, REDUCE(sym_makeatletter_token, 2),
+  [179] = {.count = 1, .reusable = true}, REDUCE(sym_token, 2),
+  [181] = {.count = 1, .reusable = false}, SHIFT(134),
+  [183] = {.count = 1, .reusable = false}, REDUCE(sym_token, 2),
+  [185] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 2),
+  [187] = {.count = 1, .reusable = true}, SHIFT(135),
+  [189] = {.count = 1, .reusable = true}, SHIFT(136),
+  [191] = {.count = 1, .reusable = false}, SHIFT(137),
+  [193] = {.count = 1, .reusable = true}, SHIFT(138),
+  [195] = {.count = 1, .reusable = true}, SHIFT(139),
+  [197] = {.count = 1, .reusable = true}, SHIFT(141),
+  [199] = {.count = 1, .reusable = true}, SHIFT(142),
+  [201] = {.count = 1, .reusable = true}, SHIFT(144),
+  [203] = {.count = 1, .reusable = true}, SHIFT(146),
+  [205] = {.count = 1, .reusable = true}, SHIFT(148),
+  [207] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode, 1),
+  [209] = {.count = 1, .reusable = true}, SHIFT(149),
+  [211] = {.count = 1, .reusable = true}, REDUCE(sym_parameter, 2),
+  [213] = {.count = 1, .reusable = true}, SHIFT(150),
+  [215] = {.count = 1, .reusable = true}, SHIFT(152),
+  [217] = {.count = 1, .reusable = true}, SHIFT(153),
+  [219] = {.count = 1, .reusable = true}, SHIFT(159),
+  [221] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 2),
+  [223] = {.count = 1, .reusable = true}, SHIFT(161),
+  [225] = {.count = 1, .reusable = false}, SHIFT(164),
+  [227] = {.count = 1, .reusable = true}, SHIFT(163),
+  [229] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_text, 1),
+  [231] = {.count = 1, .reusable = true}, SHIFT(165),
+  [233] = {.count = 1, .reusable = false}, SHIFT(159),
+  [235] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 2),
+  [237] = {.count = 1, .reusable = true}, SHIFT(168),
+  [239] = {.count = 1, .reusable = false}, SHIFT(169),
+  [241] = {.count = 1, .reusable = false}, SHIFT(170),
+  [243] = {.count = 1, .reusable = false}, SHIFT(171),
+  [245] = {.count = 1, .reusable = false}, SHIFT(172),
+  [247] = {.count = 1, .reusable = true}, SHIFT(173),
+  [249] = {.count = 1, .reusable = true}, SHIFT(174),
+  [251] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_begin, 2),
+  [253] = {.count = 1, .reusable = true}, SHIFT(177),
+  [255] = {.count = 1, .reusable = true}, REDUCE(sym_begin, 2, .alias_sequence_id = 2),
+  [257] = {.count = 1, .reusable = true}, SHIFT(172),
+  [259] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 2, .alias_sequence_id = 3),
+  [261] = {.count = 1, .reusable = true}, SHIFT(180),
+  [263] = {.count = 1, .reusable = true}, SHIFT(182),
+  [265] = {.count = 1, .reusable = true}, SHIFT(184),
+  [267] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 2, .alias_sequence_id = 4),
+  [269] = {.count = 1, .reusable = true}, SHIFT(185),
+  [271] = {.count = 1, .reusable = true}, REDUCE(sym_include, 2),
+  [273] = {.count = 1, .reusable = true}, REDUCE(sym_section, 2),
+  [275] = {.count = 1, .reusable = true}, SHIFT(187),
+  [277] = {.count = 1, .reusable = false}, SHIFT(189),
+  [279] = {.count = 1, .reusable = true}, SHIFT(190),
+  [281] = {.count = 1, .reusable = true}, REDUCE(sym_emph, 2),
+  [283] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 2),
+  [285] = {.count = 1, .reusable = true}, SHIFT(191),
+  [287] = {.count = 1, .reusable = true}, REDUCE(sym_textbf, 2),
+  [289] = {.count = 1, .reusable = true}, REDUCE(sym_textit, 2),
+  [291] = {.count = 1, .reusable = true}, REDUCE(sym_texttt, 2),
+  [293] = {.count = 1, .reusable = false}, SHIFT(193),
+  [295] = {.count = 1, .reusable = false}, SHIFT(194),
+  [297] = {.count = 1, .reusable = true}, SHIFT(195),
+  [299] = {.count = 1, .reusable = true}, SHIFT(196),
+  [301] = {.count = 1, .reusable = true}, SHIFT(197),
+  [303] = {.count = 1, .reusable = true}, SHIFT(198),
+  [305] = {.count = 1, .reusable = true}, SHIFT(199),
+  [307] = {.count = 1, .reusable = true}, SHIFT(200),
+  [309] = {.count = 1, .reusable = true}, SHIFT(205),
+  [311] = {.count = 1, .reusable = true}, SHIFT(206),
+  [313] = {.count = 1, .reusable = true}, SHIFT(209),
+  [315] = {.count = 1, .reusable = true}, SHIFT(213),
+  [317] = {.count = 1, .reusable = true}, SHIFT(215),
+  [319] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 2),
+  [321] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother, 1),
+  [323] = {.count = 1, .reusable = true}, SHIFT(228),
+  [325] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at, 1),
+  [327] = {.count = 1, .reusable = true}, SHIFT(229),
+  [329] = {.count = 1, .reusable = true}, REDUCE(sym_end_opt, 1),
+  [331] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 2),
+  [333] = {.count = 1, .reusable = true}, SHIFT(231),
+  [335] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2),
+  [337] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(2),
+  [340] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(3),
+  [343] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(4),
+  [346] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(5),
+  [349] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(122),
+  [352] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(6),
+  [355] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(7),
+  [358] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 3),
+  [360] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 3),
+  [362] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 3),
+  [364] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 3),
+  [366] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 3),
+  [368] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 3),
+  [370] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_token, 3),
+  [372] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 3),
+  [374] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 3),
+  [376] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 3),
+  [378] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 3),
+  [380] = {.count = 1, .reusable = true}, REDUCE(sym_token, 3),
+  [382] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 3),
+  [384] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(136),
+  [387] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 2),
+  [389] = {.count = 1, .reusable = true}, SHIFT(232),
+  [391] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 2),
+  [393] = {.count = 1, .reusable = true}, SHIFT(233),
+  [395] = {.count = 1, .reusable = true}, SHIFT(234),
+  [397] = {.count = 1, .reusable = true}, SHIFT(235),
+  [399] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math, 3),
+  [401] = {.count = 1, .reusable = true}, SHIFT(236),
+  [403] = {.count = 1, .reusable = true}, SHIFT(238),
+  [405] = {.count = 1, .reusable = true}, REDUCE(sym_tag, 2),
+  [407] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 2),
+  [409] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 2),
+  [411] = {.count = 1, .reusable = true}, SHIFT(241),
+  [413] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(2),
+  [416] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(51),
+  [419] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(52),
+  [422] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2),
+  [424] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(149),
+  [427] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(6),
+  [430] = {.count = 1, .reusable = true}, SHIFT(242),
+  [432] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math, 3),
+  [434] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(152),
+  [437] = {.count = 1, .reusable = true}, SHIFT(243),
+  [439] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math, 3),
+  [441] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env, 3),
+  [443] = {.count = 1, .reusable = true}, SHIFT(244),
+  [445] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env, 3),
+  [447] = {.count = 1, .reusable = true}, SHIFT(246),
+  [449] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 2),
+  [451] = {.count = 1, .reusable = true}, SHIFT(248),
+  [453] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 3),
+  [455] = {.count = 1, .reusable = true}, SHIFT(249),
+  [457] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_end, 2),
+  [459] = {.count = 1, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
+  [461] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
+  [463] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat1, 2), SHIFT_REPEAT(164),
+  [466] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat1, 2),
+  [468] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(70),
+  [471] = {.count = 2, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(165),
+  [474] = {.count = 1, .reusable = true}, REDUCE(sym_end, 2, .alias_sequence_id = 2),
+  [476] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 3),
+  [478] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(168),
+  [481] = {.count = 1, .reusable = true}, SHIFT(250),
+  [483] = {.count = 1, .reusable = true}, SHIFT(251),
+  [485] = {.count = 1, .reusable = true}, SHIFT(252),
+  [487] = {.count = 1, .reusable = true}, SHIFT(253),
+  [489] = {.count = 1, .reusable = true}, SHIFT(254),
+  [491] = {.count = 1, .reusable = true}, SHIFT(255),
+  [493] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 3),
+  [495] = {.count = 1, .reusable = true}, SHIFT(256),
+  [497] = {.count = 1, .reusable = true}, SHIFT(257),
+  [499] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 3),
+  [501] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 3),
+  [503] = {.count = 1, .reusable = true}, SHIFT(259),
+  [505] = {.count = 1, .reusable = true}, SHIFT(260),
+  [507] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 3, .alias_sequence_id = 5),
+  [509] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 3, .alias_sequence_id = 6),
+  [511] = {.count = 1, .reusable = true}, REDUCE(sym_section, 3),
+  [513] = {.count = 1, .reusable = true}, SHIFT(266),
+  [515] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 3),
+  [517] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 2),
+  [519] = {.count = 1, .reusable = false}, SHIFT(268),
+  [521] = {.count = 1, .reusable = false}, REDUCE(sym_makeatother_token, 2),
+  [523] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 2),
+  [525] = {.count = 1, .reusable = false}, SHIFT(269),
+  [527] = {.count = 1, .reusable = false}, REDUCE(sym_token_at, 2),
+  [529] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 2),
+  [531] = {.count = 1, .reusable = true}, SHIFT(270),
+  [533] = {.count = 1, .reusable = true}, SHIFT(271),
+  [535] = {.count = 1, .reusable = true}, SHIFT(272),
+  [537] = {.count = 1, .reusable = true}, SHIFT(273),
+  [539] = {.count = 1, .reusable = true}, SHIFT(275),
+  [541] = {.count = 1, .reusable = true}, SHIFT(276),
+  [543] = {.count = 1, .reusable = true}, SHIFT(278),
+  [545] = {.count = 1, .reusable = true}, SHIFT(280),
+  [547] = {.count = 1, .reusable = true}, SHIFT(282),
+  [549] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode_at, 1),
+  [551] = {.count = 1, .reusable = true}, SHIFT(283),
+  [553] = {.count = 1, .reusable = true}, SHIFT(193),
+  [555] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 3),
+  [557] = {.count = 1, .reusable = true}, SHIFT(285),
+  [559] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 2),
+  [561] = {.count = 1, .reusable = true}, SHIFT(290),
+  [563] = {.count = 1, .reusable = true}, SHIFT(291),
+  [565] = {.count = 1, .reusable = true}, REDUCE(sym_include_at, 2),
+  [567] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 2),
+  [569] = {.count = 1, .reusable = true}, SHIFT(294),
+  [571] = {.count = 1, .reusable = true}, SHIFT(297),
+  [573] = {.count = 1, .reusable = true}, REDUCE(sym_emph_at, 2),
+  [575] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 2),
+  [577] = {.count = 1, .reusable = true}, SHIFT(298),
+  [579] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_at, 2),
+  [581] = {.count = 1, .reusable = true}, REDUCE(sym_textit_at, 2),
+  [583] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_at, 2),
+  [585] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 2),
+  [587] = {.count = 1, .reusable = true}, SHIFT(301),
+  [589] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(2),
+  [592] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(195),
+  [595] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(99),
+  [598] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(100),
+  [601] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(229),
+  [604] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(6),
+  [607] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(7),
+  [610] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 3),
+  [612] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(231),
+  [615] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 3),
+  [617] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 3),
+  [619] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(234),
+  [622] = {.count = 1, .reusable = true}, SHIFT(302),
+  [624] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 2),
+  [626] = {.count = 1, .reusable = true}, SHIFT(303),
+  [628] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 3),
+  [630] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 3),
+  [632] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(241),
+  [635] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 2),
+  [637] = {.count = 1, .reusable = false}, SHIFT(304),
+  [639] = {.count = 1, .reusable = false}, REDUCE(sym_end_display_math, 2),
+  [641] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 2),
+  [643] = {.count = 1, .reusable = false}, SHIFT(305),
+  [645] = {.count = 1, .reusable = false}, REDUCE(sym_end_inline_math, 2),
+  [647] = {.count = 1, .reusable = true}, SHIFT(306),
+  [649] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_end, 2),
+  [651] = {.count = 1, .reusable = true}, SHIFT(170),
+  [653] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_end, 2),
+  [655] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 3),
+  [657] = {.count = 1, .reusable = true}, SHIFT(307),
+  [659] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_group, 3),
+  [661] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_group, 3),
+  [663] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env_group, 3),
+  [665] = {.count = 1, .reusable = true}, REDUCE(sym_simple_text_group, 3),
+  [667] = {.count = 1, .reusable = true}, SHIFT(308),
+  [669] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 4),
+  [671] = {.count = 1, .reusable = true}, SHIFT(309),
+  [673] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 4),
+  [675] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 4),
+  [677] = {.count = 1, .reusable = true}, SHIFT(311),
+  [679] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 4, .alias_sequence_id = 7),
+  [681] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 4, .alias_sequence_id = 8),
+  [683] = {.count = 1, .reusable = true}, REDUCE(sym_section, 4),
+  [685] = {.count = 1, .reusable = true}, REDUCE(sym_catcode, 4),
+  [687] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 4),
+  [689] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 3),
+  [691] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 3),
+  [693] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 3),
+  [695] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2),
+  [697] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(271),
+  [700] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 2),
+  [702] = {.count = 1, .reusable = true}, SHIFT(313),
+  [704] = {.count = 1, .reusable = true}, SHIFT(314),
+  [706] = {.count = 1, .reusable = true}, SHIFT(315),
+  [708] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math_at, 3),
+  [710] = {.count = 1, .reusable = true}, SHIFT(316),
+  [712] = {.count = 1, .reusable = true}, SHIFT(318),
+  [714] = {.count = 1, .reusable = true}, REDUCE(sym_tag_at, 2),
+  [716] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 2),
+  [718] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 2),
+  [720] = {.count = 1, .reusable = true}, SHIFT(321),
+  [722] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(2),
+  [725] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(198),
+  [728] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(199),
+  [731] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2),
+  [733] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(283),
+  [736] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(6),
+  [739] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math_at, 3),
+  [741] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(285),
+  [744] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math_at, 3),
+  [746] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_at, 3),
+  [748] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_at, 3),
+  [750] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 3),
+  [752] = {.count = 1, .reusable = true}, SHIFT(322),
+  [754] = {.count = 1, .reusable = true}, SHIFT(323),
+  [756] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 3),
+  [758] = {.count = 1, .reusable = true}, SHIFT(324),
+  [760] = {.count = 1, .reusable = true}, SHIFT(325),
+  [762] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 3),
+  [764] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 3),
+  [766] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 3),
+  [768] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(301),
+  [771] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math, 5),
+  [773] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 3),
+  [775] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 3),
+  [777] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 3),
+  [779] = {.count = 1, .reusable = true}, SHIFT(330),
+  [781] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 5),
+  [783] = {.count = 1, .reusable = true}, SHIFT(331),
+  [785] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 5),
+  [787] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 5),
+  [789] = {.count = 1, .reusable = true}, SHIFT(332),
+  [791] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 3),
+  [793] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(314),
+  [796] = {.count = 1, .reusable = true}, SHIFT(333),
+  [798] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 2),
+  [800] = {.count = 1, .reusable = true}, SHIFT(334),
+  [802] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 3),
+  [804] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 3),
+  [806] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(321),
+  [809] = {.count = 1, .reusable = true}, SHIFT(335),
+  [811] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 4),
+  [813] = {.count = 1, .reusable = true}, SHIFT(336),
+  [815] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 4),
+  [817] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 4),
+  [819] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 6),
+  [821] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 6),
+  [823] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 6),
+  [825] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math_at, 5),
+  [827] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 3),
+  [829] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 5),
+  [831] = {.count = 1, .reusable = true}, SHIFT(338),
+  [833] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 6),
 };
 
 #ifdef _WIN32

--- a/src/parser.c
+++ b/src/parser.c
@@ -6,18 +6,18 @@
 #endif
 
 #define LANGUAGE_VERSION 9
-#define STATE_COUNT 300
-#define SYMBOL_COUNT 160
+#define STATE_COUNT 346
+#define SYMBOL_COUNT 162
 #define ALIAS_COUNT 4
-#define TOKEN_COUNT 46
+#define TOKEN_COUNT 47
 #define EXTERNAL_TOKEN_COUNT 2
-#define MAX_ALIAS_SEQUENCE_LENGTH 3
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
 
 enum {
   sym_verb_body = 1,
   sym_verb_delim = 2,
   anon_sym_verb = 3,
-  aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH = 4,
+  sym__whitespace = 4,
   anon_sym_LBRACK = 5,
   anon_sym_RBRACK = 6,
   anon_sym_LPAREN = 7,
@@ -38,33 +38,33 @@ enum {
   anon_sym_EQ = 22,
   aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH = 23,
   anon_sym_emph = 24,
-  anon_sym_textbf = 25,
-  anon_sym_textit = 26,
-  anon_sym_texttt = 27,
-  anon_sym_makeatletter = 28,
-  anon_sym_makeatother = 29,
-  sym_magic_comment = 30,
-  sym_comment = 31,
-  sym__escape = 32,
-  sym_begin_group = 33,
-  sym_end_group = 34,
-  sym_math_shift = 35,
-  sym_alignment_tab = 36,
-  sym__end_of_line = 37,
-  sym_parameter_char = 38,
-  sym_superscript = 39,
-  sym_subscript = 40,
-  sym__name = 41,
-  sym__name_at = 42,
-  sym_active_char = 43,
-  sym_text = 44,
-  sym_number = 45,
-  sym_document = 46,
-  sym__common = 47,
-  sym__text_mode_common = 48,
-  sym_inline_verbatim = 49,
-  sym_verb_token = 50,
-  sym__whitespace = 51,
+  anon_sym_footnote = 25,
+  anon_sym_textbf = 26,
+  anon_sym_textit = 27,
+  anon_sym_texttt = 28,
+  anon_sym_makeatletter = 29,
+  anon_sym_makeatother = 30,
+  sym_magic_comment = 31,
+  sym_comment = 32,
+  sym__escape = 33,
+  sym_begin_group = 34,
+  sym_end_group = 35,
+  sym_math_shift = 36,
+  sym_alignment_tab = 37,
+  sym__end_of_line = 38,
+  sym_parameter_char = 39,
+  sym_superscript = 40,
+  sym_subscript = 41,
+  sym__name = 42,
+  sym__name_at = 43,
+  sym_active_char = 44,
+  sym_text = 45,
+  sym_number = 46,
+  sym_document = 47,
+  sym__common = 48,
+  sym__text_mode_common = 49,
+  sym_inline_verbatim = 50,
+  sym_verb_token = 51,
   sym__text_mode = 52,
   sym_text_mode = 53,
   sym__text_mode_at = 54,
@@ -137,46 +137,48 @@ enum {
   sym_emph = 121,
   sym_emph_at = 122,
   sym_emph_token = 123,
-  sym_textbf = 124,
-  sym_textbf_at = 125,
-  sym_textbf_token = 126,
-  sym_textit = 127,
-  sym_textit_at = 128,
-  sym_textit_token = 129,
-  sym_texttt = 130,
-  sym_texttt_at = 131,
-  sym_texttt_token = 132,
-  sym_makeatletter = 133,
-  sym_makeatletter_token = 134,
-  sym_makeatother = 135,
-  sym_makeatother_token = 136,
-  sym_text_group = 137,
-  sym_text_group_at = 138,
-  sym_simple_text_group = 139,
-  sym_opt_text_group = 140,
-  sym_opt_text_group_at = 141,
-  sym_math_group = 142,
-  sym_math_group_at = 143,
-  sym_opt_math_group = 144,
-  sym_opt_math_group_at = 145,
-  sym_math_text_group = 146,
-  sym_math_text_group_at = 147,
-  sym_token = 148,
-  sym_token_at = 149,
-  sym_begin_opt = 150,
-  sym_end_opt = 151,
-  aux_sym__whitespace_repeat1 = 152,
-  aux_sym_text_mode_repeat1 = 153,
-  aux_sym_text_mode_at_repeat1 = 154,
-  aux_sym_math_mode_repeat1 = 155,
-  aux_sym_math_mode_at_repeat1 = 156,
-  aux_sym_parameter_repeat1 = 157,
-  aux_sym_verbatim_text_repeat1 = 158,
-  aux_sym_verbatim_text_repeat2 = 159,
-  anon_alias_sym_class_name = 160,
-  anon_alias_sym_env_name = 161,
-  anon_alias_sym_package_name = 162,
-  anon_alias_sym_text = 163,
+  sym_footnote = 124,
+  sym_footnote_at = 125,
+  sym_footnote_token = 126,
+  sym_textbf = 127,
+  sym_textbf_at = 128,
+  sym_textbf_token = 129,
+  sym_textit = 130,
+  sym_textit_at = 131,
+  sym_textit_token = 132,
+  sym_texttt = 133,
+  sym_texttt_at = 134,
+  sym_texttt_token = 135,
+  sym_makeatletter = 136,
+  sym_makeatletter_token = 137,
+  sym_makeatother = 138,
+  sym_makeatother_token = 139,
+  sym_text_group = 140,
+  sym_text_group_at = 141,
+  sym_simple_text_group = 142,
+  sym_opt_text_group = 143,
+  sym_opt_text_group_at = 144,
+  sym_math_group = 145,
+  sym_math_group_at = 146,
+  sym_opt_math_group = 147,
+  sym_opt_math_group_at = 148,
+  sym_math_text_group = 149,
+  sym_math_text_group_at = 150,
+  sym_token = 151,
+  sym_token_at = 152,
+  sym_begin_opt = 153,
+  sym_end_opt = 154,
+  aux_sym_text_mode_repeat1 = 155,
+  aux_sym_text_mode_at_repeat1 = 156,
+  aux_sym_math_mode_repeat1 = 157,
+  aux_sym_math_mode_at_repeat1 = 158,
+  aux_sym_parameter_repeat1 = 159,
+  aux_sym_verbatim_text_repeat1 = 160,
+  aux_sym_verbatim_text_repeat2 = 161,
+  anon_alias_sym_class_name = 162,
+  anon_alias_sym_env_name = 163,
+  anon_alias_sym_package_name = 164,
+  anon_alias_sym_text = 165,
 };
 
 static const char *ts_symbol_names[] = {
@@ -184,7 +186,7 @@ static const char *ts_symbol_names[] = {
   [sym_verb_delim] = "verb_delim",
   [ts_builtin_sym_end] = "END",
   [anon_sym_verb] = "verb",
-  [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = "/[\\s\\t]/",
+  [sym__whitespace] = "_whitespace",
   [anon_sym_LBRACK] = "[",
   [anon_sym_RBRACK] = "]",
   [anon_sym_LPAREN] = "(",
@@ -205,6 +207,7 @@ static const char *ts_symbol_names[] = {
   [anon_sym_EQ] = "=",
   [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = "/k?catcode`/",
   [anon_sym_emph] = "emph",
+  [anon_sym_footnote] = "footnote",
   [anon_sym_textbf] = "textbf",
   [anon_sym_textit] = "textit",
   [anon_sym_texttt] = "texttt",
@@ -231,7 +234,6 @@ static const char *ts_symbol_names[] = {
   [sym__text_mode_common] = "_text_mode_common",
   [sym_inline_verbatim] = "inline_verbatim",
   [sym_verb_token] = "verb_token",
-  [sym__whitespace] = "_whitespace",
   [sym__text_mode] = "_text_mode",
   [sym_text_mode] = "text_mode",
   [sym__text_mode_at] = "_text_mode_at",
@@ -304,6 +306,9 @@ static const char *ts_symbol_names[] = {
   [sym_emph] = "emph",
   [sym_emph_at] = "emph_at",
   [sym_emph_token] = "emph_token",
+  [sym_footnote] = "footnote",
+  [sym_footnote_at] = "footnote_at",
+  [sym_footnote_token] = "footnote_token",
   [sym_textbf] = "textbf",
   [sym_textbf_at] = "textbf_at",
   [sym_textbf_token] = "textbf_token",
@@ -332,7 +337,6 @@ static const char *ts_symbol_names[] = {
   [sym_token_at] = "token_at",
   [sym_begin_opt] = "begin_opt",
   [sym_end_opt] = "end_opt",
-  [aux_sym__whitespace_repeat1] = "_whitespace_repeat1",
   [aux_sym_text_mode_repeat1] = "text_mode_repeat1",
   [aux_sym_text_mode_at_repeat1] = "text_mode_at_repeat1",
   [aux_sym_math_mode_repeat1] = "math_mode_repeat1",
@@ -363,9 +367,9 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = {
+  [sym__whitespace] = {
     .visible = false,
-    .named = false,
+    .named = true,
   },
   [anon_sym_LBRACK] = {
     .visible = true,
@@ -444,6 +448,10 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .named = false,
   },
   [anon_sym_emph] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_footnote] = {
     .visible = true,
     .named = false,
   },
@@ -549,10 +557,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
   [sym_verb_token] = {
     .visible = true,
-    .named = true,
-  },
-  [sym__whitespace] = {
-    .visible = false,
     .named = true,
   },
   [sym__text_mode] = {
@@ -843,6 +847,18 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
+  [sym_footnote] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_footnote_at] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_footnote_token] = {
+    .visible = true,
+    .named = true,
+  },
   [sym_textbf] = {
     .visible = true,
     .named = true,
@@ -955,10 +971,6 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = true,
   },
-  [aux_sym__whitespace_repeat1] = {
-    .visible = false,
-    .named = false,
-  },
   [aux_sym_text_mode_repeat1] = {
     .visible = false,
     .named = false,
@@ -1005,7 +1017,7 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
   },
 };
 
-static TSSymbol ts_alias_sequences[7][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static TSSymbol ts_alias_sequences[9][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [1] = {
     [0] = anon_alias_sym_text,
   },
@@ -1023,6 +1035,12 @@ static TSSymbol ts_alias_sequences[7][MAX_ALIAS_SEQUENCE_LENGTH] = {
   },
   [6] = {
     [2] = anon_alias_sym_package_name,
+  },
+  [7] = {
+    [3] = anon_alias_sym_class_name,
+  },
+  [8] = {
+    [3] = anon_alias_sym_package_name,
   },
 };
 
@@ -1065,7 +1083,6 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '~')
         ADVANCE(32);
       if (lookahead == '\t' ||
-          lookahead == '\r' ||
           lookahead == ' ')
         ADVANCE(33);
       ADVANCE(34);
@@ -1250,7 +1267,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_active_char);
       END_STATE();
     case 33:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH);
+      ACCEPT_TOKEN(sym__whitespace);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(33);
       END_STATE();
     case 34:
       ACCEPT_TOKEN(aux_sym_SLASH_DOT_SLASH);
@@ -1338,33 +1358,35 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(71);
       if (lookahead == 'e')
         ADVANCE(86);
-      if (lookahead == 'i')
+      if (lookahead == 'f')
         ADVANCE(91);
+      if (lookahead == 'i')
+        ADVANCE(99);
       if (lookahead == 'k')
-        ADVANCE(100);
+        ADVANCE(108);
       if (lookahead == 'm')
-        ADVANCE(102);
+        ADVANCE(110);
       if (lookahead == 'p')
-        ADVANCE(117);
-      if (lookahead == 's')
         ADVANCE(125);
+      if (lookahead == 's')
+        ADVANCE(133);
       if (lookahead == 't')
-        ADVANCE(140);
+        ADVANCE(148);
       if (lookahead == 'u')
-        ADVANCE(150);
+        ADVANCE(158);
       if (lookahead == 'v')
-        ADVANCE(160);
+        ADVANCE(168);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(164);
+        ADVANCE(172);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(165);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(173);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
     case 39:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
@@ -1782,7 +1804,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 91:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'n')
+      if (lookahead == 'o')
         ADVANCE(92);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1790,17 +1812,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 92:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 'o')
         ADVANCE(93);
-      if (lookahead == 'p')
-        ADVANCE(98);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 93:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'l')
+      if (lookahead == 't')
         ADVANCE(94);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1808,7 +1828,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 94:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'u')
+      if (lookahead == 'n')
         ADVANCE(95);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1816,7 +1836,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 95:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'd')
+      if (lookahead == 'o')
         ADVANCE(96);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1824,63 +1844,63 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 96:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(97);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(47);
-      END_STATE();
-    case 97:
-      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(47);
-      END_STATE();
-    case 98:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'u')
-        ADVANCE(99);
-      if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(47);
-      END_STATE();
-    case 99:
-      ACCEPT_TOKEN(sym__name);
       if (lookahead == 't')
         ADVANCE(97);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 100:
+    case 97:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(98);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 98:
+      ACCEPT_TOKEN(anon_sym_footnote);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 99:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'n')
+        ADVANCE(100);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 100:
+      ACCEPT_TOKEN(sym__name);
       if (lookahead == 'c')
         ADVANCE(101);
+      if (lookahead == 'p')
+        ADVANCE(106);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 101:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(59);
+      if (lookahead == 'l')
+        ADVANCE(102);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 102:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'u')
         ADVANCE(103);
-      if (lookahead == 'i')
-        ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 103:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'k')
+      if (lookahead == 'd')
         ADVANCE(104);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1895,16 +1915,14 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(47);
       END_STATE();
     case 105:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(106);
+      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 106:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'u')
         ADVANCE(107);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1912,15 +1930,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 107:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'l')
-        ADVANCE(108);
+      if (lookahead == 't')
+        ADVANCE(105);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 108:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'c')
         ADVANCE(109);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1928,23 +1946,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 109:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
-        ADVANCE(110);
+      if (lookahead == 'a')
+        ADVANCE(59);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 110:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
         ADVANCE(111);
+      if (lookahead == 'i')
+        ADVANCE(122);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 111:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      if (lookahead == 'k')
         ADVANCE(112);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1952,21 +1972,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 112:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 'e')
         ADVANCE(113);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 113:
-      ACCEPT_TOKEN(anon_sym_makeatletter);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'a')
+        ADVANCE(114);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 114:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'n')
+      if (lookahead == 't')
         ADVANCE(115);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1974,7 +1996,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 115:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'i')
+      if (lookahead == 'l')
         ADVANCE(116);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -1982,23 +2004,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 116:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 's')
-        ADVANCE(51);
+      if (lookahead == 'e')
+        ADVANCE(117);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 117:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 't')
         ADVANCE(118);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 118:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 't')
         ADVANCE(119);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2006,41 +2028,37 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 119:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 'e')
         ADVANCE(120);
-      if (lookahead == 't')
-        ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 120:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'g')
+      if (lookahead == 'r')
         ADVANCE(121);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 121:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
-        ADVANCE(122);
+      ACCEPT_TOKEN(anon_sym_makeatletter);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 122:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 'n')
         ADVANCE(123);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 123:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
+      if (lookahead == 'i')
         ADVANCE(124);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2048,25 +2066,23 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 124:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'h')
-        ADVANCE(46);
+      if (lookahead == 's')
+        ADVANCE(51);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 125:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      if (lookahead == 'a')
         ADVANCE(126);
-      if (lookahead == 'u')
-        ADVANCE(131);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 126:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 'r')
         ADVANCE(127);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2074,15 +2090,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 127:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(128);
+      if (lookahead == 't')
+        ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 128:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'i')
+      if (lookahead == 'g')
         ADVANCE(129);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2090,7 +2108,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 129:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'o')
+      if (lookahead == 'r')
         ADVANCE(130);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2098,15 +2116,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 130:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'n')
-        ADVANCE(46);
+      if (lookahead == 'a')
+        ADVANCE(131);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 131:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
+      if (lookahead == 'p')
         ADVANCE(132);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2114,25 +2132,25 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 132:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
-        ADVANCE(133);
-      if (lookahead == 's')
-        ADVANCE(136);
+      if (lookahead == 'h')
+        ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 133:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(134);
+      if (lookahead == 'u')
+        ADVANCE(139);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 134:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 'c')
         ADVANCE(135);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2140,17 +2158,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 135:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(120);
+      if (lookahead == 't')
+        ADVANCE(136);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 136:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(126);
-      if (lookahead == 'u')
+      if (lookahead == 'i')
         ADVANCE(137);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2158,7 +2174,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 137:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
+      if (lookahead == 'o')
         ADVANCE(138);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2166,39 +2182,41 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 138:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 's')
-        ADVANCE(139);
+      if (lookahead == 'n')
+        ADVANCE(46);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 139:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
-        ADVANCE(126);
+      if (lookahead == 'b')
+        ADVANCE(140);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 140:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'p')
         ADVANCE(141);
+      if (lookahead == 's')
+        ADVANCE(144);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'x')
+      if (lookahead == 'a')
         ADVANCE(142);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 'r')
         ADVANCE(143);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2206,61 +2224,65 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
-        ADVANCE(144);
-      if (lookahead == 'i')
-        ADVANCE(146);
-      if (lookahead == 't')
-        ADVANCE(148);
+      if (lookahead == 'a')
+        ADVANCE(128);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 144:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'f')
+      if (lookahead == 'e')
+        ADVANCE(134);
+      if (lookahead == 'u')
         ADVANCE(145);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 145:
-      ACCEPT_TOKEN(anon_sym_textbf);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'b')
+        ADVANCE(146);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 146:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      if (lookahead == 's')
         ADVANCE(147);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(anon_sym_textit);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(134);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(149);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(anon_sym_texttt);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'x')
+        ADVANCE(150);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 150:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 's')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 't')
         ADVANCE(151);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2268,77 +2290,77 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 151:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      if (lookahead == 'b')
         ADVANCE(152);
+      if (lookahead == 'i')
+        ADVANCE(154);
+      if (lookahead == 't')
+        ADVANCE(156);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 152:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'p')
+      if (lookahead == 'f')
         ADVANCE(153);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 153:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
-        ADVANCE(154);
+      ACCEPT_TOKEN(anon_sym_textbf);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 154:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'c')
+      if (lookahead == 't')
         ADVANCE(155);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 155:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'k')
-        ADVANCE(156);
+      ACCEPT_TOKEN(anon_sym_textit);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 156:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'a')
+      if (lookahead == 't')
         ADVANCE(157);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
+          ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 157:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'g')
-        ADVANCE(158);
+      ACCEPT_TOKEN(anon_sym_texttt);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 158:
-      ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 's')
         ADVANCE(159);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 159:
-      ACCEPT_TOKEN(anon_sym_usepackage);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(160);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 160:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'p')
         ADVANCE(161);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
@@ -2346,27 +2368,89 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 161:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'r')
+      if (lookahead == 'a')
         ADVANCE(162);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
+          ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 162:
       ACCEPT_TOKEN(sym__name);
-      if (lookahead == 'b')
+      if (lookahead == 'c')
         ADVANCE(163);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 163:
-      ACCEPT_TOKEN(anon_sym_verb);
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'k')
+        ADVANCE(164);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
     case 164:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'a')
+        ADVANCE(165);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 165:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'g')
+        ADVANCE(166);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 166:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'e')
+        ADVANCE(167);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 167:
+      ACCEPT_TOKEN(anon_sym_usepackage);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 168:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
+        ADVANCE(169);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 169:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'r')
+        ADVANCE(170);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 170:
+      ACCEPT_TOKEN(sym__name);
+      if (lookahead == 'b')
+        ADVANCE(171);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 171:
+      ACCEPT_TOKEN(anon_sym_verb);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(47);
+      END_STATE();
+    case 172:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(87);
@@ -2374,16 +2458,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 165:
+    case 173:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 166:
+    case 174:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       END_STATE();
-    case 167:
+    case 175:
       if (lookahead == '#')
         ADVANCE(3);
       if (lookahead == '$')
@@ -2410,7 +2494,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           (lookahead < '[' || lookahead > '_'))
         ADVANCE(36);
       END_STATE();
-    case 168:
+    case 176:
       if (lookahead == 0)
         ADVANCE(1);
       if (lookahead == '#')
@@ -2439,13 +2523,13 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(32);
       ADVANCE(36);
       END_STATE();
-    case 169:
+    case 177:
       if (lookahead == 0)
         ADVANCE(1);
       if (lookahead == '%')
         ADVANCE(20);
       END_STATE();
-    case 170:
+    case 178:
       if (lookahead == '\n')
         ADVANCE(2);
       if (lookahead == '%')
@@ -2455,58 +2539,107 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0)
         ADVANCE(34);
       END_STATE();
-    case 171:
+    case 179:
       if (lookahead == '#')
         ADVANCE(3);
       if (lookahead == '%')
         ADVANCE(20);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(172);
+        ADVANCE(180);
       END_STATE();
-    case 172:
+    case 180:
       ACCEPT_TOKEN(sym_number);
       if (('0' <= lookahead && lookahead <= '9'))
-        ADVANCE(172);
+        ADVANCE(180);
       END_STATE();
-    case 173:
+    case 181:
+      if (lookahead == '\n')
+        ADVANCE(2);
       if (lookahead == '%')
         ADVANCE(20);
+      if (lookahead == '[')
+        ADVANCE(25);
+      if (lookahead == '{')
+        ADVANCE(30);
       if (lookahead == '\t' ||
-          lookahead == '\n' ||
-          lookahead == '\r' ||
           lookahead == ' ')
         ADVANCE(33);
       END_STATE();
-    case 174:
+    case 182:
+      if (lookahead == 0)
+        ADVANCE(1);
+      if (lookahead == '#')
+        ADVANCE(3);
+      if (lookahead == '$')
+        ADVANCE(4);
+      if (lookahead == '%')
+        ADVANCE(20);
+      if (lookahead == '&')
+        ADVANCE(21);
+      if (lookahead == '[')
+        ADVANCE(25);
+      if (lookahead == '\\')
+        ADVANCE(26);
+      if (lookahead == ']')
+        ADVANCE(27);
+      if (lookahead == '^')
+        ADVANCE(28);
+      if (lookahead == '_')
+        ADVANCE(29);
+      if (lookahead == '{')
+        ADVANCE(30);
+      if (lookahead == '}')
+        ADVANCE(31);
+      if (lookahead == '~')
+        ADVANCE(32);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(183);
+      ADVANCE(36);
+      END_STATE();
+    case 183:
+      ACCEPT_TOKEN(sym__whitespace);
+      if (lookahead == '\t' ||
+          lookahead == ' ')
+        ADVANCE(183);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 184:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == 'b')
         ADVANCE(53);
       if (lookahead == 'c')
-        ADVANCE(175);
+        ADVANCE(185);
       if (lookahead == 'd')
-        ADVANCE(176);
+        ADVANCE(186);
       if (lookahead == 'i')
-        ADVANCE(91);
+        ADVANCE(99);
       if (lookahead == 'k')
-        ADVANCE(100);
+        ADVANCE(108);
       if (lookahead == 't')
-        ADVANCE(177);
+        ADVANCE(187);
       if (lookahead == 'e' ||
           lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(164);
+        ADVANCE(172);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(165);
+        ADVANCE(173);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < 'A' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 175:
+    case 185:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
         ADVANCE(59);
@@ -2514,7 +2647,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 176:
+    case 186:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'e')
         ADVANCE(72);
@@ -2522,46 +2655,46 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 177:
+    case 187:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(178);
+        ADVANCE(188);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 178:
+    case 188:
       ACCEPT_TOKEN(sym__name);
       if (lookahead == 'g')
-        ADVANCE(179);
+        ADVANCE(189);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 179:
+    case 189:
       ACCEPT_TOKEN(anon_sym_tag);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 180:
+    case 190:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'e')
-        ADVANCE(181);
+        ADVANCE(191);
       END_STATE();
-    case 181:
+    case 191:
       if (lookahead == 'n')
-        ADVANCE(182);
+        ADVANCE(192);
       END_STATE();
-    case 182:
+    case 192:
       if (lookahead == 'd')
-        ADVANCE(183);
+        ADVANCE(193);
       END_STATE();
-    case 183:
+    case 193:
       ACCEPT_TOKEN(anon_sym_end);
       END_STATE();
-    case 184:
+    case 194:
       if (lookahead == '\n')
         ADVANCE(2);
       if (lookahead == '%')
@@ -2569,7 +2702,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0)
         ADVANCE(34);
       END_STATE();
-    case 185:
+    case 195:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == '(')
@@ -2585,205 +2718,89 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'd')
         ADVANCE(71);
       if (lookahead == 'e')
-        ADVANCE(186);
-      if (lookahead == 'i')
+        ADVANCE(196);
+      if (lookahead == 'f')
         ADVANCE(91);
+      if (lookahead == 'i')
+        ADVANCE(99);
       if (lookahead == 'k')
-        ADVANCE(100);
+        ADVANCE(108);
       if (lookahead == 'm')
-        ADVANCE(102);
+        ADVANCE(110);
       if (lookahead == 'p')
-        ADVANCE(117);
-      if (lookahead == 's')
         ADVANCE(125);
+      if (lookahead == 's')
+        ADVANCE(133);
       if (lookahead == 't')
-        ADVANCE(140);
+        ADVANCE(148);
       if (lookahead == 'u')
-        ADVANCE(150);
+        ADVANCE(158);
       if (lookahead == 'v')
-        ADVANCE(160);
+        ADVANCE(168);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(164);
+        ADVANCE(172);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(165);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(173);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 186:
+    case 196:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(87);
       if (lookahead == 'm')
         ADVANCE(88);
       if (lookahead == 'n')
-        ADVANCE(187);
+        ADVANCE(197);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 187:
+    case 197:
       ACCEPT_TOKEN(sym__name);
       if (lookahead == 'd')
-        ADVANCE(188);
+        ADVANCE(198);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 188:
+    case 198:
       ACCEPT_TOKEN(anon_sym_end);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 189:
+    case 199:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'V')
-        ADVANCE(190);
+        ADVANCE(200);
       if (lookahead == 'a')
-        ADVANCE(199);
+        ADVANCE(209);
       if (lookahead == 'd')
-        ADVANCE(207);
+        ADVANCE(217);
       if (lookahead == 'e')
-        ADVANCE(233);
+        ADVANCE(243);
       if (lookahead == 'f')
-        ADVANCE(241);
-      if (lookahead == 'g')
-        ADVANCE(246);
-      if (lookahead == 'l')
         ADVANCE(251);
+      if (lookahead == 'g')
+        ADVANCE(256);
+      if (lookahead == 'l')
+        ADVANCE(261);
       if (lookahead == 'm')
-        ADVANCE(260);
+        ADVANCE(270);
       if (lookahead == 's')
-        ADVANCE(275);
+        ADVANCE(285);
       if (lookahead == 'v')
-        ADVANCE(278);
+        ADVANCE(288);
       if (lookahead == 'B' ||
           lookahead == 'L')
-        ADVANCE(285);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 190:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
-        ADVANCE(191);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 191:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(192);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 192:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'b')
-        ADVANCE(193);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 193:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(194);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(195);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(196);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 196:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
-        ADVANCE(197);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 197:
-      ACCEPT_TOKEN(sym_verbatim_env_name);
-      if (lookahead == '*')
-        ADVANCE(198);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 198:
-      ACCEPT_TOKEN(sym_verbatim_env_name);
-      if (lookahead != 0 &&
-          (lookahead < '#' || lookahead > '&') &&
-          (lookahead < '[' || lookahead > '_') &&
-          lookahead != '{' &&
-          lookahead != '}' &&
-          lookahead != '~')
-        ADVANCE(36);
-      END_STATE();
-    case 199:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
-        ADVANCE(200);
+        ADVANCE(295);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2794,7 +2811,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 200:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'e')
         ADVANCE(201);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2806,7 +2823,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 201:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
+      if (lookahead == 'r')
         ADVANCE(202);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2818,7 +2835,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 202:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'b')
         ADVANCE(203);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2829,11 +2846,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(sym_display_math_env_name);
-      if (lookahead == '*')
-        ADVANCE(204);
+      ACCEPT_TOKEN(sym_text);
       if (lookahead == 'a')
-        ADVANCE(205);
+        ADVANCE(204);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2843,7 +2858,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 204:
-      ACCEPT_TOKEN(sym_display_math_env_name);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 't')
+        ADVANCE(205);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2854,7 +2871,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 205:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'i')
         ADVANCE(206);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2865,9 +2882,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 206:
-      ACCEPT_TOKEN(sym_display_math_env_name);
-      if (lookahead == '*')
-        ADVANCE(204);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'm')
+        ADVANCE(207);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2877,17 +2894,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 207:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym_verbatim_env_name);
+      if (lookahead == '*')
         ADVANCE(208);
-      if (lookahead == 'g')
-        ADVANCE(212);
-      if (lookahead == 'i')
-        ADVANCE(216);
-      if (lookahead == 'm')
-        ADVANCE(225);
-      if (lookahead == 's')
-        ADVANCE(228);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2897,9 +2906,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 208:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(209);
+      ACCEPT_TOKEN(sym_verbatim_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2910,7 +2917,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 209:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'l')
         ADVANCE(210);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2922,7 +2929,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 210:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'i')
         ADVANCE(211);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2934,8 +2941,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'y')
-        ADVANCE(206);
+      if (lookahead == 'g')
+        ADVANCE(212);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2946,7 +2953,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 212:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'n')
         ADVANCE(213);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -2957,9 +2964,11 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 213:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'o')
+      ACCEPT_TOKEN(sym_display_math_env_name);
+      if (lookahead == '*')
         ADVANCE(214);
+      if (lookahead == 'a')
+        ADVANCE(215);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2969,9 +2978,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 214:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'u')
-        ADVANCE(215);
+      ACCEPT_TOKEN(sym_display_math_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2982,8 +2989,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 215:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
-        ADVANCE(206);
+      if (lookahead == 't')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -2993,9 +3000,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 216:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
-        ADVANCE(217);
+      ACCEPT_TOKEN(sym_display_math_env_name);
+      if (lookahead == '*')
+        ADVANCE(214);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3006,8 +3013,16 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 217:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
+      if (lookahead == 'a')
         ADVANCE(218);
+      if (lookahead == 'g')
+        ADVANCE(222);
+      if (lookahead == 'i')
+        ADVANCE(226);
+      if (lookahead == 'm')
+        ADVANCE(235);
+      if (lookahead == 's')
+        ADVANCE(238);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3018,7 +3033,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 218:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'r')
         ADVANCE(219);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3030,7 +3045,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 219:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'r')
         ADVANCE(220);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3042,7 +3057,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 220:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'y')
+      if (lookahead == 'a')
         ADVANCE(221);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3054,8 +3069,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 221:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
-        ADVANCE(222);
+      if (lookahead == 'y')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3066,7 +3081,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 222:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'r')
         ADVANCE(223);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3078,7 +3093,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 223:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'o')
         ADVANCE(224);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3090,8 +3105,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 224:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
-        ADVANCE(204);
+      if (lookahead == 'u')
+        ADVANCE(225);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3102,8 +3117,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 225:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(226);
+      if (lookahead == 'p')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3114,7 +3129,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 226:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 's')
         ADVANCE(227);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3126,8 +3141,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 227:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
-        ADVANCE(206);
+      if (lookahead == 'p')
+        ADVANCE(228);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3138,7 +3153,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 228:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'l')
         ADVANCE(229);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3150,7 +3165,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 229:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 'a')
         ADVANCE(230);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3162,7 +3177,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 230:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'y')
         ADVANCE(231);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3174,7 +3189,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 231:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'm')
         ADVANCE(232);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3186,8 +3201,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 232:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
-        ADVANCE(206);
+      if (lookahead == 'a')
+        ADVANCE(233);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3198,7 +3213,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 233:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'q')
+      if (lookahead == 't')
         ADVANCE(234);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3210,10 +3225,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 234:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
-        ADVANCE(235);
-      if (lookahead == 'u')
-        ADVANCE(236);
+      if (lookahead == 'h')
+        ADVANCE(214);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3225,7 +3238,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
     case 235:
       ACCEPT_TOKEN(sym_text);
       if (lookahead == 'a')
-        ADVANCE(208);
+        ADVANCE(236);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3236,7 +3249,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 236:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 't')
         ADVANCE(237);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3248,8 +3261,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 237:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(238);
+      if (lookahead == 'h')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3260,7 +3273,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 238:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'e')
         ADVANCE(239);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3272,7 +3285,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 239:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'o')
+      if (lookahead == 'r')
         ADVANCE(240);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3284,8 +3297,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 240:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
-        ADVANCE(206);
+      if (lookahead == 'i')
+        ADVANCE(241);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3296,7 +3309,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 241:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'e')
         ADVANCE(242);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3308,8 +3321,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 242:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(243);
+      if (lookahead == 's')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3320,7 +3333,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 243:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'q')
         ADVANCE(244);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3332,8 +3345,10 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 244:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'n')
         ADVANCE(245);
+      if (lookahead == 'u')
+        ADVANCE(246);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3344,8 +3359,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 245:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
-        ADVANCE(240);
+      if (lookahead == 'a')
+        ADVANCE(218);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3380,7 +3395,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 248:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
+      if (lookahead == 'i')
         ADVANCE(249);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3392,7 +3407,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 249:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'o')
         ADVANCE(250);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3404,8 +3419,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 250:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
-        ADVANCE(206);
+      if (lookahead == 'n')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3416,7 +3431,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 251:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
+      if (lookahead == 'l')
         ADVANCE(252);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3428,7 +3443,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 252:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(253);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3464,8 +3479,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 255:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 's')
-        ADVANCE(256);
+      if (lookahead == 'g')
+        ADVANCE(250);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3476,7 +3491,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 256:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'a')
         ADVANCE(257);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3488,7 +3503,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 257:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 't')
         ADVANCE(258);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3500,7 +3515,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 258:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'h')
         ADVANCE(259);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3512,8 +3527,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 259:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'g')
-        ADVANCE(198);
+      if (lookahead == 'e')
+        ADVANCE(260);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3524,12 +3539,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 260:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
-        ADVANCE(261);
-      if (lookahead == 'i')
-        ADVANCE(264);
-      if (lookahead == 'u')
-        ADVANCE(268);
+      if (lookahead == 'r')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3540,7 +3551,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 261:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 's')
         ADVANCE(262);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3552,7 +3563,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 262:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'h')
+      if (lookahead == 't')
         ADVANCE(263);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3563,7 +3574,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 263:
-      ACCEPT_TOKEN(sym_inline_math_env_name);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l')
+        ADVANCE(264);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3574,7 +3587,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 264:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
+      if (lookahead == 'i')
         ADVANCE(265);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3586,7 +3599,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 265:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 's')
         ADVANCE(266);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3598,7 +3611,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 266:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 't')
         ADVANCE(267);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3610,8 +3623,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 267:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'd')
-        ADVANCE(198);
+      if (lookahead == 'i')
+        ADVANCE(268);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3622,7 +3635,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 268:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'n')
         ADVANCE(269);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3634,8 +3647,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 269:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
-        ADVANCE(270);
+      if (lookahead == 'g')
+        ADVANCE(208);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3646,8 +3659,12 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 270:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'a')
         ADVANCE(271);
+      if (lookahead == 'i')
+        ADVANCE(274);
+      if (lookahead == 'u')
+        ADVANCE(278);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3658,7 +3675,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 271:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 't')
         ADVANCE(272);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3670,7 +3687,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 272:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'h')
         ADVANCE(273);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3681,9 +3698,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 273:
-      ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'n')
-        ADVANCE(274);
+      ACCEPT_TOKEN(sym_inline_math_env_name);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3694,8 +3709,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 274:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
-        ADVANCE(206);
+      if (lookahead == 'n')
+        ADVANCE(275);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3706,7 +3721,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 275:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'p')
+      if (lookahead == 't')
         ADVANCE(276);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3718,7 +3733,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 276:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'l')
+      if (lookahead == 'e')
         ADVANCE(277);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3730,8 +3745,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 277:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
-        ADVANCE(205);
+      if (lookahead == 'd')
+        ADVANCE(208);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3742,7 +3757,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 278:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'e')
+      if (lookahead == 'l')
         ADVANCE(279);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3754,7 +3769,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 279:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'r')
+      if (lookahead == 't')
         ADVANCE(280);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3766,7 +3781,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 280:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'b')
+      if (lookahead == 'i')
         ADVANCE(281);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3778,7 +3793,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 281:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'a')
+      if (lookahead == 'l')
         ADVANCE(282);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3790,7 +3805,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 282:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 't')
+      if (lookahead == 'i')
         ADVANCE(283);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3802,7 +3817,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 283:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'i')
+      if (lookahead == 'n')
         ADVANCE(284);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
@@ -3814,8 +3829,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 284:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'm')
-        ADVANCE(198);
+      if (lookahead == 'e')
+        ADVANCE(216);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3826,8 +3841,8 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 285:
       ACCEPT_TOKEN(sym_text);
-      if (lookahead == 'V')
-        ADVANCE(190);
+      if (lookahead == 'p')
+        ADVANCE(286);
       if (lookahead != 0 &&
           (lookahead < '#' || lookahead > '&') &&
           (lookahead < '[' || lookahead > '_') &&
@@ -3837,16 +3852,126 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         ADVANCE(36);
       END_STATE();
     case 286:
-      if (lookahead == '\n')
-        ADVANCE(2);
-      if (lookahead == '%')
-        ADVANCE(20);
-      if (lookahead == '[')
-        ADVANCE(25);
-      if (lookahead == '{')
-        ADVANCE(30);
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'l')
+        ADVANCE(287);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
       END_STATE();
     case 287:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'i')
+        ADVANCE(215);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 288:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'e')
+        ADVANCE(289);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 289:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'r')
+        ADVANCE(290);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 290:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'b')
+        ADVANCE(291);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 291:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'a')
+        ADVANCE(292);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 292:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 't')
+        ADVANCE(293);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 293:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'i')
+        ADVANCE(294);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 294:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'm')
+        ADVANCE(208);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 295:
+      ACCEPT_TOKEN(sym_text);
+      if (lookahead == 'V')
+        ADVANCE(200);
+      if (lookahead != 0 &&
+          (lookahead < '#' || lookahead > '&') &&
+          (lookahead < '[' || lookahead > '_') &&
+          lookahead != '{' &&
+          lookahead != '}' &&
+          lookahead != '~')
+        ADVANCE(36);
+      END_STATE();
+    case 296:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead != 0 &&
@@ -3854,15 +3979,15 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != ')' &&
           lookahead != '[' &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 288:
+    case 297:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == '=')
         ADVANCE(24);
       END_STATE();
-    case 289:
+    case 298:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == '(')
@@ -3870,1080 +3995,1144 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(290);
+        ADVANCE(299);
       if (lookahead == 'b')
-        ADVANCE(303);
+        ADVANCE(312);
       if (lookahead == 'c')
-        ADVANCE(308);
+        ADVANCE(317);
       if (lookahead == 'd')
-        ADVANCE(320);
+        ADVANCE(329);
       if (lookahead == 'e')
-        ADVANCE(335);
-      if (lookahead == 'i')
-        ADVANCE(340);
-      if (lookahead == 'k')
+        ADVANCE(344);
+      if (lookahead == 'f')
         ADVANCE(349);
+      if (lookahead == 'i')
+        ADVANCE(357);
+      if (lookahead == 'k')
+        ADVANCE(366);
       if (lookahead == 'm')
-        ADVANCE(351);
+        ADVANCE(368);
       if (lookahead == 'p')
-        ADVANCE(365);
+        ADVANCE(382);
       if (lookahead == 's')
-        ADVANCE(373);
+        ADVANCE(390);
       if (lookahead == 't')
-        ADVANCE(388);
+        ADVANCE(405);
       if (lookahead == 'u')
-        ADVANCE(398);
+        ADVANCE(415);
       if (lookahead == 'v')
-        ADVANCE(408);
+        ADVANCE(425);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(412);
+        ADVANCE(429);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(413);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(430);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(166);
-      END_STATE();
-    case 290:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'd')
-        ADVANCE(291);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 291:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'd')
-        ADVANCE(292);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 292:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(293);
-      if (lookahead == 'p')
-        ADVANCE(298);
-      if (lookahead == 's')
-        ADVANCE(301);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 293:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
-        ADVANCE(294);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 294:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(295);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 295:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
-        ADVANCE(296);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 296:
-      ACCEPT_TOKEN(aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 297:
-      ACCEPT_TOKEN(sym__name_at);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 298:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(299);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(174);
       END_STATE();
     case 299:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'd')
         ADVANCE(300);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 300:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(296);
+      if (lookahead == 'd')
+        ADVANCE(301);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 301:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 'c')
         ADVANCE(302);
+      if (lookahead == 'p')
+        ADVANCE(307);
+      if (lookahead == 's')
+        ADVANCE(310);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 302:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(296);
+      if (lookahead == 'h')
+        ADVANCE(303);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 303:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
         ADVANCE(304);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 304:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
+      if (lookahead == 'p')
         ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 305:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
-        ADVANCE(306);
+      ACCEPT_TOKEN(aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 306:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
-        ADVANCE(307);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 307:
-      ACCEPT_TOKEN(anon_sym_begin);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 308:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'a')
-        ADVANCE(309);
-      if (lookahead == 'h')
-        ADVANCE(315);
+        ADVANCE(308);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
+      END_STATE();
+    case 308:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
+        ADVANCE(309);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 309:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 't')
-        ADVANCE(310);
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 310:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 'e')
         ADVANCE(311);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 311:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
-        ADVANCE(312);
+      if (lookahead == 'c')
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 312:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'd')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(313);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 313:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 'g')
         ADVANCE(314);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 314:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'i')
+        ADVANCE(315);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 315:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'n')
+        ADVANCE(316);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 316:
+      ACCEPT_TOKEN(anon_sym_begin);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 317:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
+        ADVANCE(318);
+      if (lookahead == 'h')
+        ADVANCE(324);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 318:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(319);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 319:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(320);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 320:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'o')
+        ADVANCE(321);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 321:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'd')
+        ADVANCE(322);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 322:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(323);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 323:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == '`')
         ADVANCE(65);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 315:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(316);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 316:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
-        ADVANCE(317);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 317:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(318);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 318:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(319);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 319:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(296);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 320:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
-        ADVANCE(321);
-      if (lookahead == 'o')
-        ADVANCE(323);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 321:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'f')
-        ADVANCE(322);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 322:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 323:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
-        ADVANCE(324);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 324:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
+      if (lookahead == 'a')
         ADVANCE(325);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 325:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'm')
+      if (lookahead == 'p')
         ADVANCE(326);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 326:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 't')
         ADVANCE(327);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 327:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
+      if (lookahead == 'e')
         ADVANCE(328);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 328:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(329);
+      if (lookahead == 'r')
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 329:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(330);
+      if (lookahead == 'o')
+        ADVANCE(332);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 330:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'l')
+      if (lookahead == 'f')
         ADVANCE(331);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 331:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(332);
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 332:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
+      if (lookahead == 'c')
         ADVANCE(333);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 333:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
+      if (lookahead == 'u')
         ADVANCE(334);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 334:
-      ACCEPT_TOKEN(anon_sym_documentclass);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'm')
+        ADVANCE(335);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 335:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'd')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
         ADVANCE(336);
-      if (lookahead == 'm')
-        ADVANCE(337);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 336:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(321);
+      if (lookahead == 'n')
+        ADVANCE(337);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 337:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
+      if (lookahead == 't')
         ADVANCE(338);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 338:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
+      if (lookahead == 'c')
         ADVANCE(339);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 339:
-      ACCEPT_TOKEN(anon_sym_emph);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'l')
+        ADVANCE(340);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 340:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'n')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
         ADVANCE(341);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 341:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 's')
         ADVANCE(342);
-      if (lookahead == 'p')
-        ADVANCE(347);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 342:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'l')
+      if (lookahead == 's')
         ADVANCE(343);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 343:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
-        ADVANCE(344);
+      ACCEPT_TOKEN(anon_sym_documentclass);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 344:
-      ACCEPT_TOKEN(sym__name_at);
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(345);
+      if (lookahead == 'm')
+        ADVANCE(346);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 345:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'e')
-        ADVANCE(346);
+        ADVANCE(330);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 346:
-      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'p')
+        ADVANCE(347);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 347:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'u')
+      if (lookahead == 'h')
         ADVANCE(348);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 348:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
-        ADVANCE(346);
+      ACCEPT_TOKEN(anon_sym_emph);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 349:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'c')
+      if (lookahead == 'o')
         ADVANCE(350);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 350:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(309);
+      if (lookahead == 'o')
+        ADVANCE(351);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 351:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
         ADVANCE(352);
-      if (lookahead == 'i')
-        ADVANCE(362);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 352:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'k')
+      if (lookahead == 'n')
         ADVANCE(353);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 353:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 'o')
         ADVANCE(354);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 354:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 't')
         ADVANCE(355);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 355:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'e')
         ADVANCE(356);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 356:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
-        ADVANCE(357);
+      ACCEPT_TOKEN(anon_sym_footnote);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 357:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'n')
         ADVANCE(358);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 358:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
+      if (lookahead == 'c')
         ADVANCE(359);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 359:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(360);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 360:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(361);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 361:
-      ACCEPT_TOKEN(anon_sym_makeatother);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 362:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
-        ADVANCE(363);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 363:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
+      if (lookahead == 'p')
         ADVANCE(364);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
+      END_STATE();
+    case 359:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'l')
+        ADVANCE(360);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 360:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'u')
+        ADVANCE(361);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 361:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'd')
+        ADVANCE(362);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 362:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(363);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 363:
+      ACCEPT_TOKEN(aux_sym_SLASHinclude_PIPEinput_SLASH);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 364:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
-        ADVANCE(301);
+      if (lookahead == 'u')
+        ADVANCE(365);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 365:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'a')
-        ADVANCE(366);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(363);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 366:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'c')
         ADVANCE(367);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 367:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'a')
-        ADVANCE(368);
-      if (lookahead == 't')
-        ADVANCE(296);
+        ADVANCE(318);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 368:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
         ADVANCE(369);
+      if (lookahead == 'i')
+        ADVANCE(379);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 369:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      if (lookahead == 'k')
         ADVANCE(370);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 370:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 'e')
         ADVANCE(371);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 371:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
+      if (lookahead == 'a')
         ADVANCE(372);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 372:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'h')
-        ADVANCE(296);
+      if (lookahead == 't')
+        ADVANCE(373);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 373:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'o')
         ADVANCE(374);
-      if (lookahead == 'u')
-        ADVANCE(379);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 374:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 't')
         ADVANCE(375);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 375:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'h')
         ADVANCE(376);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 376:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'i')
+      if (lookahead == 'e')
         ADVANCE(377);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 377:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'o')
+      if (lookahead == 'r')
         ADVANCE(378);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 378:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'n')
-        ADVANCE(296);
+      ACCEPT_TOKEN(anon_sym_makeatother);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 379:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
+      if (lookahead == 'n')
         ADVANCE(380);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 380:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'p')
+      if (lookahead == 'i')
         ADVANCE(381);
-      if (lookahead == 's')
-        ADVANCE(384);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 381:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(382);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 382:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
-        ADVANCE(383);
+      if (lookahead == 's')
+        ADVANCE(310);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
+      END_STATE();
+    case 382:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'a')
+        ADVANCE(383);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 383:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(368);
+      if (lookahead == 'r')
+        ADVANCE(384);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 384:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(374);
-      if (lookahead == 'u')
+      if (lookahead == 'a')
         ADVANCE(385);
+      if (lookahead == 't')
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 385:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
+      if (lookahead == 'g')
         ADVANCE(386);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 386:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 's')
+      if (lookahead == 'r')
         ADVANCE(387);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 387:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(374);
+      if (lookahead == 'a')
+        ADVANCE(388);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 388:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'p')
         ADVANCE(389);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 389:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'x')
-        ADVANCE(390);
+      if (lookahead == 'h')
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 390:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(391);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 391:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
-        ADVANCE(392);
-      if (lookahead == 'i')
-        ADVANCE(394);
-      if (lookahead == 't')
+      if (lookahead == 'u')
         ADVANCE(396);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
+      END_STATE();
+    case 391:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(392);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 392:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'f')
+      if (lookahead == 't')
         ADVANCE(393);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 393:
-      ACCEPT_TOKEN(anon_sym_textbf);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'i')
+        ADVANCE(394);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 394:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'o')
         ADVANCE(395);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 395:
-      ACCEPT_TOKEN(anon_sym_textit);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'n')
+        ADVANCE(305);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 396:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 't')
+      if (lookahead == 'b')
         ADVANCE(397);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 397:
-      ACCEPT_TOKEN(anon_sym_texttt);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 398:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 's')
-        ADVANCE(399);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 399:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
-        ADVANCE(400);
-      if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
-      END_STATE();
-    case 400:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'p')
+        ADVANCE(398);
+      if (lookahead == 's')
         ADVANCE(401);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
+      END_STATE();
+    case 398:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(399);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 399:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
+        ADVANCE(400);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 400:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(385);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 401:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
+      if (lookahead == 'e')
+        ADVANCE(391);
+      if (lookahead == 'u')
         ADVANCE(402);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 402:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'c')
+      if (lookahead == 'b')
         ADVANCE(403);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 403:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'k')
+      if (lookahead == 's')
         ADVANCE(404);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 404:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'a')
-        ADVANCE(405);
+      if (lookahead == 'e')
+        ADVANCE(391);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
       END_STATE();
     case 405:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'g')
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
         ADVANCE(406);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 406:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'e')
+      if (lookahead == 'x')
         ADVANCE(407);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 407:
-      ACCEPT_TOKEN(anon_sym_usepackage);
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(408);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 408:
-      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
-      if (lookahead == 'e')
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'b')
         ADVANCE(409);
+      if (lookahead == 'i')
+        ADVANCE(411);
+      if (lookahead == 't')
+        ADVANCE(413);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 409:
       ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'r')
+      if (lookahead == 'f')
         ADVANCE(410);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 410:
-      ACCEPT_TOKEN(sym__name_at);
-      if (lookahead == 'b')
-        ADVANCE(411);
+      ACCEPT_TOKEN(anon_sym_textbf);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     case 411:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(412);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 412:
+      ACCEPT_TOKEN(anon_sym_textit);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 413:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 't')
+        ADVANCE(414);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 414:
+      ACCEPT_TOKEN(anon_sym_texttt);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 415:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 's')
+        ADVANCE(416);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 416:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(417);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 417:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'p')
+        ADVANCE(418);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 418:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(419);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 419:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'c')
+        ADVANCE(420);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 420:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'k')
+        ADVANCE(421);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 421:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'a')
+        ADVANCE(422);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 422:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'g')
+        ADVANCE(423);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 423:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'e')
+        ADVANCE(424);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 424:
+      ACCEPT_TOKEN(anon_sym_usepackage);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 425:
+      ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
+      if (lookahead == 'e')
+        ADVANCE(426);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 426:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'r')
+        ADVANCE(427);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 427:
+      ACCEPT_TOKEN(sym__name_at);
+      if (lookahead == 'b')
+        ADVANCE(428);
+      if (('@' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z'))
+        ADVANCE(306);
+      END_STATE();
+    case 428:
       ACCEPT_TOKEN(anon_sym_verb);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 412:
+    case 429:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(336);
+        ADVANCE(345);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 413:
+    case 430:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 414:
+    case 431:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == 'b')
         ADVANCE(53);
       if (lookahead == 'c')
-        ADVANCE(175);
+        ADVANCE(185);
       if (lookahead == 'd')
-        ADVANCE(176);
+        ADVANCE(186);
       if (lookahead == 'e')
-        ADVANCE(415);
+        ADVANCE(432);
       if (lookahead == 'i')
-        ADVANCE(91);
+        ADVANCE(99);
       if (lookahead == 'k')
-        ADVANCE(100);
+        ADVANCE(108);
       if (lookahead == 't')
-        ADVANCE(177);
+        ADVANCE(187);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(164);
+        ADVANCE(172);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(165);
+        ADVANCE(173);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < 'A' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 415:
+    case 432:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
         ADVANCE(87);
       if (lookahead == 'n')
-        ADVANCE(187);
+        ADVANCE(197);
       if (('A' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
         ADVANCE(47);
       END_STATE();
-    case 416:
+    case 433:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == ')')
         ADVANCE(23);
       END_STATE();
-    case 417:
+    case 434:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == '(')
@@ -4951,168 +5140,170 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(290);
+        ADVANCE(299);
       if (lookahead == 'b')
-        ADVANCE(303);
+        ADVANCE(312);
       if (lookahead == 'c')
-        ADVANCE(308);
+        ADVANCE(317);
       if (lookahead == 'd')
-        ADVANCE(320);
+        ADVANCE(329);
       if (lookahead == 'e')
-        ADVANCE(335);
-      if (lookahead == 'i')
-        ADVANCE(340);
-      if (lookahead == 'k')
+        ADVANCE(344);
+      if (lookahead == 'f')
         ADVANCE(349);
+      if (lookahead == 'i')
+        ADVANCE(357);
+      if (lookahead == 'k')
+        ADVANCE(366);
       if (lookahead == 'm')
-        ADVANCE(418);
+        ADVANCE(435);
       if (lookahead == 'p')
-        ADVANCE(365);
+        ADVANCE(382);
       if (lookahead == 's')
-        ADVANCE(373);
+        ADVANCE(390);
       if (lookahead == 't')
-        ADVANCE(388);
+        ADVANCE(405);
       if (lookahead == 'u')
-        ADVANCE(398);
+        ADVANCE(415);
       if (lookahead == 'v')
-        ADVANCE(408);
+        ADVANCE(425);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(412);
+        ADVANCE(429);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(413);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(430);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 418:
+    case 435:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'i')
-        ADVANCE(362);
+        ADVANCE(379);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 419:
+    case 436:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == 'b')
-        ADVANCE(303);
+        ADVANCE(312);
       if (lookahead == 'c')
-        ADVANCE(420);
+        ADVANCE(437);
       if (lookahead == 'd')
-        ADVANCE(421);
+        ADVANCE(438);
       if (lookahead == 'i')
-        ADVANCE(340);
+        ADVANCE(357);
       if (lookahead == 'k')
-        ADVANCE(349);
+        ADVANCE(366);
       if (lookahead == 't')
-        ADVANCE(422);
+        ADVANCE(439);
       if (lookahead == 'e' ||
           lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(412);
+        ADVANCE(429);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(413);
+        ADVANCE(430);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < '@' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 420:
+    case 437:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(309);
+        ADVANCE(318);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 421:
+    case 438:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'e')
-        ADVANCE(321);
+        ADVANCE(330);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 422:
+    case 439:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'a')
-        ADVANCE(423);
+        ADVANCE(440);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('b' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 423:
+    case 440:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'g')
-        ADVANCE(424);
+        ADVANCE(441);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 424:
+    case 441:
       ACCEPT_TOKEN(anon_sym_tag);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 425:
+    case 442:
       if (lookahead == '%')
         ADVANCE(20);
       if (lookahead == 'm')
-        ADVANCE(426);
+        ADVANCE(443);
       END_STATE();
-    case 426:
+    case 443:
       if (lookahead == 'a')
-        ADVANCE(427);
+        ADVANCE(444);
       END_STATE();
-    case 427:
+    case 444:
       if (lookahead == 'k')
-        ADVANCE(428);
+        ADVANCE(445);
       END_STATE();
-    case 428:
+    case 445:
       if (lookahead == 'e')
-        ADVANCE(429);
+        ADVANCE(446);
       END_STATE();
-    case 429:
+    case 446:
       if (lookahead == 'a')
-        ADVANCE(430);
+        ADVANCE(447);
       END_STATE();
-    case 430:
+    case 447:
       if (lookahead == 't')
-        ADVANCE(431);
+        ADVANCE(448);
       END_STATE();
-    case 431:
+    case 448:
       if (lookahead == 'o')
-        ADVANCE(432);
+        ADVANCE(449);
       END_STATE();
-    case 432:
+    case 449:
       if (lookahead == 't')
-        ADVANCE(433);
+        ADVANCE(450);
       END_STATE();
-    case 433:
+    case 450:
       if (lookahead == 'h')
-        ADVANCE(434);
+        ADVANCE(451);
       END_STATE();
-    case 434:
+    case 451:
       if (lookahead == 'e')
-        ADVANCE(435);
+        ADVANCE(452);
       END_STATE();
-    case 435:
+    case 452:
       if (lookahead == 'r')
-        ADVANCE(436);
+        ADVANCE(453);
       END_STATE();
-    case 436:
+    case 453:
       ACCEPT_TOKEN(anon_sym_makeatother);
       END_STATE();
-    case 437:
+    case 454:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == '(')
@@ -5120,108 +5311,110 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '[')
         ADVANCE(25);
       if (lookahead == 'a')
-        ADVANCE(290);
+        ADVANCE(299);
       if (lookahead == 'b')
-        ADVANCE(303);
+        ADVANCE(312);
       if (lookahead == 'c')
-        ADVANCE(308);
+        ADVANCE(317);
       if (lookahead == 'd')
-        ADVANCE(320);
+        ADVANCE(329);
       if (lookahead == 'e')
-        ADVANCE(438);
-      if (lookahead == 'i')
-        ADVANCE(340);
-      if (lookahead == 'k')
+        ADVANCE(455);
+      if (lookahead == 'f')
         ADVANCE(349);
+      if (lookahead == 'i')
+        ADVANCE(357);
+      if (lookahead == 'k')
+        ADVANCE(366);
       if (lookahead == 'm')
-        ADVANCE(418);
+        ADVANCE(435);
       if (lookahead == 'p')
-        ADVANCE(365);
+        ADVANCE(382);
       if (lookahead == 's')
-        ADVANCE(373);
+        ADVANCE(390);
       if (lookahead == 't')
-        ADVANCE(388);
+        ADVANCE(405);
       if (lookahead == 'u')
-        ADVANCE(398);
+        ADVANCE(415);
       if (lookahead == 'v')
-        ADVANCE(408);
+        ADVANCE(425);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(412);
+        ADVANCE(429);
       if (('@' <= lookahead && lookahead <= 'Z') ||
-          ('f' <= lookahead && lookahead <= 'z'))
-        ADVANCE(413);
+          ('h' <= lookahead && lookahead <= 'z'))
+        ADVANCE(430);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 438:
+    case 455:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(336);
+        ADVANCE(345);
       if (lookahead == 'm')
-        ADVANCE(337);
+        ADVANCE(346);
       if (lookahead == 'n')
-        ADVANCE(439);
+        ADVANCE(456);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 439:
+    case 456:
       ACCEPT_TOKEN(sym__name_at);
       if (lookahead == 'd')
-        ADVANCE(440);
+        ADVANCE(457);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 440:
+    case 457:
       ACCEPT_TOKEN(anon_sym_end);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
-    case 441:
+    case 458:
       if (lookahead == '%')
         ADVANCE(39);
       if (lookahead == 'b')
-        ADVANCE(303);
+        ADVANCE(312);
       if (lookahead == 'c')
-        ADVANCE(420);
+        ADVANCE(437);
       if (lookahead == 'd')
-        ADVANCE(421);
+        ADVANCE(438);
       if (lookahead == 'e')
-        ADVANCE(442);
+        ADVANCE(459);
       if (lookahead == 'i')
-        ADVANCE(340);
+        ADVANCE(357);
       if (lookahead == 'k')
-        ADVANCE(349);
+        ADVANCE(366);
       if (lookahead == 't')
-        ADVANCE(422);
+        ADVANCE(439);
       if (lookahead == 'g' ||
           lookahead == 'x')
-        ADVANCE(412);
+        ADVANCE(429);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(413);
+        ADVANCE(430);
       if (lookahead != 0 &&
           lookahead != '(' &&
           lookahead != ')' &&
           (lookahead < '@' || lookahead > '[') &&
           lookahead != ']')
-        ADVANCE(166);
+        ADVANCE(174);
       END_STATE();
-    case 442:
+    case 459:
       ACCEPT_TOKEN(aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH);
       if (lookahead == 'd')
-        ADVANCE(336);
+        ADVANCE(345);
       if (lookahead == 'n')
-        ADVANCE(439);
+        ADVANCE(456);
       if (('@' <= lookahead && lookahead <= 'Z') ||
           ('a' <= lookahead && lookahead <= 'z'))
-        ADVANCE(297);
+        ADVANCE(306);
       END_STATE();
     default:
       return false;
@@ -5233,24 +5426,24 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [1] = {.lex_state = 35},
   [2] = {.lex_state = 37},
   [3] = {.lex_state = 38},
-  [4] = {.lex_state = 167},
+  [4] = {.lex_state = 175},
   [5] = {.lex_state = 35},
-  [6] = {.lex_state = 168},
-  [7] = {.lex_state = 169},
-  [8] = {.lex_state = 169, .external_lex_state = 2},
-  [9] = {.lex_state = 169},
+  [6] = {.lex_state = 176},
+  [7] = {.lex_state = 177},
+  [8] = {.lex_state = 35, .external_lex_state = 2},
+  [9] = {.lex_state = 177},
   [10] = {.lex_state = 35},
   [11] = {.lex_state = 35},
   [12] = {.lex_state = 35},
   [13] = {.lex_state = 35},
-  [14] = {.lex_state = 170},
+  [14] = {.lex_state = 178},
   [15] = {.lex_state = 35},
   [16] = {.lex_state = 35},
   [17] = {.lex_state = 35},
   [18] = {.lex_state = 35},
   [19] = {.lex_state = 35},
   [20] = {.lex_state = 35},
-  [21] = {.lex_state = 168},
+  [21] = {.lex_state = 176},
   [22] = {.lex_state = 35},
   [23] = {.lex_state = 35},
   [24] = {.lex_state = 35},
@@ -5258,79 +5451,79 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [26] = {.lex_state = 35},
   [27] = {.lex_state = 35},
   [28] = {.lex_state = 35},
-  [29] = {.lex_state = 37},
-  [30] = {.lex_state = 35},
-  [31] = {.lex_state = 171},
-  [32] = {.lex_state = 173, .external_lex_state = 2},
-  [33] = {.lex_state = 35},
-  [34] = {.lex_state = 35},
-  [35] = {.lex_state = 168},
-  [36] = {.lex_state = 35},
-  [37] = {.lex_state = 35},
-  [38] = {.lex_state = 35},
-  [39] = {.lex_state = 35},
+  [29] = {.lex_state = 35},
+  [30] = {.lex_state = 37},
+  [31] = {.lex_state = 35},
+  [32] = {.lex_state = 179},
+  [33] = {.lex_state = 181, .external_lex_state = 2},
+  [34] = {.lex_state = 182},
+  [35] = {.lex_state = 182},
+  [36] = {.lex_state = 176},
+  [37] = {.lex_state = 181},
+  [38] = {.lex_state = 181},
+  [39] = {.lex_state = 181},
   [40] = {.lex_state = 35},
-  [41] = {.lex_state = 168},
-  [42] = {.lex_state = 35},
+  [41] = {.lex_state = 35},
+  [42] = {.lex_state = 176},
   [43] = {.lex_state = 35},
-  [44] = {.lex_state = 35},
-  [45] = {.lex_state = 35},
-  [46] = {.lex_state = 35},
-  [47] = {.lex_state = 35},
-  [48] = {.lex_state = 168},
-  [49] = {.lex_state = 168},
-  [50] = {.lex_state = 167},
-  [51] = {.lex_state = 174},
-  [52] = {.lex_state = 167},
-  [53] = {.lex_state = 35},
-  [54] = {.lex_state = 35},
+  [44] = {.lex_state = 181},
+  [45] = {.lex_state = 181},
+  [46] = {.lex_state = 181},
+  [47] = {.lex_state = 181},
+  [48] = {.lex_state = 181},
+  [49] = {.lex_state = 182},
+  [50] = {.lex_state = 182},
+  [51] = {.lex_state = 176},
+  [52] = {.lex_state = 175},
+  [53] = {.lex_state = 184},
+  [54] = {.lex_state = 175},
   [55] = {.lex_state = 35},
   [56] = {.lex_state = 35},
   [57] = {.lex_state = 35},
-  [58] = {.lex_state = 37},
+  [58] = {.lex_state = 35},
   [59] = {.lex_state = 35},
-  [60] = {.lex_state = 169, .external_lex_state = 3},
+  [60] = {.lex_state = 37},
   [61] = {.lex_state = 35},
-  [62] = {.lex_state = 35},
+  [62] = {.lex_state = 177, .external_lex_state = 3},
   [63] = {.lex_state = 35},
   [64] = {.lex_state = 35},
   [65] = {.lex_state = 35},
-  [66] = {.lex_state = 180},
-  [67] = {.lex_state = 168},
-  [68] = {.lex_state = 35},
-  [69] = {.lex_state = 35},
-  [70] = {.lex_state = 184},
-  [71] = {.lex_state = 170},
-  [72] = {.lex_state = 185},
-  [73] = {.lex_state = 168},
-  [74] = {.lex_state = 35},
-  [75] = {.lex_state = 35},
-  [76] = {.lex_state = 189},
-  [77] = {.lex_state = 286},
-  [78] = {.lex_state = 35},
-  [79] = {.lex_state = 286},
+  [66] = {.lex_state = 35},
+  [67] = {.lex_state = 35},
+  [68] = {.lex_state = 190},
+  [69] = {.lex_state = 176},
+  [70] = {.lex_state = 35},
+  [71] = {.lex_state = 35},
+  [72] = {.lex_state = 194},
+  [73] = {.lex_state = 178},
+  [74] = {.lex_state = 195},
+  [75] = {.lex_state = 176},
+  [76] = {.lex_state = 35},
+  [77] = {.lex_state = 35},
+  [78] = {.lex_state = 199},
+  [79] = {.lex_state = 181},
   [80] = {.lex_state = 35},
-  [81] = {.lex_state = 35},
-  [82] = {.lex_state = 168},
+  [81] = {.lex_state = 181},
+  [82] = {.lex_state = 35},
   [83] = {.lex_state = 35},
-  [84] = {.lex_state = 168},
-  [85] = {.lex_state = 35},
-  [86] = {.lex_state = 168},
-  [87] = {.lex_state = 168},
-  [88] = {.lex_state = 35},
-  [89] = {.lex_state = 287},
-  [90] = {.lex_state = 288},
-  [91] = {.lex_state = 168},
-  [92] = {.lex_state = 168},
-  [93] = {.lex_state = 168},
-  [94] = {.lex_state = 168},
-  [95] = {.lex_state = 289},
-  [96] = {.lex_state = 167},
-  [97] = {.lex_state = 35},
-  [98] = {.lex_state = 35},
-  [99] = {.lex_state = 35},
-  [100] = {.lex_state = 35},
-  [101] = {.lex_state = 35},
+  [84] = {.lex_state = 176},
+  [85] = {.lex_state = 181},
+  [86] = {.lex_state = 37},
+  [87] = {.lex_state = 176},
+  [88] = {.lex_state = 181},
+  [89] = {.lex_state = 176},
+  [90] = {.lex_state = 176},
+  [91] = {.lex_state = 181},
+  [92] = {.lex_state = 296},
+  [93] = {.lex_state = 297},
+  [94] = {.lex_state = 176},
+  [95] = {.lex_state = 176},
+  [96] = {.lex_state = 181},
+  [97] = {.lex_state = 176},
+  [98] = {.lex_state = 176},
+  [99] = {.lex_state = 176},
+  [100] = {.lex_state = 298},
+  [101] = {.lex_state = 175},
   [102] = {.lex_state = 35},
   [103] = {.lex_state = 35},
   [104] = {.lex_state = 35},
@@ -5340,195 +5533,241 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [108] = {.lex_state = 35},
   [109] = {.lex_state = 35},
   [110] = {.lex_state = 35},
-  [111] = {.lex_state = 168},
-  [112] = {.lex_state = 168},
-  [113] = {.lex_state = 37},
+  [111] = {.lex_state = 35},
+  [112] = {.lex_state = 35},
+  [113] = {.lex_state = 35},
   [114] = {.lex_state = 35},
-  [115] = {.lex_state = 168},
-  [116] = {.lex_state = 168},
-  [117] = {.lex_state = 37},
-  [118] = {.lex_state = 35},
-  [119] = {.lex_state = 168},
-  [120] = {.lex_state = 171},
-  [121] = {.lex_state = 169, .external_lex_state = 2},
-  [122] = {.lex_state = 173, .external_lex_state = 2},
-  [123] = {.lex_state = 168},
-  [124] = {.lex_state = 167},
-  [125] = {.lex_state = 35},
-  [126] = {.lex_state = 168},
-  [127] = {.lex_state = 167},
+  [115] = {.lex_state = 35},
+  [116] = {.lex_state = 35},
+  [117] = {.lex_state = 176},
+  [118] = {.lex_state = 176},
+  [119] = {.lex_state = 37},
+  [120] = {.lex_state = 35},
+  [121] = {.lex_state = 176},
+  [122] = {.lex_state = 176},
+  [123] = {.lex_state = 37},
+  [124] = {.lex_state = 35},
+  [125] = {.lex_state = 176},
+  [126] = {.lex_state = 179},
+  [127] = {.lex_state = 35, .external_lex_state = 2},
   [128] = {.lex_state = 35},
-  [129] = {.lex_state = 168},
-  [130] = {.lex_state = 167},
-  [131] = {.lex_state = 168},
-  [132] = {.lex_state = 414},
-  [133] = {.lex_state = 168},
+  [129] = {.lex_state = 35},
+  [130] = {.lex_state = 35},
+  [131] = {.lex_state = 35},
+  [132] = {.lex_state = 35},
+  [133] = {.lex_state = 35},
   [134] = {.lex_state = 35},
-  [135] = {.lex_state = 168},
-  [136] = {.lex_state = 37},
+  [135] = {.lex_state = 35},
+  [136] = {.lex_state = 35},
   [137] = {.lex_state = 35},
-  [138] = {.lex_state = 169, .external_lex_state = 2},
-  [139] = {.lex_state = 37},
-  [140] = {.lex_state = 168},
-  [141] = {.lex_state = 35},
-  [142] = {.lex_state = 416},
-  [143] = {.lex_state = 168},
-  [144] = {.lex_state = 168},
+  [138] = {.lex_state = 35},
+  [139] = {.lex_state = 176},
+  [140] = {.lex_state = 176},
+  [141] = {.lex_state = 175},
+  [142] = {.lex_state = 181},
+  [143] = {.lex_state = 176},
+  [144] = {.lex_state = 175},
   [145] = {.lex_state = 35},
-  [146] = {.lex_state = 168},
-  [147] = {.lex_state = 35},
-  [148] = {.lex_state = 35},
-  [149] = {.lex_state = 168},
-  [150] = {.lex_state = 189},
-  [151] = {.lex_state = 168},
-  [152] = {.lex_state = 170},
-  [153] = {.lex_state = 184},
-  [154] = {.lex_state = 170},
-  [155] = {.lex_state = 168},
-  [156] = {.lex_state = 168},
-  [157] = {.lex_state = 35},
-  [158] = {.lex_state = 167},
-  [159] = {.lex_state = 167},
-  [160] = {.lex_state = 167},
-  [161] = {.lex_state = 167},
-  [162] = {.lex_state = 167},
-  [163] = {.lex_state = 35},
-  [164] = {.lex_state = 286},
-  [165] = {.lex_state = 286},
-  [166] = {.lex_state = 37},
-  [167] = {.lex_state = 170},
-  [168] = {.lex_state = 286},
-  [169] = {.lex_state = 286},
-  [170] = {.lex_state = 168},
-  [171] = {.lex_state = 168},
-  [172] = {.lex_state = 168},
-  [173] = {.lex_state = 288},
-  [174] = {.lex_state = 171},
-  [175] = {.lex_state = 168},
-  [176] = {.lex_state = 168},
-  [177] = {.lex_state = 417},
-  [178] = {.lex_state = 168},
-  [179] = {.lex_state = 167},
-  [180] = {.lex_state = 419},
-  [181] = {.lex_state = 167},
-  [182] = {.lex_state = 35},
-  [183] = {.lex_state = 35},
-  [184] = {.lex_state = 35},
-  [185] = {.lex_state = 35},
-  [186] = {.lex_state = 37},
-  [187] = {.lex_state = 35},
-  [188] = {.lex_state = 425},
-  [189] = {.lex_state = 168},
-  [190] = {.lex_state = 35},
+  [146] = {.lex_state = 176},
+  [147] = {.lex_state = 175},
+  [148] = {.lex_state = 176},
+  [149] = {.lex_state = 431},
+  [150] = {.lex_state = 176},
+  [151] = {.lex_state = 35},
+  [152] = {.lex_state = 176},
+  [153] = {.lex_state = 37},
+  [154] = {.lex_state = 35},
+  [155] = {.lex_state = 35, .external_lex_state = 2},
+  [156] = {.lex_state = 37},
+  [157] = {.lex_state = 176},
+  [158] = {.lex_state = 35},
+  [159] = {.lex_state = 433},
+  [160] = {.lex_state = 176},
+  [161] = {.lex_state = 176},
+  [162] = {.lex_state = 35},
+  [163] = {.lex_state = 176},
+  [164] = {.lex_state = 35},
+  [165] = {.lex_state = 181},
+  [166] = {.lex_state = 176},
+  [167] = {.lex_state = 199},
+  [168] = {.lex_state = 176},
+  [169] = {.lex_state = 178},
+  [170] = {.lex_state = 194},
+  [171] = {.lex_state = 178},
+  [172] = {.lex_state = 176},
+  [173] = {.lex_state = 176},
+  [174] = {.lex_state = 35},
+  [175] = {.lex_state = 175},
+  [176] = {.lex_state = 175},
+  [177] = {.lex_state = 175},
+  [178] = {.lex_state = 175},
+  [179] = {.lex_state = 175},
+  [180] = {.lex_state = 35},
+  [181] = {.lex_state = 181},
+  [182] = {.lex_state = 181},
+  [183] = {.lex_state = 178},
+  [184] = {.lex_state = 181},
+  [185] = {.lex_state = 181},
+  [186] = {.lex_state = 35},
+  [187] = {.lex_state = 176},
+  [188] = {.lex_state = 181},
+  [189] = {.lex_state = 181},
+  [190] = {.lex_state = 37},
   [191] = {.lex_state = 35},
-  [192] = {.lex_state = 35},
+  [192] = {.lex_state = 176},
   [193] = {.lex_state = 35},
-  [194] = {.lex_state = 35},
-  [195] = {.lex_state = 437},
-  [196] = {.lex_state = 168},
+  [194] = {.lex_state = 176},
+  [195] = {.lex_state = 297},
+  [196] = {.lex_state = 179},
   [197] = {.lex_state = 35},
-  [198] = {.lex_state = 286},
-  [199] = {.lex_state = 168},
-  [200] = {.lex_state = 168},
-  [201] = {.lex_state = 35},
-  [202] = {.lex_state = 168},
-  [203] = {.lex_state = 168},
-  [204] = {.lex_state = 168},
-  [205] = {.lex_state = 168},
-  [206] = {.lex_state = 168},
-  [207] = {.lex_state = 37},
+  [198] = {.lex_state = 176},
+  [199] = {.lex_state = 182},
+  [200] = {.lex_state = 182},
+  [201] = {.lex_state = 434},
+  [202] = {.lex_state = 176},
+  [203] = {.lex_state = 175},
+  [204] = {.lex_state = 436},
+  [205] = {.lex_state = 175},
+  [206] = {.lex_state = 35},
+  [207] = {.lex_state = 35},
   [208] = {.lex_state = 35},
-  [209] = {.lex_state = 168},
+  [209] = {.lex_state = 35},
   [210] = {.lex_state = 37},
-  [211] = {.lex_state = 173, .external_lex_state = 2},
-  [212] = {.lex_state = 168},
-  [213] = {.lex_state = 167},
+  [211] = {.lex_state = 35},
+  [212] = {.lex_state = 442},
+  [213] = {.lex_state = 176},
   [214] = {.lex_state = 35},
-  [215] = {.lex_state = 168},
-  [216] = {.lex_state = 167},
-  [217] = {.lex_state = 167},
-  [218] = {.lex_state = 168},
-  [219] = {.lex_state = 168},
-  [220] = {.lex_state = 37},
-  [221] = {.lex_state = 168},
-  [222] = {.lex_state = 168},
-  [223] = {.lex_state = 168},
-  [224] = {.lex_state = 189},
-  [225] = {.lex_state = 168},
-  [226] = {.lex_state = 189},
-  [227] = {.lex_state = 168},
-  [228] = {.lex_state = 167},
-  [229] = {.lex_state = 286},
-  [230] = {.lex_state = 168},
-  [231] = {.lex_state = 286},
-  [232] = {.lex_state = 168},
-  [233] = {.lex_state = 286},
-  [234] = {.lex_state = 167},
+  [215] = {.lex_state = 35},
+  [216] = {.lex_state = 35},
+  [217] = {.lex_state = 35},
+  [218] = {.lex_state = 35},
+  [219] = {.lex_state = 454},
+  [220] = {.lex_state = 176},
+  [221] = {.lex_state = 35},
+  [222] = {.lex_state = 181},
+  [223] = {.lex_state = 176},
+  [224] = {.lex_state = 176},
+  [225] = {.lex_state = 181},
+  [226] = {.lex_state = 37},
+  [227] = {.lex_state = 176},
+  [228] = {.lex_state = 176},
+  [229] = {.lex_state = 181},
+  [230] = {.lex_state = 176},
+  [231] = {.lex_state = 176},
+  [232] = {.lex_state = 176},
+  [233] = {.lex_state = 176},
+  [234] = {.lex_state = 37},
   [235] = {.lex_state = 35},
-  [236] = {.lex_state = 286},
-  [237] = {.lex_state = 286},
-  [238] = {.lex_state = 286},
-  [239] = {.lex_state = 37},
-  [240] = {.lex_state = 170},
-  [241] = {.lex_state = 286},
-  [242] = {.lex_state = 168},
-  [243] = {.lex_state = 168},
-  [244] = {.lex_state = 167},
-  [245] = {.lex_state = 168},
-  [246] = {.lex_state = 167},
-  [247] = {.lex_state = 35},
-  [248] = {.lex_state = 168},
-  [249] = {.lex_state = 167},
-  [250] = {.lex_state = 168},
-  [251] = {.lex_state = 441},
-  [252] = {.lex_state = 168},
-  [253] = {.lex_state = 35},
-  [254] = {.lex_state = 168},
-  [255] = {.lex_state = 37},
-  [256] = {.lex_state = 35},
-  [257] = {.lex_state = 168},
-  [258] = {.lex_state = 35},
-  [259] = {.lex_state = 168},
-  [260] = {.lex_state = 168},
-  [261] = {.lex_state = 168},
-  [262] = {.lex_state = 168},
-  [263] = {.lex_state = 167},
-  [264] = {.lex_state = 35},
-  [265] = {.lex_state = 286},
-  [266] = {.lex_state = 286},
-  [267] = {.lex_state = 37},
-  [268] = {.lex_state = 168},
-  [269] = {.lex_state = 168},
-  [270] = {.lex_state = 37},
-  [271] = {.lex_state = 168},
-  [272] = {.lex_state = 168},
-  [273] = {.lex_state = 167},
-  [274] = {.lex_state = 168},
-  [275] = {.lex_state = 286},
-  [276] = {.lex_state = 35},
-  [277] = {.lex_state = 286},
-  [278] = {.lex_state = 170},
-  [279] = {.lex_state = 168},
-  [280] = {.lex_state = 167},
+  [236] = {.lex_state = 176},
+  [237] = {.lex_state = 37},
+  [238] = {.lex_state = 35},
+  [239] = {.lex_state = 176},
+  [240] = {.lex_state = 175},
+  [241] = {.lex_state = 35},
+  [242] = {.lex_state = 176},
+  [243] = {.lex_state = 175},
+  [244] = {.lex_state = 175},
+  [245] = {.lex_state = 176},
+  [246] = {.lex_state = 176},
+  [247] = {.lex_state = 37},
+  [248] = {.lex_state = 176},
+  [249] = {.lex_state = 182},
+  [250] = {.lex_state = 182},
+  [251] = {.lex_state = 199},
+  [252] = {.lex_state = 176},
+  [253] = {.lex_state = 199},
+  [254] = {.lex_state = 176},
+  [255] = {.lex_state = 35},
+  [256] = {.lex_state = 175},
+  [257] = {.lex_state = 181},
+  [258] = {.lex_state = 176},
+  [259] = {.lex_state = 181},
+  [260] = {.lex_state = 176},
+  [261] = {.lex_state = 181},
+  [262] = {.lex_state = 175},
+  [263] = {.lex_state = 35},
+  [264] = {.lex_state = 181},
+  [265] = {.lex_state = 181},
+  [266] = {.lex_state = 178},
+  [267] = {.lex_state = 181},
+  [268] = {.lex_state = 181},
+  [269] = {.lex_state = 176},
+  [270] = {.lex_state = 181},
+  [271] = {.lex_state = 176},
+  [272] = {.lex_state = 176},
+  [273] = {.lex_state = 176},
+  [274] = {.lex_state = 176},
+  [275] = {.lex_state = 176},
+  [276] = {.lex_state = 176},
+  [277] = {.lex_state = 176},
+  [278] = {.lex_state = 175},
+  [279] = {.lex_state = 176},
+  [280] = {.lex_state = 175},
   [281] = {.lex_state = 35},
-  [282] = {.lex_state = 168},
-  [283] = {.lex_state = 167},
-  [284] = {.lex_state = 167},
-  [285] = {.lex_state = 168},
-  [286] = {.lex_state = 168},
-  [287] = {.lex_state = 37},
-  [288] = {.lex_state = 286},
-  [289] = {.lex_state = 167},
+  [282] = {.lex_state = 176},
+  [283] = {.lex_state = 175},
+  [284] = {.lex_state = 176},
+  [285] = {.lex_state = 458},
+  [286] = {.lex_state = 176},
+  [287] = {.lex_state = 35},
+  [288] = {.lex_state = 176},
+  [289] = {.lex_state = 37},
   [290] = {.lex_state = 35},
-  [291] = {.lex_state = 286},
-  [292] = {.lex_state = 286},
-  [293] = {.lex_state = 37},
-  [294] = {.lex_state = 168},
-  [295] = {.lex_state = 168},
-  [296] = {.lex_state = 168},
-  [297] = {.lex_state = 286},
+  [291] = {.lex_state = 176},
+  [292] = {.lex_state = 35},
+  [293] = {.lex_state = 176},
+  [294] = {.lex_state = 176},
+  [295] = {.lex_state = 176},
+  [296] = {.lex_state = 176},
+  [297] = {.lex_state = 175},
   [298] = {.lex_state = 35},
-  [299] = {.lex_state = 286},
+  [299] = {.lex_state = 181},
+  [300] = {.lex_state = 181},
+  [301] = {.lex_state = 35},
+  [302] = {.lex_state = 176},
+  [303] = {.lex_state = 181},
+  [304] = {.lex_state = 37},
+  [305] = {.lex_state = 35},
+  [306] = {.lex_state = 176},
+  [307] = {.lex_state = 176},
+  [308] = {.lex_state = 37},
+  [309] = {.lex_state = 176},
+  [310] = {.lex_state = 176},
+  [311] = {.lex_state = 176},
+  [312] = {.lex_state = 176},
+  [313] = {.lex_state = 175},
+  [314] = {.lex_state = 176},
+  [315] = {.lex_state = 181},
+  [316] = {.lex_state = 35},
+  [317] = {.lex_state = 181},
+  [318] = {.lex_state = 178},
+  [319] = {.lex_state = 181},
+  [320] = {.lex_state = 176},
+  [321] = {.lex_state = 175},
+  [322] = {.lex_state = 35},
+  [323] = {.lex_state = 176},
+  [324] = {.lex_state = 175},
+  [325] = {.lex_state = 175},
+  [326] = {.lex_state = 176},
+  [327] = {.lex_state = 176},
+  [328] = {.lex_state = 37},
+  [329] = {.lex_state = 181},
+  [330] = {.lex_state = 175},
+  [331] = {.lex_state = 35},
+  [332] = {.lex_state = 181},
+  [333] = {.lex_state = 181},
+  [334] = {.lex_state = 176},
+  [335] = {.lex_state = 181},
+  [336] = {.lex_state = 176},
+  [337] = {.lex_state = 176},
+  [338] = {.lex_state = 35},
+  [339] = {.lex_state = 178},
+  [340] = {.lex_state = 176},
+  [341] = {.lex_state = 176},
+  [342] = {.lex_state = 181},
+  [343] = {.lex_state = 35},
+  [344] = {.lex_state = 181},
+  [345] = {.lex_state = 35},
 };
 
 enum {
@@ -5559,7 +5798,7 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_verb_body] = ACTIONS(1),
     [sym_verb_delim] = ACTIONS(1),
     [ts_builtin_sym_end] = ACTIONS(1),
-    [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = ACTIONS(3),
+    [sym__whitespace] = ACTIONS(1),
     [anon_sym_LBRACK] = ACTIONS(1),
     [anon_sym_RBRACK] = ACTIONS(1),
     [anon_sym_LPAREN] = ACTIONS(1),
@@ -5582,60 +5821,62 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
   },
   [1] = {
     [sym_document] = STATE(7),
-    [sym__common] = STATE(30),
-    [sym__text_mode_common] = STATE(30),
-    [sym_inline_verbatim] = STATE(30),
+    [sym__common] = STATE(31),
+    [sym__text_mode_common] = STATE(31),
+    [sym_inline_verbatim] = STATE(31),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(30),
+    [sym__text_mode] = STATE(31),
     [sym_text_mode] = STATE(9),
-    [sym_text_mode_at_region] = STATE(30),
-    [sym_parameter] = STATE(30),
-    [sym_text_env] = STATE(30),
-    [sym__display_math] = STATE(30),
-    [sym_tex_display_math] = STATE(30),
-    [sym_latex_display_math] = STATE(30),
+    [sym_text_mode_at_region] = STATE(31),
+    [sym_parameter] = STATE(31),
+    [sym_text_env] = STATE(31),
+    [sym__display_math] = STATE(31),
+    [sym_tex_display_math] = STATE(31),
+    [sym_latex_display_math] = STATE(31),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(30),
+    [sym_display_math_env] = STATE(31),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(30),
-    [sym_tex_inline_math] = STATE(30),
-    [sym_latex_inline_math] = STATE(30),
-    [sym_inline_math_env] = STATE(30),
+    [sym__inline_math] = STATE(31),
+    [sym_tex_inline_math] = STATE(31),
+    [sym_latex_inline_math] = STATE(31),
+    [sym_inline_math_env] = STATE(31),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(30),
+    [sym_verbatim_env] = STATE(31),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(30),
+    [sym_escaped] = STATE(31),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(30),
+    [sym_documentclass] = STATE(31),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(30),
+    [sym_usepackage] = STATE(31),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(30),
+    [sym_include] = STATE(31),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(30),
+    [sym_section] = STATE(31),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(30),
+    [sym_storage] = STATE(31),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(30),
+    [sym_catcode] = STATE(31),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(30),
+    [sym_emph] = STATE(31),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(30),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(30),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(30),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(30),
-    [sym_opt_text_group] = STATE(30),
-    [sym_token] = STATE(30),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(30),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_footnote] = STATE(31),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(31),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(31),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(31),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(31),
+    [sym_opt_text_group] = STATE(31),
+    [sym_token] = STATE(31),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(31),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [ts_builtin_sym_end] = ACTIONS(5),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
@@ -5678,860 +5919,634 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
     [anon_sym_emph] = ACTIONS(49),
-    [anon_sym_textbf] = ACTIONS(51),
-    [anon_sym_textit] = ACTIONS(53),
-    [anon_sym_texttt] = ACTIONS(55),
-    [anon_sym_makeatletter] = ACTIONS(57),
+    [anon_sym_footnote] = ACTIONS(51),
+    [anon_sym_textbf] = ACTIONS(53),
+    [anon_sym_textit] = ACTIONS(55),
+    [anon_sym_texttt] = ACTIONS(57),
+    [anon_sym_makeatletter] = ACTIONS(59),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(59),
+    [sym__name] = ACTIONS(61),
   },
   [4] = {
-    [sym__common] = STATE(50),
-    [sym__text_mode_common] = STATE(50),
-    [sym_inline_verbatim] = STATE(50),
+    [sym__common] = STATE(52),
+    [sym__text_mode_common] = STATE(52),
+    [sym_inline_verbatim] = STATE(52),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(50),
-    [sym_text_mode_at_region] = STATE(50),
-    [sym_parameter] = STATE(50),
-    [sym_text_env] = STATE(50),
-    [sym__display_math] = STATE(50),
-    [sym_tex_display_math] = STATE(50),
-    [sym_latex_display_math] = STATE(50),
+    [sym__text_mode] = STATE(52),
+    [sym_text_mode_at_region] = STATE(52),
+    [sym_parameter] = STATE(52),
+    [sym_text_env] = STATE(52),
+    [sym__display_math] = STATE(52),
+    [sym_tex_display_math] = STATE(52),
+    [sym_latex_display_math] = STATE(52),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(50),
+    [sym_display_math_env] = STATE(52),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(50),
-    [sym_tex_inline_math] = STATE(50),
-    [sym_latex_inline_math] = STATE(50),
-    [sym_inline_math_env] = STATE(50),
+    [sym__inline_math] = STATE(52),
+    [sym_tex_inline_math] = STATE(52),
+    [sym_latex_inline_math] = STATE(52),
+    [sym_inline_math_env] = STATE(52),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(50),
+    [sym_verbatim_env] = STATE(52),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(50),
+    [sym_escaped] = STATE(52),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(50),
+    [sym_documentclass] = STATE(52),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(50),
+    [sym_usepackage] = STATE(52),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(50),
+    [sym_include] = STATE(52),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(50),
+    [sym_section] = STATE(52),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(50),
+    [sym_storage] = STATE(52),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(50),
+    [sym_catcode] = STATE(52),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(50),
+    [sym_emph] = STATE(52),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(50),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(50),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(50),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(50),
-    [sym_opt_text_group] = STATE(50),
-    [sym_token] = STATE(50),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(50),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_footnote] = STATE(52),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(52),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(52),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(52),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(52),
+    [sym_opt_text_group] = STATE(52),
+    [sym_token] = STATE(52),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(52),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(61),
+    [sym_end_group] = ACTIONS(63),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(63),
+    [sym_alignment_tab] = ACTIONS(65),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(63),
-    [sym_text] = ACTIONS(63),
+    [sym_active_char] = ACTIONS(65),
+    [sym_text] = ACTIONS(65),
   },
   [5] = {
-    [sym__common] = STATE(59),
-    [sym__math_mode_common] = STATE(59),
-    [sym__math_mode] = STATE(59),
-    [sym_math_mode] = STATE(54),
-    [sym_parameter] = STATE(59),
-    [sym_math_env] = STATE(59),
-    [sym_tag] = STATE(59),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(59),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(59),
+    [sym__common] = STATE(61),
+    [sym__math_mode_common] = STATE(61),
+    [sym__math_mode] = STATE(61),
+    [sym_math_mode] = STATE(56),
+    [sym_parameter] = STATE(61),
+    [sym_math_env] = STATE(61),
+    [sym_tag] = STATE(61),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(61),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(61),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(59),
+    [sym_storage] = STATE(61),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(59),
+    [sym_catcode] = STATE(61),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(59),
-    [sym_opt_math_group] = STATE(59),
-    [sym_token] = STATE(59),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(59),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group] = STATE(61),
+    [sym_opt_math_group] = STATE(61),
+    [sym_token] = STATE(61),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(61),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_math_shift] = ACTIONS(69),
-    [sym_alignment_tab] = ACTIONS(71),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(71),
-    [sym_subscript] = ACTIONS(71),
-    [sym_active_char] = ACTIONS(71),
-    [sym_text] = ACTIONS(71),
-  },
-  [6] = {
-    [ts_builtin_sym_end] = ACTIONS(73),
-    [anon_sym_LBRACK] = ACTIONS(73),
-    [anon_sym_RBRACK] = ACTIONS(73),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(73),
-    [sym_begin_group] = ACTIONS(73),
-    [sym_end_group] = ACTIONS(73),
-    [sym_math_shift] = ACTIONS(73),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_math_shift] = ACTIONS(71),
     [sym_alignment_tab] = ACTIONS(73),
-    [sym_parameter_char] = ACTIONS(73),
+    [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(73),
     [sym_subscript] = ACTIONS(73),
     [sym_active_char] = ACTIONS(73),
     [sym_text] = ACTIONS(73),
   },
-  [7] = {
+  [6] = {
     [ts_builtin_sym_end] = ACTIONS(75),
+    [anon_sym_LBRACK] = ACTIONS(75),
+    [anon_sym_RBRACK] = ACTIONS(75),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(75),
+    [sym_begin_group] = ACTIONS(75),
+    [sym_end_group] = ACTIONS(75),
+    [sym_math_shift] = ACTIONS(75),
+    [sym_alignment_tab] = ACTIONS(75),
+    [sym_parameter_char] = ACTIONS(75),
+    [sym_superscript] = ACTIONS(75),
+    [sym_subscript] = ACTIONS(75),
+    [sym_active_char] = ACTIONS(75),
+    [sym_text] = ACTIONS(75),
+  },
+  [7] = {
+    [ts_builtin_sym_end] = ACTIONS(77),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
   },
   [8] = {
-    [sym_verb_delim] = ACTIONS(77),
+    [sym_verb_delim] = ACTIONS(79),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
   },
   [9] = {
-    [ts_builtin_sym_end] = ACTIONS(79),
+    [ts_builtin_sym_end] = ACTIONS(81),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
   },
   [10] = {
-    [sym__common] = STATE(62),
-    [sym__math_mode_common] = STATE(62),
-    [sym__math_mode] = STATE(62),
-    [sym_math_mode] = STATE(61),
-    [sym_parameter] = STATE(62),
-    [sym_math_env] = STATE(62),
-    [sym_tag] = STATE(62),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(62),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(62),
+    [sym__common] = STATE(64),
+    [sym__math_mode_common] = STATE(64),
+    [sym__math_mode] = STATE(64),
+    [sym_math_mode] = STATE(63),
+    [sym_parameter] = STATE(64),
+    [sym_math_env] = STATE(64),
+    [sym_tag] = STATE(64),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(64),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(64),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(62),
+    [sym_storage] = STATE(64),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(62),
+    [sym_catcode] = STATE(64),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(62),
-    [sym_opt_math_group] = STATE(62),
-    [sym_token] = STATE(62),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(62),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group] = STATE(64),
+    [sym_opt_math_group] = STATE(64),
+    [sym_token] = STATE(64),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(64),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(81),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(83),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(81),
-    [sym_subscript] = ACTIONS(81),
-    [sym_active_char] = ACTIONS(81),
-    [sym_text] = ACTIONS(81),
+    [sym_superscript] = ACTIONS(83),
+    [sym_subscript] = ACTIONS(83),
+    [sym_active_char] = ACTIONS(83),
+    [sym_text] = ACTIONS(83),
   },
   [11] = {
-    [sym__common] = STATE(62),
-    [sym__math_mode_common] = STATE(62),
-    [sym__math_mode] = STATE(62),
-    [sym_math_mode] = STATE(63),
-    [sym_parameter] = STATE(62),
-    [sym_math_env] = STATE(62),
-    [sym_tag] = STATE(62),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(62),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(62),
+    [sym__common] = STATE(64),
+    [sym__math_mode_common] = STATE(64),
+    [sym__math_mode] = STATE(64),
+    [sym_math_mode] = STATE(65),
+    [sym_parameter] = STATE(64),
+    [sym_math_env] = STATE(64),
+    [sym_tag] = STATE(64),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(64),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(64),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(62),
+    [sym_storage] = STATE(64),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(62),
+    [sym_catcode] = STATE(64),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(62),
-    [sym_opt_math_group] = STATE(62),
-    [sym_token] = STATE(62),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(62),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group] = STATE(64),
+    [sym_opt_math_group] = STATE(64),
+    [sym_token] = STATE(64),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(64),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(81),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(83),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(81),
-    [sym_subscript] = ACTIONS(81),
-    [sym_active_char] = ACTIONS(81),
-    [sym_text] = ACTIONS(81),
+    [sym_superscript] = ACTIONS(83),
+    [sym_subscript] = ACTIONS(83),
+    [sym_active_char] = ACTIONS(83),
+    [sym_text] = ACTIONS(83),
   },
   [12] = {
-    [sym__common] = STATE(62),
-    [sym__math_mode_common] = STATE(62),
-    [sym__math_mode] = STATE(62),
-    [sym_math_mode] = STATE(64),
-    [sym_parameter] = STATE(62),
-    [sym_math_env] = STATE(62),
-    [sym_tag] = STATE(62),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(62),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(62),
+    [sym__common] = STATE(64),
+    [sym__math_mode_common] = STATE(64),
+    [sym__math_mode] = STATE(64),
+    [sym_math_mode] = STATE(66),
+    [sym_parameter] = STATE(64),
+    [sym_math_env] = STATE(64),
+    [sym_tag] = STATE(64),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(64),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(64),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(62),
+    [sym_storage] = STATE(64),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(62),
+    [sym_catcode] = STATE(64),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(62),
-    [sym_opt_math_group] = STATE(62),
-    [sym_token] = STATE(62),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(62),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group] = STATE(64),
+    [sym_opt_math_group] = STATE(64),
+    [sym_token] = STATE(64),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(64),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(81),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(83),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(81),
-    [sym_subscript] = ACTIONS(81),
-    [sym_active_char] = ACTIONS(81),
-    [sym_text] = ACTIONS(81),
+    [sym_superscript] = ACTIONS(83),
+    [sym_subscript] = ACTIONS(83),
+    [sym_active_char] = ACTIONS(83),
+    [sym_text] = ACTIONS(83),
   },
   [13] = {
-    [sym__common] = STATE(62),
-    [sym__math_mode_common] = STATE(62),
-    [sym__math_mode] = STATE(62),
-    [sym_math_mode] = STATE(65),
-    [sym_parameter] = STATE(62),
-    [sym_math_env] = STATE(62),
-    [sym_tag] = STATE(62),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(62),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(62),
+    [sym__common] = STATE(64),
+    [sym__math_mode_common] = STATE(64),
+    [sym__math_mode] = STATE(64),
+    [sym_math_mode] = STATE(67),
+    [sym_parameter] = STATE(64),
+    [sym_math_env] = STATE(64),
+    [sym_tag] = STATE(64),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(64),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(64),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(62),
+    [sym_storage] = STATE(64),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(62),
+    [sym_catcode] = STATE(64),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(62),
-    [sym_opt_math_group] = STATE(62),
-    [sym_token] = STATE(62),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(62),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group] = STATE(64),
+    [sym_opt_math_group] = STATE(64),
+    [sym_token] = STATE(64),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(64),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(81),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(83),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(81),
-    [sym_subscript] = ACTIONS(81),
-    [sym_active_char] = ACTIONS(81),
-    [sym_text] = ACTIONS(81),
+    [sym_superscript] = ACTIONS(83),
+    [sym_subscript] = ACTIONS(83),
+    [sym_active_char] = ACTIONS(83),
+    [sym_text] = ACTIONS(83),
   },
   [14] = {
-    [sym_verbatim_end] = STATE(67),
-    [sym_verbatim_text] = STATE(68),
-    [sym_end_token] = STATE(69),
-    [aux_sym_verbatim_text_repeat1] = STATE(70),
-    [aux_sym_verbatim_text_repeat2] = STATE(71),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(83),
+    [sym_verbatim_end] = STATE(69),
+    [sym_verbatim_text] = STATE(70),
+    [sym_end_token] = STATE(71),
+    [aux_sym_verbatim_text_repeat1] = STATE(72),
+    [aux_sym_verbatim_text_repeat2] = STATE(73),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(85),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
-    [sym__end_of_line] = ACTIONS(87),
+    [sym__escape] = ACTIONS(87),
+    [sym__end_of_line] = ACTIONS(89),
   },
   [15] = {
-    [sym__common] = STATE(75),
-    [sym__text_mode_common] = STATE(75),
-    [sym_inline_verbatim] = STATE(75),
+    [sym__common] = STATE(77),
+    [sym__text_mode_common] = STATE(77),
+    [sym_inline_verbatim] = STATE(77),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(75),
-    [sym_text_mode_at_region] = STATE(75),
-    [sym_parameter] = STATE(75),
-    [sym_text_env] = STATE(75),
-    [sym__display_math] = STATE(75),
-    [sym_tex_display_math] = STATE(75),
-    [sym_latex_display_math] = STATE(75),
+    [sym__text_mode] = STATE(77),
+    [sym_text_mode_at_region] = STATE(77),
+    [sym_parameter] = STATE(77),
+    [sym_text_env] = STATE(77),
+    [sym__display_math] = STATE(77),
+    [sym_tex_display_math] = STATE(77),
+    [sym_latex_display_math] = STATE(77),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(75),
+    [sym_display_math_env] = STATE(77),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(75),
-    [sym_tex_inline_math] = STATE(75),
-    [sym_latex_inline_math] = STATE(75),
-    [sym_inline_math_env] = STATE(75),
+    [sym__inline_math] = STATE(77),
+    [sym_tex_inline_math] = STATE(77),
+    [sym_latex_inline_math] = STATE(77),
+    [sym_inline_math_env] = STATE(77),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(75),
+    [sym_verbatim_env] = STATE(77),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(75),
+    [sym_escaped] = STATE(77),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_end] = STATE(73),
-    [sym_end_token] = STATE(74),
-    [sym_documentclass] = STATE(75),
+    [sym_end] = STATE(75),
+    [sym_end_token] = STATE(76),
+    [sym_documentclass] = STATE(77),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(75),
+    [sym_usepackage] = STATE(77),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(75),
+    [sym_include] = STATE(77),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(75),
+    [sym_section] = STATE(77),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(75),
+    [sym_storage] = STATE(77),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(75),
+    [sym_catcode] = STATE(77),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(75),
+    [sym_emph] = STATE(77),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(75),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(75),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(75),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(75),
-    [sym_opt_text_group] = STATE(75),
-    [sym_token] = STATE(75),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(75),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_footnote] = STATE(77),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(77),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(77),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(77),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(77),
+    [sym_opt_text_group] = STATE(77),
+    [sym_token] = STATE(77),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(77),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(89),
+    [sym__escape] = ACTIONS(91),
     [sym_begin_group] = ACTIONS(15),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(91),
+    [sym_alignment_tab] = ACTIONS(93),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(91),
-    [sym_text] = ACTIONS(91),
+    [sym_active_char] = ACTIONS(93),
+    [sym_text] = ACTIONS(93),
   },
   [16] = {
-    [sym_display_math_env_group] = STATE(77),
-    [sym_inline_math_env_group] = STATE(78),
-    [sym_verbatim_env_group] = STATE(79),
-    [sym_simple_text_group] = STATE(80),
+    [sym_display_math_env_group] = STATE(79),
+    [sym_inline_math_env_group] = STATE(80),
+    [sym_verbatim_env_group] = STATE(81),
+    [sym_simple_text_group] = STATE(82),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
+    [sym_begin_group] = ACTIONS(95),
   },
   [17] = {
-    [sym_simple_text_group] = STATE(82),
-    [sym_opt_text_group] = STATE(83),
-    [sym_begin_opt] = STATE(29),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
-  },
-  [18] = {
     [sym_simple_text_group] = STATE(84),
     [sym_opt_text_group] = STATE(85),
-    [sym_begin_opt] = STATE(29),
+    [sym_begin_opt] = STATE(86),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
+    [sym_begin_group] = ACTIONS(97),
+  },
+  [18] = {
+    [sym_simple_text_group] = STATE(87),
+    [sym_opt_text_group] = STATE(88),
+    [sym_begin_opt] = STATE(86),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(97),
   },
   [19] = {
-    [sym_text_group] = STATE(86),
+    [sym_text_group] = STATE(89),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
   [20] = {
-    [sym_text_group] = STATE(87),
-    [sym_opt_text_group] = STATE(88),
-    [sym_begin_opt] = STATE(29),
+    [sym_text_group] = STATE(90),
+    [sym_opt_text_group] = STATE(91),
+    [sym_begin_opt] = STATE(86),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
   [21] = {
-    [ts_builtin_sym_end] = ACTIONS(97),
-    [anon_sym_LBRACK] = ACTIONS(97),
-    [anon_sym_RBRACK] = ACTIONS(97),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(97),
-    [sym_begin_group] = ACTIONS(97),
-    [sym_end_group] = ACTIONS(97),
-    [sym_math_shift] = ACTIONS(97),
-    [sym_alignment_tab] = ACTIONS(97),
-    [sym_parameter_char] = ACTIONS(97),
-    [sym_superscript] = ACTIONS(97),
-    [sym_subscript] = ACTIONS(97),
-    [sym_active_char] = ACTIONS(97),
-    [sym_text] = ACTIONS(97),
-  },
-  [22] = {
-    [sym_escaped] = STATE(90),
+    [ts_builtin_sym_end] = ACTIONS(99),
+    [anon_sym_LBRACK] = ACTIONS(99),
+    [anon_sym_RBRACK] = ACTIONS(99),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(99),
+    [sym_begin_group] = ACTIONS(99),
+    [sym_end_group] = ACTIONS(99),
+    [sym_math_shift] = ACTIONS(99),
+    [sym_alignment_tab] = ACTIONS(99),
+    [sym_parameter_char] = ACTIONS(99),
+    [sym_superscript] = ACTIONS(99),
+    [sym_subscript] = ACTIONS(99),
+    [sym_active_char] = ACTIONS(99),
+    [sym_text] = ACTIONS(99),
+  },
+  [22] = {
+    [sym_escaped] = STATE(93),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(101),
   },
   [23] = {
-    [sym_text_group] = STATE(91),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [24] = {
-    [sym_text_group] = STATE(92),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [25] = {
-    [sym_text_group] = STATE(93),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [26] = {
     [sym_text_group] = STATE(94),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(15),
   },
-  [27] = {
-    [sym__common] = STATE(114),
-    [sym__text_mode_common] = STATE(114),
-    [sym_inline_verbatim] = STATE(114),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(114),
-    [sym_text_mode_at] = STATE(98),
-    [sym_parameter] = STATE(114),
-    [sym_text_env_at] = STATE(114),
-    [sym__display_math_at] = STATE(114),
-    [sym_tex_display_math_at] = STATE(114),
-    [sym_latex_display_math_at] = STATE(114),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(114),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(114),
-    [sym_tex_inline_math_at] = STATE(114),
-    [sym_latex_inline_math_at] = STATE(114),
-    [sym_inline_math_env_at] = STATE(114),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(114),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(114),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(114),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(114),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(114),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(114),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(114),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(114),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(114),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(114),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(114),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(114),
-    [sym_texttt_token] = STATE(110),
-    [sym_makeatother] = STATE(111),
-    [sym_makeatother_token] = STATE(112),
-    [sym_text_group_at] = STATE(114),
-    [sym_opt_text_group_at] = STATE(114),
-    [sym_token_at] = STATE(114),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(114),
-    [aux_sym_parameter_repeat1] = STATE(31),
+  [24] = {
+    [sym_text_group] = STATE(95),
+    [sym_opt_text_group] = STATE(96),
+    [sym_begin_opt] = STATE(86),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(101),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(107),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [25] = {
+    [sym_text_group] = STATE(97),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [26] = {
+    [sym_text_group] = STATE(98),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [27] = {
+    [sym_text_group] = STATE(99),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [28] = {
+    [sym__common] = STATE(120),
+    [sym__text_mode_common] = STATE(120),
+    [sym_inline_verbatim] = STATE(120),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(120),
+    [sym_text_mode_at] = STATE(103),
+    [sym_parameter] = STATE(120),
+    [sym_text_env_at] = STATE(120),
+    [sym__display_math_at] = STATE(120),
+    [sym_tex_display_math_at] = STATE(120),
+    [sym_latex_display_math_at] = STATE(120),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(120),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(120),
+    [sym_tex_inline_math_at] = STATE(120),
+    [sym_latex_inline_math_at] = STATE(120),
+    [sym_inline_math_env_at] = STATE(120),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(120),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(120),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(120),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(120),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(120),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(120),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(120),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(120),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(120),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(120),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(120),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(120),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(120),
+    [sym_texttt_token] = STATE(116),
+    [sym_makeatother] = STATE(117),
+    [sym_makeatother_token] = STATE(118),
+    [sym_text_group_at] = STATE(120),
+    [sym_opt_text_group_at] = STATE(120),
+    [sym_token_at] = STATE(120),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(120),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(103),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(109),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(107),
-    [sym_text] = ACTIONS(107),
-  },
-  [28] = {
-    [anon_sym_LBRACK] = ACTIONS(109),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(109),
-    [sym_begin_group] = ACTIONS(109),
-    [sym_math_shift] = ACTIONS(109),
-    [sym_alignment_tab] = ACTIONS(109),
-    [sym_parameter_char] = ACTIONS(109),
-    [sym_superscript] = ACTIONS(109),
-    [sym_subscript] = ACTIONS(109),
     [sym_active_char] = ACTIONS(109),
     [sym_text] = ACTIONS(109),
   },
   [29] = {
-    [sym__common] = STATE(117),
-    [sym__text_mode_common] = STATE(117),
-    [sym_inline_verbatim] = STATE(117),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(117),
-    [sym_text_mode_at_region] = STATE(117),
-    [sym_parameter] = STATE(117),
-    [sym_text_env] = STATE(117),
-    [sym__display_math] = STATE(117),
-    [sym_tex_display_math] = STATE(117),
-    [sym_latex_display_math] = STATE(117),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(117),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(117),
-    [sym_tex_inline_math] = STATE(117),
-    [sym_latex_inline_math] = STATE(117),
-    [sym_inline_math_env] = STATE(117),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(117),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(117),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(117),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(117),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(117),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(117),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(117),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(117),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(117),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(117),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(117),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(117),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(117),
-    [sym_opt_text_group] = STATE(117),
-    [sym_token] = STATE(117),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(116),
-    [aux_sym_text_mode_repeat1] = STATE(117),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+    [anon_sym_LBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(113),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(113),
-    [sym_text] = ACTIONS(113),
+    [sym__escape] = ACTIONS(111),
+    [sym_begin_group] = ACTIONS(111),
+    [sym_math_shift] = ACTIONS(111),
+    [sym_alignment_tab] = ACTIONS(111),
+    [sym_parameter_char] = ACTIONS(111),
+    [sym_superscript] = ACTIONS(111),
+    [sym_subscript] = ACTIONS(111),
+    [sym_active_char] = ACTIONS(111),
+    [sym_text] = ACTIONS(111),
   },
   [30] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym_inline_verbatim] = STATE(118),
+    [sym__common] = STATE(123),
+    [sym__text_mode_common] = STATE(123),
+    [sym_inline_verbatim] = STATE(123),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
+    [sym__text_mode] = STATE(123),
+    [sym_text_mode_at_region] = STATE(123),
+    [sym_parameter] = STATE(123),
+    [sym_text_env] = STATE(123),
+    [sym__display_math] = STATE(123),
+    [sym_tex_display_math] = STATE(123),
+    [sym_latex_display_math] = STATE(123),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
+    [sym_display_math_env] = STATE(123),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
+    [sym__inline_math] = STATE(123),
+    [sym_tex_inline_math] = STATE(123),
+    [sym_latex_inline_math] = STATE(123),
+    [sym_inline_math_env] = STATE(123),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
+    [sym_verbatim_env] = STATE(123),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
+    [sym_escaped] = STATE(123),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
+    [sym_documentclass] = STATE(123),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
+    [sym_usepackage] = STATE(123),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
+    [sym_include] = STATE(123),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
+    [sym_section] = STATE(123),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
+    [sym_storage] = STATE(123),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
+    [sym_catcode] = STATE(123),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
+    [sym_emph] = STATE(123),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [ts_builtin_sym_end] = ACTIONS(115),
+    [sym_footnote] = STATE(123),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(123),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(123),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(123),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(123),
+    [sym_opt_text_group] = STATE(123),
+    [sym_token] = STATE(123),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(122),
+    [aux_sym_text_mode_repeat1] = STATE(123),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(117),
+    [sym_alignment_tab] = ACTIONS(115),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(117),
-    [sym_text] = ACTIONS(117),
+    [sym_active_char] = ACTIONS(115),
+    [sym_text] = ACTIONS(115),
   },
   [31] = {
-    [aux_sym_parameter_repeat1] = STATE(120),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_parameter_char] = ACTIONS(119),
-    [sym_number] = ACTIONS(121),
-  },
-  [32] = {
-    [sym__whitespace] = STATE(121),
-    [aux_sym__whitespace_repeat1] = STATE(122),
-    [sym_verb_delim] = ACTIONS(123),
-    [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = ACTIONS(125),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [33] = {
-    [anon_sym_LBRACK] = ACTIONS(127),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(127),
-    [sym_begin_group] = ACTIONS(127),
-    [sym_alignment_tab] = ACTIONS(127),
-    [sym_parameter_char] = ACTIONS(127),
-    [sym_superscript] = ACTIONS(127),
-    [sym_subscript] = ACTIONS(127),
-    [sym_active_char] = ACTIONS(127),
-    [sym_text] = ACTIONS(127),
-  },
-  [34] = {
-    [anon_sym_LBRACK] = ACTIONS(129),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(129),
-    [sym_begin_group] = ACTIONS(129),
-    [sym_alignment_tab] = ACTIONS(129),
-    [sym_parameter_char] = ACTIONS(129),
-    [sym_superscript] = ACTIONS(129),
-    [sym_subscript] = ACTIONS(129),
-    [sym_active_char] = ACTIONS(129),
-    [sym_text] = ACTIONS(129),
-  },
-  [35] = {
-    [ts_builtin_sym_end] = ACTIONS(131),
-    [anon_sym_LBRACK] = ACTIONS(131),
-    [anon_sym_RBRACK] = ACTIONS(131),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(131),
-    [sym_begin_group] = ACTIONS(131),
-    [sym_end_group] = ACTIONS(131),
-    [sym_math_shift] = ACTIONS(131),
-    [sym_alignment_tab] = ACTIONS(131),
-    [sym_parameter_char] = ACTIONS(131),
-    [sym_superscript] = ACTIONS(131),
-    [sym_subscript] = ACTIONS(131),
-    [sym_active_char] = ACTIONS(131),
-    [sym_text] = ACTIONS(131),
-  },
-  [36] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(133),
-  },
-  [37] = {
-    [anon_sym_LBRACK] = ACTIONS(135),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(135),
-  },
-  [38] = {
-    [anon_sym_LBRACK] = ACTIONS(137),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(137),
-  },
-  [39] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(139),
-  },
-  [40] = {
-    [anon_sym_LBRACK] = ACTIONS(141),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(141),
-  },
-  [41] = {
-    [ts_builtin_sym_end] = ACTIONS(143),
-    [anon_sym_LBRACK] = ACTIONS(143),
-    [anon_sym_RBRACK] = ACTIONS(143),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(143),
-    [sym_begin_group] = ACTIONS(143),
-    [sym_end_group] = ACTIONS(143),
-    [sym_math_shift] = ACTIONS(143),
-    [sym_alignment_tab] = ACTIONS(143),
-    [sym_parameter_char] = ACTIONS(143),
-    [sym_superscript] = ACTIONS(143),
-    [sym_subscript] = ACTIONS(143),
-    [sym_active_char] = ACTIONS(143),
-    [sym_text] = ACTIONS(143),
-  },
-  [42] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(145),
-  },
-  [43] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(147),
-  },
-  [44] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(149),
-  },
-  [45] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(151),
-  },
-  [46] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(153),
-  },
-  [47] = {
-    [anon_sym_LBRACK] = ACTIONS(155),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(155),
-    [sym_begin_group] = ACTIONS(155),
-    [sym_math_shift] = ACTIONS(155),
-    [sym_alignment_tab] = ACTIONS(155),
-    [sym_parameter_char] = ACTIONS(155),
-    [sym_superscript] = ACTIONS(155),
-    [sym_subscript] = ACTIONS(155),
-    [sym_active_char] = ACTIONS(155),
-    [sym_text] = ACTIONS(155),
-  },
-  [48] = {
-    [ts_builtin_sym_end] = ACTIONS(157),
-    [anon_sym_LBRACK] = ACTIONS(157),
-    [anon_sym_RBRACK] = ACTIONS(157),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(157),
-    [sym_begin_group] = ACTIONS(157),
-    [sym_end_group] = ACTIONS(157),
-    [sym_math_shift] = ACTIONS(157),
-    [sym_alignment_tab] = ACTIONS(157),
-    [sym_parameter_char] = ACTIONS(157),
-    [sym_superscript] = ACTIONS(157),
-    [sym_subscript] = ACTIONS(157),
-    [sym_active_char] = ACTIONS(157),
-    [sym_text] = ACTIONS(157),
-  },
-  [49] = {
-    [ts_builtin_sym_end] = ACTIONS(159),
-    [anon_sym_LBRACK] = ACTIONS(159),
-    [anon_sym_RBRACK] = ACTIONS(159),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(159),
-    [sym_begin_group] = ACTIONS(159),
-    [sym_end_group] = ACTIONS(159),
-    [sym_math_shift] = ACTIONS(159),
-    [sym_alignment_tab] = ACTIONS(159),
-    [sym_parameter_char] = ACTIONS(159),
-    [sym_superscript] = ACTIONS(159),
-    [sym_subscript] = ACTIONS(159),
-    [sym_active_char] = ACTIONS(159),
-    [sym_text] = ACTIONS(159),
-  },
-  [50] = {
     [sym__common] = STATE(124),
     [sym__text_mode_common] = STATE(124),
     [sym_inline_verbatim] = STATE(124),
@@ -6571,316 +6586,212 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_catcode_token] = STATE(22),
     [sym_emph] = STATE(124),
     [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(124),
+    [sym_footnote_token] = STATE(24),
     [sym_textbf] = STATE(124),
-    [sym_textbf_token] = STATE(24),
+    [sym_textbf_token] = STATE(25),
     [sym_textit] = STATE(124),
-    [sym_textit_token] = STATE(25),
+    [sym_textit_token] = STATE(26),
     [sym_texttt] = STATE(124),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
     [sym_text_group] = STATE(124),
     [sym_opt_text_group] = STATE(124),
     [sym_token] = STATE(124),
-    [sym_begin_opt] = STATE(29),
+    [sym_begin_opt] = STATE(30),
     [aux_sym_text_mode_repeat1] = STATE(124),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [ts_builtin_sym_end] = ACTIONS(117),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(161),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(163),
+    [sym_alignment_tab] = ACTIONS(119),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(163),
-    [sym_text] = ACTIONS(163),
+    [sym_active_char] = ACTIONS(119),
+    [sym_text] = ACTIONS(119),
   },
-  [51] = {
-    [anon_sym_tag] = ACTIONS(165),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+  [32] = {
+    [aux_sym_parameter_repeat1] = STATE(126),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(59),
+    [sym_parameter_char] = ACTIONS(121),
+    [sym_number] = ACTIONS(123),
   },
-  [52] = {
-    [sym__common] = STATE(127),
-    [sym__math_mode_common] = STATE(127),
-    [sym__math_mode] = STATE(127),
-    [sym_parameter] = STATE(127),
-    [sym_math_env] = STATE(127),
-    [sym_tag] = STATE(127),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(127),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(127),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(127),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(127),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(127),
-    [sym_opt_math_group] = STATE(127),
-    [sym_token] = STATE(127),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(127),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [33] = {
+    [sym_verb_delim] = ACTIONS(125),
+    [sym__whitespace] = ACTIONS(127),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_end_group] = ACTIONS(167),
-    [sym_alignment_tab] = ACTIONS(169),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(169),
-    [sym_subscript] = ACTIONS(169),
-    [sym_active_char] = ACTIONS(169),
-    [sym_text] = ACTIONS(169),
   },
-  [53] = {
-    [sym__common] = STATE(59),
-    [sym__math_mode_common] = STATE(59),
-    [sym__math_mode] = STATE(59),
-    [sym_math_mode] = STATE(128),
-    [sym_parameter] = STATE(59),
-    [sym_math_env] = STATE(59),
-    [sym_tag] = STATE(59),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(59),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(59),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(59),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(59),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(59),
-    [sym_opt_math_group] = STATE(59),
-    [sym_token] = STATE(59),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(59),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [34] = {
+    [sym__whitespace] = ACTIONS(129),
+    [anon_sym_LBRACK] = ACTIONS(131),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(71),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(71),
-    [sym_subscript] = ACTIONS(71),
-    [sym_active_char] = ACTIONS(71),
-    [sym_text] = ACTIONS(71),
+    [sym__escape] = ACTIONS(131),
+    [sym_begin_group] = ACTIONS(131),
+    [sym_alignment_tab] = ACTIONS(131),
+    [sym_parameter_char] = ACTIONS(131),
+    [sym_superscript] = ACTIONS(131),
+    [sym_subscript] = ACTIONS(131),
+    [sym_active_char] = ACTIONS(131),
+    [sym_text] = ACTIONS(133),
   },
-  [54] = {
+  [35] = {
+    [sym__whitespace] = ACTIONS(135),
+    [anon_sym_LBRACK] = ACTIONS(137),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(171),
+    [sym__escape] = ACTIONS(137),
+    [sym_begin_group] = ACTIONS(137),
+    [sym_alignment_tab] = ACTIONS(137),
+    [sym_parameter_char] = ACTIONS(137),
+    [sym_superscript] = ACTIONS(137),
+    [sym_subscript] = ACTIONS(137),
+    [sym_active_char] = ACTIONS(137),
+    [sym_text] = ACTIONS(139),
   },
-  [55] = {
-    [sym_math_text_group] = STATE(131),
+  [36] = {
+    [ts_builtin_sym_end] = ACTIONS(141),
+    [anon_sym_LBRACK] = ACTIONS(141),
+    [anon_sym_RBRACK] = ACTIONS(141),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(141),
+    [sym_begin_group] = ACTIONS(141),
+    [sym_end_group] = ACTIONS(141),
+    [sym_math_shift] = ACTIONS(141),
+    [sym_alignment_tab] = ACTIONS(141),
+    [sym_parameter_char] = ACTIONS(141),
+    [sym_superscript] = ACTIONS(141),
+    [sym_subscript] = ACTIONS(141),
+    [sym_active_char] = ACTIONS(141),
+    [sym_text] = ACTIONS(141),
+  },
+  [37] = {
+    [sym__whitespace] = ACTIONS(143),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(145),
+  },
+  [38] = {
+    [sym__whitespace] = ACTIONS(147),
+    [anon_sym_LBRACK] = ACTIONS(149),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(149),
+  },
+  [39] = {
+    [sym__whitespace] = ACTIONS(151),
+    [anon_sym_LBRACK] = ACTIONS(153),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(153),
+  },
+  [40] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(155),
+  },
+  [41] = {
+    [anon_sym_LBRACK] = ACTIONS(157),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(157),
+  },
+  [42] = {
+    [ts_builtin_sym_end] = ACTIONS(159),
+    [anon_sym_LBRACK] = ACTIONS(159),
+    [anon_sym_RBRACK] = ACTIONS(159),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(159),
+    [sym_begin_group] = ACTIONS(159),
+    [sym_end_group] = ACTIONS(159),
+    [sym_math_shift] = ACTIONS(159),
+    [sym_alignment_tab] = ACTIONS(159),
+    [sym_parameter_char] = ACTIONS(159),
+    [sym_superscript] = ACTIONS(159),
+    [sym_subscript] = ACTIONS(159),
+    [sym_active_char] = ACTIONS(159),
+    [sym_text] = ACTIONS(159),
+  },
+  [43] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(161),
+  },
+  [44] = {
+    [sym__whitespace] = ACTIONS(163),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(165),
+  },
+  [45] = {
+    [sym__whitespace] = ACTIONS(167),
+    [anon_sym_LBRACK] = ACTIONS(169),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(169),
+  },
+  [46] = {
+    [sym__whitespace] = ACTIONS(171),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym_begin_group] = ACTIONS(173),
   },
-  [56] = {
-    [sym__common] = STATE(134),
-    [sym__math_mode_common] = STATE(134),
-    [sym__math_mode] = STATE(134),
-    [sym_parameter] = STATE(134),
-    [sym_math_env] = STATE(134),
-    [sym_tag] = STATE(134),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(134),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_end] = STATE(133),
-    [sym_end_token] = STATE(74),
-    [sym_include] = STATE(134),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(134),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(134),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(134),
-    [sym_opt_math_group] = STATE(134),
-    [sym_token] = STATE(134),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(134),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [47] = {
+    [sym__whitespace] = ACTIONS(175),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(175),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(177),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(177),
-    [sym_subscript] = ACTIONS(177),
-    [sym_active_char] = ACTIONS(177),
-    [sym_text] = ACTIONS(177),
+    [sym_begin_group] = ACTIONS(177),
   },
-  [57] = {
-    [sym_simple_text_group] = STATE(80),
+  [48] = {
+    [sym__whitespace] = ACTIONS(179),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
+    [sym_begin_group] = ACTIONS(181),
   },
-  [58] = {
-    [sym__common] = STATE(136),
-    [sym__math_mode_common] = STATE(136),
-    [sym__math_mode] = STATE(136),
-    [sym_parameter] = STATE(136),
-    [sym_math_env] = STATE(136),
-    [sym_tag] = STATE(136),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(136),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(136),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(136),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(136),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(136),
-    [sym_opt_math_group] = STATE(136),
-    [sym_token] = STATE(136),
-    [sym_begin_opt] = STATE(58),
-    [sym_end_opt] = STATE(135),
-    [aux_sym_math_mode_repeat1] = STATE(136),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+  [49] = {
+    [sym__whitespace] = ACTIONS(183),
+    [anon_sym_LBRACK] = ACTIONS(185),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(179),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(179),
-    [sym_subscript] = ACTIONS(179),
-    [sym_active_char] = ACTIONS(179),
-    [sym_text] = ACTIONS(179),
+    [sym__escape] = ACTIONS(185),
+    [sym_begin_group] = ACTIONS(185),
+    [sym_math_shift] = ACTIONS(185),
+    [sym_alignment_tab] = ACTIONS(185),
+    [sym_parameter_char] = ACTIONS(185),
+    [sym_superscript] = ACTIONS(185),
+    [sym_subscript] = ACTIONS(185),
+    [sym_active_char] = ACTIONS(185),
+    [sym_text] = ACTIONS(187),
   },
-  [59] = {
-    [sym__common] = STATE(137),
-    [sym__math_mode_common] = STATE(137),
-    [sym__math_mode] = STATE(137),
-    [sym_parameter] = STATE(137),
-    [sym_math_env] = STATE(137),
-    [sym_tag] = STATE(137),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(137),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(137),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(137),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(137),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(137),
-    [sym_opt_math_group] = STATE(137),
-    [sym_token] = STATE(137),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(137),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [50] = {
+    [ts_builtin_sym_end] = ACTIONS(189),
+    [sym__whitespace] = ACTIONS(191),
+    [anon_sym_LBRACK] = ACTIONS(189),
+    [anon_sym_RBRACK] = ACTIONS(189),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_math_shift] = ACTIONS(181),
-    [sym_alignment_tab] = ACTIONS(183),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(183),
-    [sym_subscript] = ACTIONS(183),
-    [sym_active_char] = ACTIONS(183),
-    [sym_text] = ACTIONS(183),
-  },
-  [60] = {
-    [sym_verb_body] = ACTIONS(185),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [61] = {
-    [sym_end_display_math] = STATE(140),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(187),
-  },
-  [62] = {
-    [sym__common] = STATE(141),
-    [sym__math_mode_common] = STATE(141),
-    [sym__math_mode] = STATE(141),
-    [sym_parameter] = STATE(141),
-    [sym_math_env] = STATE(141),
-    [sym_tag] = STATE(141),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(141),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(141),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(141),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(141),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(141),
-    [sym_opt_math_group] = STATE(141),
-    [sym_token] = STATE(141),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(141),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(181),
-    [sym_begin_group] = ACTIONS(67),
+    [sym__escape] = ACTIONS(189),
+    [sym_begin_group] = ACTIONS(189),
+    [sym_end_group] = ACTIONS(189),
+    [sym_math_shift] = ACTIONS(189),
     [sym_alignment_tab] = ACTIONS(189),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(189),
     [sym_superscript] = ACTIONS(189),
     [sym_subscript] = ACTIONS(189),
     [sym_active_char] = ACTIONS(189),
-    [sym_text] = ACTIONS(189),
+    [sym_text] = ACTIONS(193),
   },
-  [63] = {
-    [sym_end_inline_math] = STATE(143),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(191),
-  },
-  [64] = {
-    [sym_display_math_end] = STATE(144),
-    [sym_end_token] = STATE(145),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
-  },
-  [65] = {
-    [sym_inline_math_end] = STATE(146),
-    [sym_end_token] = STATE(147),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
-  },
-  [66] = {
-    [anon_sym_end] = ACTIONS(193),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [67] = {
+  [51] = {
     [ts_builtin_sym_end] = ACTIONS(195),
     [anon_sym_LBRACK] = ACTIONS(195),
     [anon_sym_RBRACK] = ACTIONS(195),
@@ -6897,42 +6808,410 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(195),
     [sym_text] = ACTIONS(195),
   },
-  [68] = {
-    [sym_verbatim_end] = STATE(149),
-    [sym_end_token] = STATE(69),
+  [52] = {
+    [sym__common] = STATE(141),
+    [sym__text_mode_common] = STATE(141),
+    [sym_inline_verbatim] = STATE(141),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(141),
+    [sym_text_mode_at_region] = STATE(141),
+    [sym_parameter] = STATE(141),
+    [sym_text_env] = STATE(141),
+    [sym__display_math] = STATE(141),
+    [sym_tex_display_math] = STATE(141),
+    [sym_latex_display_math] = STATE(141),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(141),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(141),
+    [sym_tex_inline_math] = STATE(141),
+    [sym_latex_inline_math] = STATE(141),
+    [sym_inline_math_env] = STATE(141),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(141),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(141),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(141),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(141),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(141),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(141),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(141),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(141),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(141),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(141),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(141),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(141),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(141),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(141),
+    [sym_opt_text_group] = STATE(141),
+    [sym_token] = STATE(141),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(141),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(197),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(199),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(199),
+    [sym_text] = ACTIONS(199),
+  },
+  [53] = {
+    [anon_sym_tag] = ACTIONS(201),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name] = ACTIONS(61),
+  },
+  [54] = {
+    [sym__common] = STATE(144),
+    [sym__math_mode_common] = STATE(144),
+    [sym__math_mode] = STATE(144),
+    [sym_parameter] = STATE(144),
+    [sym_math_env] = STATE(144),
+    [sym_tag] = STATE(144),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(144),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(144),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(144),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(144),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(144),
+    [sym_opt_math_group] = STATE(144),
+    [sym_token] = STATE(144),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(144),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_end_group] = ACTIONS(203),
+    [sym_alignment_tab] = ACTIONS(205),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(205),
+    [sym_subscript] = ACTIONS(205),
+    [sym_active_char] = ACTIONS(205),
+    [sym_text] = ACTIONS(205),
+  },
+  [55] = {
+    [sym__common] = STATE(61),
+    [sym__math_mode_common] = STATE(61),
+    [sym__math_mode] = STATE(61),
+    [sym_math_mode] = STATE(145),
+    [sym_parameter] = STATE(61),
+    [sym_math_env] = STATE(61),
+    [sym_tag] = STATE(61),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(61),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(61),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(61),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(61),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(61),
+    [sym_opt_math_group] = STATE(61),
+    [sym_token] = STATE(61),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(61),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(73),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(73),
+    [sym_subscript] = ACTIONS(73),
+    [sym_active_char] = ACTIONS(73),
+    [sym_text] = ACTIONS(73),
+  },
+  [56] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(207),
+  },
+  [57] = {
+    [sym_math_text_group] = STATE(148),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(209),
+  },
+  [58] = {
+    [sym__common] = STATE(151),
+    [sym__math_mode_common] = STATE(151),
+    [sym__math_mode] = STATE(151),
+    [sym_parameter] = STATE(151),
+    [sym_math_env] = STATE(151),
+    [sym_tag] = STATE(151),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(151),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_end] = STATE(150),
+    [sym_end_token] = STATE(76),
+    [sym_include] = STATE(151),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(151),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(151),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(151),
+    [sym_opt_math_group] = STATE(151),
+    [sym_token] = STATE(151),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(151),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(211),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(213),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(213),
+    [sym_subscript] = ACTIONS(213),
+    [sym_active_char] = ACTIONS(213),
+    [sym_text] = ACTIONS(213),
+  },
+  [59] = {
+    [sym_simple_text_group] = STATE(82),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(97),
+  },
+  [60] = {
+    [sym__common] = STATE(153),
+    [sym__math_mode_common] = STATE(153),
+    [sym__math_mode] = STATE(153),
+    [sym_parameter] = STATE(153),
+    [sym_math_env] = STATE(153),
+    [sym_tag] = STATE(153),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(153),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(153),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(153),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(153),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(153),
+    [sym_opt_math_group] = STATE(153),
+    [sym_token] = STATE(153),
+    [sym_begin_opt] = STATE(60),
+    [sym_end_opt] = STATE(152),
+    [aux_sym_math_mode_repeat1] = STATE(153),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(215),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(215),
+    [sym_subscript] = ACTIONS(215),
+    [sym_active_char] = ACTIONS(215),
+    [sym_text] = ACTIONS(215),
+  },
+  [61] = {
+    [sym__common] = STATE(154),
+    [sym__math_mode_common] = STATE(154),
+    [sym__math_mode] = STATE(154),
+    [sym_parameter] = STATE(154),
+    [sym_math_env] = STATE(154),
+    [sym_tag] = STATE(154),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(154),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(154),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(154),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(154),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(154),
+    [sym_opt_math_group] = STATE(154),
+    [sym_token] = STATE(154),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(154),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_math_shift] = ACTIONS(217),
+    [sym_alignment_tab] = ACTIONS(219),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(219),
+    [sym_subscript] = ACTIONS(219),
+    [sym_active_char] = ACTIONS(219),
+    [sym_text] = ACTIONS(219),
+  },
+  [62] = {
+    [sym_verb_body] = ACTIONS(221),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [63] = {
+    [sym_end_display_math] = STATE(157),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(223),
+  },
+  [64] = {
+    [sym__common] = STATE(158),
+    [sym__math_mode_common] = STATE(158),
+    [sym__math_mode] = STATE(158),
+    [sym_parameter] = STATE(158),
+    [sym_math_env] = STATE(158),
+    [sym_tag] = STATE(158),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(158),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(158),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(158),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(158),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(158),
+    [sym_opt_math_group] = STATE(158),
+    [sym_token] = STATE(158),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(158),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(217),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(225),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(225),
+    [sym_subscript] = ACTIONS(225),
+    [sym_active_char] = ACTIONS(225),
+    [sym_text] = ACTIONS(225),
+  },
+  [65] = {
+    [sym_end_inline_math] = STATE(160),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(227),
+  },
+  [66] = {
+    [sym_display_math_end] = STATE(161),
+    [sym_end_token] = STATE(162),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(87),
+  },
+  [67] = {
+    [sym_inline_math_end] = STATE(163),
+    [sym_end_token] = STATE(164),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(87),
+  },
+  [68] = {
+    [anon_sym_end] = ACTIONS(229),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
   },
   [69] = {
-    [sym_verbatim_env_group] = STATE(151),
+    [ts_builtin_sym_end] = ACTIONS(231),
+    [anon_sym_LBRACK] = ACTIONS(231),
+    [anon_sym_RBRACK] = ACTIONS(231),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(197),
+    [sym__escape] = ACTIONS(231),
+    [sym_begin_group] = ACTIONS(231),
+    [sym_end_group] = ACTIONS(231),
+    [sym_math_shift] = ACTIONS(231),
+    [sym_alignment_tab] = ACTIONS(231),
+    [sym_parameter_char] = ACTIONS(231),
+    [sym_superscript] = ACTIONS(231),
+    [sym_subscript] = ACTIONS(231),
+    [sym_active_char] = ACTIONS(231),
+    [sym_text] = ACTIONS(231),
   },
   [70] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(153),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(199),
+    [sym_verbatim_end] = STATE(166),
+    [sym_end_token] = STATE(71),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(201),
+    [sym__escape] = ACTIONS(87),
   },
   [71] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(70),
-    [aux_sym_verbatim_text_repeat2] = STATE(154),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(83),
+    [sym_verbatim_env_group] = STATE(168),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(203),
-    [sym__end_of_line] = ACTIONS(205),
+    [sym_begin_group] = ACTIONS(233),
   },
   [72] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(170),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(235),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(237),
+  },
+  [73] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(72),
+    [aux_sym_verbatim_text_repeat2] = STATE(171),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(85),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(239),
+    [sym__end_of_line] = ACTIONS(241),
+  },
+  [74] = {
     [anon_sym_verb] = ACTIONS(27),
     [anon_sym_LBRACK] = ACTIONS(29),
     [anon_sym_LPAREN] = ACTIONS(31),
     [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
     [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_end] = ACTIONS(207),
+    [anon_sym_end] = ACTIONS(243),
     [anon_sym_documentclass] = ACTIONS(37),
     [anon_sym_usepackage] = ACTIONS(39),
     [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
@@ -6940,263 +7219,16 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
     [anon_sym_emph] = ACTIONS(49),
-    [anon_sym_textbf] = ACTIONS(51),
-    [anon_sym_textit] = ACTIONS(53),
-    [anon_sym_texttt] = ACTIONS(55),
-    [anon_sym_makeatletter] = ACTIONS(57),
+    [anon_sym_footnote] = ACTIONS(51),
+    [anon_sym_textbf] = ACTIONS(53),
+    [anon_sym_textit] = ACTIONS(55),
+    [anon_sym_texttt] = ACTIONS(57),
+    [anon_sym_makeatletter] = ACTIONS(59),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(59),
-  },
-  [73] = {
-    [ts_builtin_sym_end] = ACTIONS(209),
-    [anon_sym_LBRACK] = ACTIONS(209),
-    [anon_sym_RBRACK] = ACTIONS(209),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(209),
-    [sym_begin_group] = ACTIONS(209),
-    [sym_end_group] = ACTIONS(209),
-    [sym_math_shift] = ACTIONS(209),
-    [sym_alignment_tab] = ACTIONS(209),
-    [sym_parameter_char] = ACTIONS(209),
-    [sym_superscript] = ACTIONS(209),
-    [sym_subscript] = ACTIONS(209),
-    [sym_active_char] = ACTIONS(209),
-    [sym_text] = ACTIONS(209),
-  },
-  [74] = {
-    [sym_simple_text_group] = STATE(155),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
+    [sym__name] = ACTIONS(61),
   },
   [75] = {
-    [sym__common] = STATE(157),
-    [sym__text_mode_common] = STATE(157),
-    [sym_inline_verbatim] = STATE(157),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(157),
-    [sym_text_mode_at_region] = STATE(157),
-    [sym_parameter] = STATE(157),
-    [sym_text_env] = STATE(157),
-    [sym__display_math] = STATE(157),
-    [sym_tex_display_math] = STATE(157),
-    [sym_latex_display_math] = STATE(157),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(157),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(157),
-    [sym_tex_inline_math] = STATE(157),
-    [sym_latex_inline_math] = STATE(157),
-    [sym_inline_math_env] = STATE(157),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(157),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(157),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_end] = STATE(156),
-    [sym_end_token] = STATE(74),
-    [sym_documentclass] = STATE(157),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(157),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(157),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(157),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(157),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(157),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(157),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(157),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(157),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(157),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(157),
-    [sym_opt_text_group] = STATE(157),
-    [sym_token] = STATE(157),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(157),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(89),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(211),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(211),
-    [sym_text] = ACTIONS(211),
-  },
-  [76] = {
-    [sym_display_math_env_name] = ACTIONS(213),
-    [sym_inline_math_env_name] = ACTIONS(215),
-    [sym_verbatim_env_name] = ACTIONS(217),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_text] = ACTIONS(219),
-  },
-  [77] = {
-    [sym_text_group] = STATE(164),
-    [sym_opt_text_group] = STATE(165),
-    [sym_begin_opt] = STATE(166),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(221),
-    [sym__end_of_line] = ACTIONS(223),
-  },
-  [78] = {
-    [anon_sym_LBRACK] = ACTIONS(225),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(225),
-    [sym_begin_group] = ACTIONS(225),
-    [sym_alignment_tab] = ACTIONS(225),
-    [sym_parameter_char] = ACTIONS(225),
-    [sym_superscript] = ACTIONS(225),
-    [sym_subscript] = ACTIONS(225),
-    [sym_active_char] = ACTIONS(225),
-    [sym_text] = ACTIONS(225),
-  },
-  [79] = {
-    [sym_text_group] = STATE(168),
-    [sym_opt_text_group] = STATE(169),
-    [sym_begin_opt] = STATE(166),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(221),
-    [sym__end_of_line] = ACTIONS(227),
-  },
-  [80] = {
-    [anon_sym_LBRACK] = ACTIONS(229),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(229),
-    [sym_begin_group] = ACTIONS(229),
-    [sym_math_shift] = ACTIONS(229),
-    [sym_alignment_tab] = ACTIONS(229),
-    [sym_parameter_char] = ACTIONS(229),
-    [sym_superscript] = ACTIONS(229),
-    [sym_subscript] = ACTIONS(229),
-    [sym_active_char] = ACTIONS(229),
-    [sym_text] = ACTIONS(229),
-  },
-  [81] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_text] = ACTIONS(231),
-  },
-  [82] = {
-    [ts_builtin_sym_end] = ACTIONS(233),
-    [anon_sym_LBRACK] = ACTIONS(233),
-    [anon_sym_RBRACK] = ACTIONS(233),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(233),
-    [sym_begin_group] = ACTIONS(233),
-    [sym_end_group] = ACTIONS(233),
-    [sym_math_shift] = ACTIONS(233),
-    [sym_alignment_tab] = ACTIONS(233),
-    [sym_parameter_char] = ACTIONS(233),
-    [sym_superscript] = ACTIONS(233),
-    [sym_subscript] = ACTIONS(233),
-    [sym_active_char] = ACTIONS(233),
-    [sym_text] = ACTIONS(233),
-  },
-  [83] = {
-    [sym_simple_text_group] = STATE(170),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
-  },
-  [84] = {
-    [ts_builtin_sym_end] = ACTIONS(235),
-    [anon_sym_LBRACK] = ACTIONS(235),
-    [anon_sym_RBRACK] = ACTIONS(235),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(235),
-    [sym_begin_group] = ACTIONS(235),
-    [sym_end_group] = ACTIONS(235),
-    [sym_math_shift] = ACTIONS(235),
-    [sym_alignment_tab] = ACTIONS(235),
-    [sym_parameter_char] = ACTIONS(235),
-    [sym_superscript] = ACTIONS(235),
-    [sym_subscript] = ACTIONS(235),
-    [sym_active_char] = ACTIONS(235),
-    [sym_text] = ACTIONS(235),
-  },
-  [85] = {
-    [sym_simple_text_group] = STATE(171),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(95),
-  },
-  [86] = {
-    [ts_builtin_sym_end] = ACTIONS(237),
-    [anon_sym_LBRACK] = ACTIONS(237),
-    [anon_sym_RBRACK] = ACTIONS(237),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(237),
-    [sym_begin_group] = ACTIONS(237),
-    [sym_end_group] = ACTIONS(237),
-    [sym_math_shift] = ACTIONS(237),
-    [sym_alignment_tab] = ACTIONS(237),
-    [sym_parameter_char] = ACTIONS(237),
-    [sym_superscript] = ACTIONS(237),
-    [sym_subscript] = ACTIONS(237),
-    [sym_active_char] = ACTIONS(237),
-    [sym_text] = ACTIONS(237),
-  },
-  [87] = {
-    [ts_builtin_sym_end] = ACTIONS(239),
-    [anon_sym_LBRACK] = ACTIONS(239),
-    [anon_sym_RBRACK] = ACTIONS(239),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(239),
-    [sym_begin_group] = ACTIONS(239),
-    [sym_end_group] = ACTIONS(239),
-    [sym_math_shift] = ACTIONS(239),
-    [sym_alignment_tab] = ACTIONS(239),
-    [sym_parameter_char] = ACTIONS(239),
-    [sym_superscript] = ACTIONS(239),
-    [sym_subscript] = ACTIONS(239),
-    [sym_active_char] = ACTIONS(239),
-    [sym_text] = ACTIONS(239),
-  },
-  [88] = {
-    [sym_text_group] = STATE(172),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(15),
-  },
-  [89] = {
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(241),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [90] = {
-    [anon_sym_EQ] = ACTIONS(243),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [91] = {
     [ts_builtin_sym_end] = ACTIONS(245),
     [anon_sym_LBRACK] = ACTIONS(245),
     [anon_sym_RBRACK] = ACTIONS(245),
@@ -7213,463 +7245,263 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(245),
     [sym_text] = ACTIONS(245),
   },
-  [92] = {
-    [ts_builtin_sym_end] = ACTIONS(247),
-    [anon_sym_LBRACK] = ACTIONS(247),
-    [anon_sym_RBRACK] = ACTIONS(247),
+  [76] = {
+    [sym_simple_text_group] = STATE(172),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(247),
-    [sym_begin_group] = ACTIONS(247),
-    [sym_end_group] = ACTIONS(247),
-    [sym_math_shift] = ACTIONS(247),
-    [sym_alignment_tab] = ACTIONS(247),
-    [sym_parameter_char] = ACTIONS(247),
-    [sym_superscript] = ACTIONS(247),
-    [sym_subscript] = ACTIONS(247),
-    [sym_active_char] = ACTIONS(247),
-    [sym_text] = ACTIONS(247),
+    [sym_begin_group] = ACTIONS(97),
   },
-  [93] = {
-    [ts_builtin_sym_end] = ACTIONS(249),
-    [anon_sym_LBRACK] = ACTIONS(249),
-    [anon_sym_RBRACK] = ACTIONS(249),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(249),
-    [sym_begin_group] = ACTIONS(249),
-    [sym_end_group] = ACTIONS(249),
-    [sym_math_shift] = ACTIONS(249),
-    [sym_alignment_tab] = ACTIONS(249),
-    [sym_parameter_char] = ACTIONS(249),
-    [sym_superscript] = ACTIONS(249),
-    [sym_subscript] = ACTIONS(249),
-    [sym_active_char] = ACTIONS(249),
-    [sym_text] = ACTIONS(249),
-  },
-  [94] = {
-    [ts_builtin_sym_end] = ACTIONS(251),
-    [anon_sym_LBRACK] = ACTIONS(251),
-    [anon_sym_RBRACK] = ACTIONS(251),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(251),
-    [sym_begin_group] = ACTIONS(251),
-    [sym_end_group] = ACTIONS(251),
-    [sym_math_shift] = ACTIONS(251),
-    [sym_alignment_tab] = ACTIONS(251),
-    [sym_parameter_char] = ACTIONS(251),
-    [sym_superscript] = ACTIONS(251),
-    [sym_subscript] = ACTIONS(251),
-    [sym_active_char] = ACTIONS(251),
-    [sym_text] = ACTIONS(251),
-  },
-  [95] = {
-    [anon_sym_verb] = ACTIONS(27),
-    [anon_sym_LBRACK] = ACTIONS(29),
-    [anon_sym_LPAREN] = ACTIONS(31),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_documentclass] = ACTIONS(37),
-    [anon_sym_usepackage] = ACTIONS(39),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
-    [anon_sym_emph] = ACTIONS(49),
-    [anon_sym_textbf] = ACTIONS(51),
-    [anon_sym_textit] = ACTIONS(53),
-    [anon_sym_texttt] = ACTIONS(55),
-    [anon_sym_makeatother] = ACTIONS(253),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(255),
-  },
-  [96] = {
-    [sym__common] = STATE(179),
-    [sym__text_mode_common] = STATE(179),
-    [sym_inline_verbatim] = STATE(179),
+  [77] = {
+    [sym__common] = STATE(174),
+    [sym__text_mode_common] = STATE(174),
+    [sym_inline_verbatim] = STATE(174),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(179),
-    [sym_parameter] = STATE(179),
-    [sym_text_env_at] = STATE(179),
-    [sym__display_math_at] = STATE(179),
-    [sym_tex_display_math_at] = STATE(179),
-    [sym_latex_display_math_at] = STATE(179),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(179),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(179),
-    [sym_tex_inline_math_at] = STATE(179),
-    [sym_latex_inline_math_at] = STATE(179),
-    [sym_inline_math_env_at] = STATE(179),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(179),
+    [sym__text_mode] = STATE(174),
+    [sym_text_mode_at_region] = STATE(174),
+    [sym_parameter] = STATE(174),
+    [sym_text_env] = STATE(174),
+    [sym__display_math] = STATE(174),
+    [sym_tex_display_math] = STATE(174),
+    [sym_latex_display_math] = STATE(174),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(174),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(174),
+    [sym_tex_inline_math] = STATE(174),
+    [sym_latex_inline_math] = STATE(174),
+    [sym_inline_math_env] = STATE(174),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(174),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(179),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(179),
+    [sym_escaped] = STATE(174),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_end] = STATE(173),
+    [sym_end_token] = STATE(76),
+    [sym_documentclass] = STATE(174),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(179),
+    [sym_usepackage] = STATE(174),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(179),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(179),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(179),
+    [sym_include] = STATE(174),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(174),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(174),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(179),
+    [sym_catcode] = STATE(174),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(179),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(179),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(179),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(179),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(179),
-    [sym_opt_text_group_at] = STATE(179),
-    [sym_token_at] = STATE(179),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(179),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_emph] = STATE(174),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(174),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(174),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(174),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(174),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(174),
+    [sym_opt_text_group] = STATE(174),
+    [sym_token] = STATE(174),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(174),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_end_group] = ACTIONS(259),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(261),
+    [sym__escape] = ACTIONS(91),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(247),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(261),
-    [sym_text] = ACTIONS(261),
+    [sym_active_char] = ACTIONS(247),
+    [sym_text] = ACTIONS(247),
   },
-  [97] = {
-    [sym__common] = STATE(187),
-    [sym__math_mode_common] = STATE(187),
-    [sym__math_mode_at] = STATE(187),
-    [sym_math_mode_at] = STATE(183),
-    [sym_parameter] = STATE(187),
-    [sym_math_env_at] = STATE(187),
-    [sym_tag_at] = STATE(187),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(187),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(187),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(187),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(187),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(187),
-    [sym_opt_math_group_at] = STATE(187),
-    [sym_token_at] = STATE(187),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(187),
-    [aux_sym_parameter_repeat1] = STATE(31),
+  [78] = {
+    [sym_display_math_env_name] = ACTIONS(249),
+    [sym_inline_math_env_name] = ACTIONS(251),
+    [sym_verbatim_env_name] = ACTIONS(253),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_text] = ACTIONS(255),
+  },
+  [79] = {
+    [sym_text_group] = STATE(181),
+    [sym_opt_text_group] = STATE(182),
+    [sym_begin_opt] = STATE(86),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(259),
+  },
+  [80] = {
+    [anon_sym_LBRACK] = ACTIONS(261),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(261),
+    [sym_begin_group] = ACTIONS(261),
+    [sym_alignment_tab] = ACTIONS(261),
+    [sym_parameter_char] = ACTIONS(261),
+    [sym_superscript] = ACTIONS(261),
+    [sym_subscript] = ACTIONS(261),
+    [sym_active_char] = ACTIONS(261),
+    [sym_text] = ACTIONS(261),
+  },
+  [81] = {
+    [sym_text_group] = STATE(184),
+    [sym_opt_text_group] = STATE(185),
+    [sym_begin_opt] = STATE(86),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(263),
+  },
+  [82] = {
+    [anon_sym_LBRACK] = ACTIONS(265),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(265),
     [sym_begin_group] = ACTIONS(265),
-    [sym_math_shift] = ACTIONS(267),
+    [sym_math_shift] = ACTIONS(265),
+    [sym_alignment_tab] = ACTIONS(265),
+    [sym_parameter_char] = ACTIONS(265),
+    [sym_superscript] = ACTIONS(265),
+    [sym_subscript] = ACTIONS(265),
+    [sym_active_char] = ACTIONS(265),
+    [sym_text] = ACTIONS(265),
+  },
+  [83] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_text] = ACTIONS(267),
+  },
+  [84] = {
+    [ts_builtin_sym_end] = ACTIONS(269),
+    [anon_sym_LBRACK] = ACTIONS(269),
+    [anon_sym_RBRACK] = ACTIONS(269),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(269),
+    [sym_begin_group] = ACTIONS(269),
+    [sym_end_group] = ACTIONS(269),
+    [sym_math_shift] = ACTIONS(269),
     [sym_alignment_tab] = ACTIONS(269),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(269),
     [sym_superscript] = ACTIONS(269),
     [sym_subscript] = ACTIONS(269),
     [sym_active_char] = ACTIONS(269),
     [sym_text] = ACTIONS(269),
   },
-  [98] = {
-    [sym_makeatother] = STATE(189),
-    [sym_makeatother_token] = STATE(112),
+  [85] = {
+    [sym_simple_text_group] = STATE(187),
+    [sym__whitespace] = ACTIONS(271),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(271),
+    [sym_begin_group] = ACTIONS(97),
   },
-  [99] = {
-    [sym__common] = STATE(191),
-    [sym__math_mode_common] = STATE(191),
-    [sym__math_mode_at] = STATE(191),
-    [sym_math_mode_at] = STATE(190),
-    [sym_parameter] = STATE(191),
-    [sym_math_env_at] = STATE(191),
-    [sym_tag_at] = STATE(191),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(191),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(191),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(191),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(191),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(191),
-    [sym_opt_math_group_at] = STATE(191),
-    [sym_token_at] = STATE(191),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(191),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(273),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(273),
-    [sym_subscript] = ACTIONS(273),
-    [sym_active_char] = ACTIONS(273),
-    [sym_text] = ACTIONS(273),
-  },
-  [100] = {
-    [sym__common] = STATE(191),
-    [sym__math_mode_common] = STATE(191),
-    [sym__math_mode_at] = STATE(191),
-    [sym_math_mode_at] = STATE(192),
-    [sym_parameter] = STATE(191),
-    [sym_math_env_at] = STATE(191),
-    [sym_tag_at] = STATE(191),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(191),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(191),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(191),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(191),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(191),
-    [sym_opt_math_group_at] = STATE(191),
-    [sym_token_at] = STATE(191),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(191),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(273),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(273),
-    [sym_subscript] = ACTIONS(273),
-    [sym_active_char] = ACTIONS(273),
-    [sym_text] = ACTIONS(273),
-  },
-  [101] = {
-    [sym__common] = STATE(191),
-    [sym__math_mode_common] = STATE(191),
-    [sym__math_mode_at] = STATE(191),
-    [sym_math_mode_at] = STATE(193),
-    [sym_parameter] = STATE(191),
-    [sym_math_env_at] = STATE(191),
-    [sym_tag_at] = STATE(191),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(191),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(191),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(191),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(191),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(191),
-    [sym_opt_math_group_at] = STATE(191),
-    [sym_token_at] = STATE(191),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(191),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(273),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(273),
-    [sym_subscript] = ACTIONS(273),
-    [sym_active_char] = ACTIONS(273),
-    [sym_text] = ACTIONS(273),
-  },
-  [102] = {
-    [sym__common] = STATE(191),
-    [sym__math_mode_common] = STATE(191),
-    [sym__math_mode_at] = STATE(191),
-    [sym_math_mode_at] = STATE(194),
-    [sym_parameter] = STATE(191),
-    [sym_math_env_at] = STATE(191),
-    [sym_tag_at] = STATE(191),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(191),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(191),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(191),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(191),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(191),
-    [sym_opt_math_group_at] = STATE(191),
-    [sym_token_at] = STATE(191),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(191),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(273),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(273),
-    [sym_subscript] = ACTIONS(273),
-    [sym_active_char] = ACTIONS(273),
-    [sym_text] = ACTIONS(273),
-  },
-  [103] = {
-    [sym__common] = STATE(197),
-    [sym__text_mode_common] = STATE(197),
-    [sym_inline_verbatim] = STATE(197),
+  [86] = {
+    [sym__common] = STATE(190),
+    [sym__text_mode_common] = STATE(190),
+    [sym_inline_verbatim] = STATE(190),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(197),
-    [sym_parameter] = STATE(197),
-    [sym_text_env_at] = STATE(197),
-    [sym__display_math_at] = STATE(197),
-    [sym_tex_display_math_at] = STATE(197),
-    [sym_latex_display_math_at] = STATE(197),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(197),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(197),
-    [sym_tex_inline_math_at] = STATE(197),
-    [sym_latex_inline_math_at] = STATE(197),
-    [sym_inline_math_env_at] = STATE(197),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(197),
+    [sym__text_mode] = STATE(190),
+    [sym_text_mode_at_region] = STATE(190),
+    [sym_parameter] = STATE(190),
+    [sym_text_env] = STATE(190),
+    [sym__display_math] = STATE(190),
+    [sym_tex_display_math] = STATE(190),
+    [sym_latex_display_math] = STATE(190),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(190),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(190),
+    [sym_tex_inline_math] = STATE(190),
+    [sym_latex_inline_math] = STATE(190),
+    [sym_inline_math_env] = STATE(190),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(190),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(197),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_end] = STATE(196),
-    [sym_end_token] = STATE(74),
-    [sym_documentclass] = STATE(197),
+    [sym_escaped] = STATE(190),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(190),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(197),
+    [sym_usepackage] = STATE(190),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(197),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(197),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(197),
+    [sym_include] = STATE(190),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(190),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(190),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(197),
+    [sym_catcode] = STATE(190),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(197),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(197),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(197),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(197),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(197),
-    [sym_opt_text_group_at] = STATE(197),
-    [sym_token_at] = STATE(197),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(197),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_emph] = STATE(190),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(190),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(190),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(190),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(190),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(190),
+    [sym_opt_text_group] = STATE(190),
+    [sym_token] = STATE(190),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(189),
+    [aux_sym_text_mode_repeat1] = STATE(190),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(273),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(275),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(277),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(275),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(275),
+    [sym_text] = ACTIONS(275),
+  },
+  [87] = {
+    [ts_builtin_sym_end] = ACTIONS(277),
+    [anon_sym_LBRACK] = ACTIONS(277),
+    [anon_sym_RBRACK] = ACTIONS(277),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(277),
+    [sym_begin_group] = ACTIONS(277),
+    [sym_end_group] = ACTIONS(277),
+    [sym_math_shift] = ACTIONS(277),
+    [sym_alignment_tab] = ACTIONS(277),
+    [sym_parameter_char] = ACTIONS(277),
+    [sym_superscript] = ACTIONS(277),
+    [sym_subscript] = ACTIONS(277),
     [sym_active_char] = ACTIONS(277),
     [sym_text] = ACTIONS(277),
   },
-  [104] = {
-    [sym_display_math_env_group] = STATE(198),
-    [sym_inline_math_env_group] = STATE(78),
-    [sym_verbatim_env_group] = STATE(79),
-    [sym_simple_text_group] = STATE(80),
+  [88] = {
+    [sym_simple_text_group] = STATE(192),
+    [sym__whitespace] = ACTIONS(279),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(93),
+    [sym_begin_group] = ACTIONS(97),
   },
-  [105] = {
-    [sym_text_group_at] = STATE(199),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [106] = {
-    [sym_text_group_at] = STATE(200),
-    [sym_opt_text_group_at] = STATE(201),
-    [sym_begin_opt] = STATE(113),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [107] = {
-    [sym_text_group_at] = STATE(202),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [108] = {
-    [sym_text_group_at] = STATE(203),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [109] = {
-    [sym_text_group_at] = STATE(204),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [110] = {
-    [sym_text_group_at] = STATE(205),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [111] = {
-    [ts_builtin_sym_end] = ACTIONS(279),
-    [anon_sym_LBRACK] = ACTIONS(279),
-    [anon_sym_RBRACK] = ACTIONS(279),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(279),
-    [sym_begin_group] = ACTIONS(279),
-    [sym_end_group] = ACTIONS(279),
-    [sym_math_shift] = ACTIONS(279),
-    [sym_alignment_tab] = ACTIONS(279),
-    [sym_parameter_char] = ACTIONS(279),
-    [sym_superscript] = ACTIONS(279),
-    [sym_subscript] = ACTIONS(279),
-    [sym_active_char] = ACTIONS(279),
-    [sym_text] = ACTIONS(279),
-  },
-  [112] = {
+  [89] = {
     [ts_builtin_sym_end] = ACTIONS(281),
     [anon_sym_LBRACK] = ACTIONS(281),
     [anon_sym_RBRACK] = ACTIONS(281),
@@ -7686,154 +7518,41 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(281),
     [sym_text] = ACTIONS(281),
   },
-  [113] = {
-    [sym__common] = STATE(207),
-    [sym__text_mode_common] = STATE(207),
-    [sym_inline_verbatim] = STATE(207),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(207),
-    [sym_parameter] = STATE(207),
-    [sym_text_env_at] = STATE(207),
-    [sym__display_math_at] = STATE(207),
-    [sym_tex_display_math_at] = STATE(207),
-    [sym_latex_display_math_at] = STATE(207),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(207),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(207),
-    [sym_tex_inline_math_at] = STATE(207),
-    [sym_latex_inline_math_at] = STATE(207),
-    [sym_inline_math_env_at] = STATE(207),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(207),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(207),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(207),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(207),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(207),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(207),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(207),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(207),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(207),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(207),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(207),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(207),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(207),
-    [sym_opt_text_group_at] = STATE(207),
-    [sym_token_at] = STATE(207),
-    [sym_begin_opt] = STATE(113),
-    [sym_end_opt] = STATE(206),
-    [aux_sym_text_mode_at_repeat1] = STATE(207),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+  [90] = {
+    [ts_builtin_sym_end] = ACTIONS(283),
+    [anon_sym_LBRACK] = ACTIONS(283),
+    [anon_sym_RBRACK] = ACTIONS(283),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
+    [sym__escape] = ACTIONS(283),
+    [sym_begin_group] = ACTIONS(283),
+    [sym_end_group] = ACTIONS(283),
+    [sym_math_shift] = ACTIONS(283),
     [sym_alignment_tab] = ACTIONS(283),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(283),
+    [sym_superscript] = ACTIONS(283),
+    [sym_subscript] = ACTIONS(283),
     [sym_active_char] = ACTIONS(283),
     [sym_text] = ACTIONS(283),
   },
-  [114] = {
-    [sym__common] = STATE(208),
-    [sym__text_mode_common] = STATE(208),
-    [sym_inline_verbatim] = STATE(208),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(208),
-    [sym_parameter] = STATE(208),
-    [sym_text_env_at] = STATE(208),
-    [sym__display_math_at] = STATE(208),
-    [sym_tex_display_math_at] = STATE(208),
-    [sym_latex_display_math_at] = STATE(208),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(208),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(208),
-    [sym_tex_inline_math_at] = STATE(208),
-    [sym_latex_inline_math_at] = STATE(208),
-    [sym_inline_math_env_at] = STATE(208),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(208),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(208),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(208),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(208),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(208),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(208),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(208),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(208),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(208),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(208),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(208),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(208),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(208),
-    [sym_opt_text_group_at] = STATE(208),
-    [sym_token_at] = STATE(208),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(208),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [91] = {
+    [sym_text_group] = STATE(194),
+    [sym__whitespace] = ACTIONS(285),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(285),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(287),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(287),
-    [sym_text] = ACTIONS(287),
+    [sym_begin_group] = ACTIONS(15),
   },
-  [115] = {
-    [ts_builtin_sym_end] = ACTIONS(289),
-    [anon_sym_LBRACK] = ACTIONS(289),
-    [anon_sym_RBRACK] = ACTIONS(289),
+  [92] = {
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(287),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(289),
-    [sym_begin_group] = ACTIONS(289),
-    [sym_end_group] = ACTIONS(289),
-    [sym_math_shift] = ACTIONS(289),
-    [sym_alignment_tab] = ACTIONS(289),
-    [sym_parameter_char] = ACTIONS(289),
-    [sym_superscript] = ACTIONS(289),
-    [sym_subscript] = ACTIONS(289),
-    [sym_active_char] = ACTIONS(289),
-    [sym_text] = ACTIONS(289),
   },
-  [116] = {
+  [93] = {
+    [anon_sym_EQ] = ACTIONS(289),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [94] = {
     [ts_builtin_sym_end] = ACTIONS(291),
     [anon_sym_LBRACK] = ACTIONS(291),
     [anon_sym_RBRACK] = ACTIONS(291),
@@ -7850,180 +7569,501 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(291),
     [sym_text] = ACTIONS(291),
   },
-  [117] = {
-    [sym__common] = STATE(210),
-    [sym__text_mode_common] = STATE(210),
-    [sym_inline_verbatim] = STATE(210),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(210),
-    [sym_text_mode_at_region] = STATE(210),
-    [sym_parameter] = STATE(210),
-    [sym_text_env] = STATE(210),
-    [sym__display_math] = STATE(210),
-    [sym_tex_display_math] = STATE(210),
-    [sym_latex_display_math] = STATE(210),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(210),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(210),
-    [sym_tex_inline_math] = STATE(210),
-    [sym_latex_inline_math] = STATE(210),
-    [sym_inline_math_env] = STATE(210),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(210),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(210),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(210),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(210),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(210),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(210),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(210),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(210),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(210),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(210),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(210),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(210),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(210),
-    [sym_opt_text_group] = STATE(210),
-    [sym_token] = STATE(210),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(209),
-    [aux_sym_text_mode_repeat1] = STATE(210),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+  [95] = {
+    [ts_builtin_sym_end] = ACTIONS(293),
+    [anon_sym_LBRACK] = ACTIONS(293),
+    [anon_sym_RBRACK] = ACTIONS(293),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
+    [sym__escape] = ACTIONS(293),
+    [sym_begin_group] = ACTIONS(293),
+    [sym_end_group] = ACTIONS(293),
+    [sym_math_shift] = ACTIONS(293),
     [sym_alignment_tab] = ACTIONS(293),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(293),
+    [sym_superscript] = ACTIONS(293),
+    [sym_subscript] = ACTIONS(293),
     [sym_active_char] = ACTIONS(293),
     [sym_text] = ACTIONS(293),
   },
-  [118] = {
-    [sym__common] = STATE(118),
-    [sym__text_mode_common] = STATE(118),
-    [sym_inline_verbatim] = STATE(118),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(118),
-    [sym_text_mode_at_region] = STATE(118),
-    [sym_parameter] = STATE(118),
-    [sym_text_env] = STATE(118),
-    [sym__display_math] = STATE(118),
-    [sym_tex_display_math] = STATE(118),
-    [sym_latex_display_math] = STATE(118),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(118),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(118),
-    [sym_tex_inline_math] = STATE(118),
-    [sym_latex_inline_math] = STATE(118),
-    [sym_inline_math_env] = STATE(118),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(118),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(118),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(118),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(118),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(118),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(118),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(118),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(118),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(118),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(118),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(118),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(118),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(118),
-    [sym_opt_text_group] = STATE(118),
-    [sym_token] = STATE(118),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(118),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [ts_builtin_sym_end] = ACTIONS(295),
+  [96] = {
+    [sym_text_group] = STATE(198),
+    [sym__whitespace] = ACTIONS(295),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(15),
+  },
+  [97] = {
+    [ts_builtin_sym_end] = ACTIONS(297),
     [anon_sym_LBRACK] = ACTIONS(297),
+    [anon_sym_RBRACK] = ACTIONS(297),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(300),
-    [sym_begin_group] = ACTIONS(303),
-    [sym_math_shift] = ACTIONS(306),
-    [sym_alignment_tab] = ACTIONS(309),
-    [sym_parameter_char] = ACTIONS(312),
-    [sym_superscript] = ACTIONS(315),
-    [sym_subscript] = ACTIONS(315),
-    [sym_active_char] = ACTIONS(309),
-    [sym_text] = ACTIONS(309),
+    [sym__escape] = ACTIONS(297),
+    [sym_begin_group] = ACTIONS(297),
+    [sym_end_group] = ACTIONS(297),
+    [sym_math_shift] = ACTIONS(297),
+    [sym_alignment_tab] = ACTIONS(297),
+    [sym_parameter_char] = ACTIONS(297),
+    [sym_superscript] = ACTIONS(297),
+    [sym_subscript] = ACTIONS(297),
+    [sym_active_char] = ACTIONS(297),
+    [sym_text] = ACTIONS(297),
   },
-  [119] = {
-    [ts_builtin_sym_end] = ACTIONS(318),
-    [anon_sym_LBRACK] = ACTIONS(318),
-    [anon_sym_RBRACK] = ACTIONS(318),
+  [98] = {
+    [ts_builtin_sym_end] = ACTIONS(299),
+    [anon_sym_LBRACK] = ACTIONS(299),
+    [anon_sym_RBRACK] = ACTIONS(299),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(318),
-    [sym_begin_group] = ACTIONS(318),
-    [sym_end_group] = ACTIONS(318),
-    [sym_math_shift] = ACTIONS(318),
-    [sym_alignment_tab] = ACTIONS(318),
-    [sym_parameter_char] = ACTIONS(318),
-    [sym_superscript] = ACTIONS(318),
-    [sym_subscript] = ACTIONS(318),
-    [sym_active_char] = ACTIONS(318),
-    [sym_text] = ACTIONS(318),
+    [sym__escape] = ACTIONS(299),
+    [sym_begin_group] = ACTIONS(299),
+    [sym_end_group] = ACTIONS(299),
+    [sym_math_shift] = ACTIONS(299),
+    [sym_alignment_tab] = ACTIONS(299),
+    [sym_parameter_char] = ACTIONS(299),
+    [sym_superscript] = ACTIONS(299),
+    [sym_subscript] = ACTIONS(299),
+    [sym_active_char] = ACTIONS(299),
+    [sym_text] = ACTIONS(299),
   },
-  [120] = {
-    [aux_sym_parameter_repeat1] = STATE(120),
+  [99] = {
+    [ts_builtin_sym_end] = ACTIONS(301),
+    [anon_sym_LBRACK] = ACTIONS(301),
+    [anon_sym_RBRACK] = ACTIONS(301),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_parameter_char] = ACTIONS(320),
-    [sym_number] = ACTIONS(323),
+    [sym__escape] = ACTIONS(301),
+    [sym_begin_group] = ACTIONS(301),
+    [sym_end_group] = ACTIONS(301),
+    [sym_math_shift] = ACTIONS(301),
+    [sym_alignment_tab] = ACTIONS(301),
+    [sym_parameter_char] = ACTIONS(301),
+    [sym_superscript] = ACTIONS(301),
+    [sym_subscript] = ACTIONS(301),
+    [sym_active_char] = ACTIONS(301),
+    [sym_text] = ACTIONS(301),
   },
-  [121] = {
-    [sym_verb_delim] = ACTIONS(325),
+  [100] = {
+    [anon_sym_verb] = ACTIONS(27),
+    [anon_sym_LBRACK] = ACTIONS(29),
+    [anon_sym_LPAREN] = ACTIONS(31),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [anon_sym_documentclass] = ACTIONS(37),
+    [anon_sym_usepackage] = ACTIONS(39),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [anon_sym_emph] = ACTIONS(49),
+    [anon_sym_footnote] = ACTIONS(51),
+    [anon_sym_textbf] = ACTIONS(53),
+    [anon_sym_textit] = ACTIONS(55),
+    [anon_sym_texttt] = ACTIONS(57),
+    [anon_sym_makeatother] = ACTIONS(303),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(305),
   },
-  [122] = {
-    [aux_sym__whitespace_repeat1] = STATE(211),
-    [sym_verb_delim] = ACTIONS(327),
-    [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = ACTIONS(329),
+  [101] = {
+    [sym__common] = STATE(203),
+    [sym__text_mode_common] = STATE(203),
+    [sym_inline_verbatim] = STATE(203),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(203),
+    [sym_parameter] = STATE(203),
+    [sym_text_env_at] = STATE(203),
+    [sym__display_math_at] = STATE(203),
+    [sym_tex_display_math_at] = STATE(203),
+    [sym_latex_display_math_at] = STATE(203),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(203),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(203),
+    [sym_tex_inline_math_at] = STATE(203),
+    [sym_latex_inline_math_at] = STATE(203),
+    [sym_inline_math_env_at] = STATE(203),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(203),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(203),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(203),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(203),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(203),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(203),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(203),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(203),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(203),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(203),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(203),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(203),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(203),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(203),
+    [sym_opt_text_group_at] = STATE(203),
+    [sym_token_at] = STATE(203),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(203),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(309),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(311),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(311),
+    [sym_text] = ACTIONS(311),
   },
-  [123] = {
+  [102] = {
+    [sym__common] = STATE(211),
+    [sym__math_mode_common] = STATE(211),
+    [sym__math_mode_at] = STATE(211),
+    [sym_math_mode_at] = STATE(207),
+    [sym_parameter] = STATE(211),
+    [sym_math_env_at] = STATE(211),
+    [sym_tag_at] = STATE(211),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(211),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(211),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(211),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(211),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(211),
+    [sym_opt_math_group_at] = STATE(211),
+    [sym_token_at] = STATE(211),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(211),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_math_shift] = ACTIONS(317),
+    [sym_alignment_tab] = ACTIONS(319),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(319),
+    [sym_subscript] = ACTIONS(319),
+    [sym_active_char] = ACTIONS(319),
+    [sym_text] = ACTIONS(319),
+  },
+  [103] = {
+    [sym_makeatother] = STATE(213),
+    [sym_makeatother_token] = STATE(118),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(321),
+  },
+  [104] = {
+    [sym__common] = STATE(215),
+    [sym__math_mode_common] = STATE(215),
+    [sym__math_mode_at] = STATE(215),
+    [sym_math_mode_at] = STATE(214),
+    [sym_parameter] = STATE(215),
+    [sym_math_env_at] = STATE(215),
+    [sym_tag_at] = STATE(215),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(215),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(215),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(215),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(215),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(215),
+    [sym_opt_math_group_at] = STATE(215),
+    [sym_token_at] = STATE(215),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(215),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(323),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(323),
+    [sym_subscript] = ACTIONS(323),
+    [sym_active_char] = ACTIONS(323),
+    [sym_text] = ACTIONS(323),
+  },
+  [105] = {
+    [sym__common] = STATE(215),
+    [sym__math_mode_common] = STATE(215),
+    [sym__math_mode_at] = STATE(215),
+    [sym_math_mode_at] = STATE(216),
+    [sym_parameter] = STATE(215),
+    [sym_math_env_at] = STATE(215),
+    [sym_tag_at] = STATE(215),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(215),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(215),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(215),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(215),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(215),
+    [sym_opt_math_group_at] = STATE(215),
+    [sym_token_at] = STATE(215),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(215),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(323),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(323),
+    [sym_subscript] = ACTIONS(323),
+    [sym_active_char] = ACTIONS(323),
+    [sym_text] = ACTIONS(323),
+  },
+  [106] = {
+    [sym__common] = STATE(215),
+    [sym__math_mode_common] = STATE(215),
+    [sym__math_mode_at] = STATE(215),
+    [sym_math_mode_at] = STATE(217),
+    [sym_parameter] = STATE(215),
+    [sym_math_env_at] = STATE(215),
+    [sym_tag_at] = STATE(215),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(215),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(215),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(215),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(215),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(215),
+    [sym_opt_math_group_at] = STATE(215),
+    [sym_token_at] = STATE(215),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(215),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(323),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(323),
+    [sym_subscript] = ACTIONS(323),
+    [sym_active_char] = ACTIONS(323),
+    [sym_text] = ACTIONS(323),
+  },
+  [107] = {
+    [sym__common] = STATE(215),
+    [sym__math_mode_common] = STATE(215),
+    [sym__math_mode_at] = STATE(215),
+    [sym_math_mode_at] = STATE(218),
+    [sym_parameter] = STATE(215),
+    [sym_math_env_at] = STATE(215),
+    [sym_tag_at] = STATE(215),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(215),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(215),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(215),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(215),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(215),
+    [sym_opt_math_group_at] = STATE(215),
+    [sym_token_at] = STATE(215),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(215),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(323),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(323),
+    [sym_subscript] = ACTIONS(323),
+    [sym_active_char] = ACTIONS(323),
+    [sym_text] = ACTIONS(323),
+  },
+  [108] = {
+    [sym__common] = STATE(221),
+    [sym__text_mode_common] = STATE(221),
+    [sym_inline_verbatim] = STATE(221),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(221),
+    [sym_parameter] = STATE(221),
+    [sym_text_env_at] = STATE(221),
+    [sym__display_math_at] = STATE(221),
+    [sym_tex_display_math_at] = STATE(221),
+    [sym_latex_display_math_at] = STATE(221),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(221),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(221),
+    [sym_tex_inline_math_at] = STATE(221),
+    [sym_latex_inline_math_at] = STATE(221),
+    [sym_inline_math_env_at] = STATE(221),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(221),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(221),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_end] = STATE(220),
+    [sym_end_token] = STATE(76),
+    [sym_documentclass] = STATE(221),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(221),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(221),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(221),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(221),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(221),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(221),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(221),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(221),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(221),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(221),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(221),
+    [sym_opt_text_group_at] = STATE(221),
+    [sym_token_at] = STATE(221),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(221),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(325),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(327),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(327),
+    [sym_text] = ACTIONS(327),
+  },
+  [109] = {
+    [sym_display_math_env_group] = STATE(222),
+    [sym_inline_math_env_group] = STATE(80),
+    [sym_verbatim_env_group] = STATE(81),
+    [sym_simple_text_group] = STATE(82),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(95),
+  },
+  [110] = {
+    [sym_text_group_at] = STATE(223),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [111] = {
+    [sym_text_group_at] = STATE(224),
+    [sym_opt_text_group_at] = STATE(225),
+    [sym_begin_opt] = STATE(226),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [112] = {
+    [sym_text_group_at] = STATE(227),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [113] = {
+    [sym_text_group_at] = STATE(228),
+    [sym_opt_text_group_at] = STATE(229),
+    [sym_begin_opt] = STATE(226),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [114] = {
+    [sym_text_group_at] = STATE(230),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [115] = {
+    [sym_text_group_at] = STATE(231),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [116] = {
+    [sym_text_group_at] = STATE(232),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [117] = {
+    [ts_builtin_sym_end] = ACTIONS(329),
+    [anon_sym_LBRACK] = ACTIONS(329),
+    [anon_sym_RBRACK] = ACTIONS(329),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(329),
+    [sym_begin_group] = ACTIONS(329),
+    [sym_end_group] = ACTIONS(329),
+    [sym_math_shift] = ACTIONS(329),
+    [sym_alignment_tab] = ACTIONS(329),
+    [sym_parameter_char] = ACTIONS(329),
+    [sym_superscript] = ACTIONS(329),
+    [sym_subscript] = ACTIONS(329),
+    [sym_active_char] = ACTIONS(329),
+    [sym_text] = ACTIONS(329),
+  },
+  [118] = {
     [ts_builtin_sym_end] = ACTIONS(331),
     [anon_sym_LBRACK] = ACTIONS(331),
     [anon_sym_RBRACK] = ACTIONS(331),
@@ -8039,6 +8079,245 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_subscript] = ACTIONS(331),
     [sym_active_char] = ACTIONS(331),
     [sym_text] = ACTIONS(331),
+  },
+  [119] = {
+    [sym__common] = STATE(234),
+    [sym__text_mode_common] = STATE(234),
+    [sym_inline_verbatim] = STATE(234),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(234),
+    [sym_parameter] = STATE(234),
+    [sym_text_env_at] = STATE(234),
+    [sym__display_math_at] = STATE(234),
+    [sym_tex_display_math_at] = STATE(234),
+    [sym_latex_display_math_at] = STATE(234),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(234),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(234),
+    [sym_tex_inline_math_at] = STATE(234),
+    [sym_latex_inline_math_at] = STATE(234),
+    [sym_inline_math_env_at] = STATE(234),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(234),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(234),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(234),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(234),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(234),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(234),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(234),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(234),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(234),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(234),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(234),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(234),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(234),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(234),
+    [sym_opt_text_group_at] = STATE(234),
+    [sym_token_at] = STATE(234),
+    [sym_begin_opt] = STATE(119),
+    [sym_end_opt] = STATE(233),
+    [aux_sym_text_mode_at_repeat1] = STATE(234),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(333),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(333),
+    [sym_text] = ACTIONS(333),
+  },
+  [120] = {
+    [sym__common] = STATE(235),
+    [sym__text_mode_common] = STATE(235),
+    [sym_inline_verbatim] = STATE(235),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(235),
+    [sym_parameter] = STATE(235),
+    [sym_text_env_at] = STATE(235),
+    [sym__display_math_at] = STATE(235),
+    [sym_tex_display_math_at] = STATE(235),
+    [sym_latex_display_math_at] = STATE(235),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(235),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(235),
+    [sym_tex_inline_math_at] = STATE(235),
+    [sym_latex_inline_math_at] = STATE(235),
+    [sym_inline_math_env_at] = STATE(235),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(235),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(235),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(235),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(235),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(235),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(235),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(235),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(235),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(235),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(235),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(235),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(235),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(235),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(235),
+    [sym_opt_text_group_at] = STATE(235),
+    [sym_token_at] = STATE(235),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(235),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(335),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(337),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(337),
+    [sym_text] = ACTIONS(337),
+  },
+  [121] = {
+    [ts_builtin_sym_end] = ACTIONS(339),
+    [anon_sym_LBRACK] = ACTIONS(339),
+    [anon_sym_RBRACK] = ACTIONS(339),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(339),
+    [sym_begin_group] = ACTIONS(339),
+    [sym_end_group] = ACTIONS(339),
+    [sym_math_shift] = ACTIONS(339),
+    [sym_alignment_tab] = ACTIONS(339),
+    [sym_parameter_char] = ACTIONS(339),
+    [sym_superscript] = ACTIONS(339),
+    [sym_subscript] = ACTIONS(339),
+    [sym_active_char] = ACTIONS(339),
+    [sym_text] = ACTIONS(339),
+  },
+  [122] = {
+    [ts_builtin_sym_end] = ACTIONS(341),
+    [anon_sym_LBRACK] = ACTIONS(341),
+    [anon_sym_RBRACK] = ACTIONS(341),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(341),
+    [sym_begin_group] = ACTIONS(341),
+    [sym_end_group] = ACTIONS(341),
+    [sym_math_shift] = ACTIONS(341),
+    [sym_alignment_tab] = ACTIONS(341),
+    [sym_parameter_char] = ACTIONS(341),
+    [sym_superscript] = ACTIONS(341),
+    [sym_subscript] = ACTIONS(341),
+    [sym_active_char] = ACTIONS(341),
+    [sym_text] = ACTIONS(341),
+  },
+  [123] = {
+    [sym__common] = STATE(237),
+    [sym__text_mode_common] = STATE(237),
+    [sym_inline_verbatim] = STATE(237),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(237),
+    [sym_text_mode_at_region] = STATE(237),
+    [sym_parameter] = STATE(237),
+    [sym_text_env] = STATE(237),
+    [sym__display_math] = STATE(237),
+    [sym_tex_display_math] = STATE(237),
+    [sym_latex_display_math] = STATE(237),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(237),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(237),
+    [sym_tex_inline_math] = STATE(237),
+    [sym_latex_inline_math] = STATE(237),
+    [sym_inline_math_env] = STATE(237),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(237),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(237),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(237),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(237),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(237),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(237),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(237),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(237),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(237),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(237),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(237),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(237),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(237),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(237),
+    [sym_opt_text_group] = STATE(237),
+    [sym_token] = STATE(237),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(236),
+    [aux_sym_text_mode_repeat1] = STATE(237),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(343),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(343),
+    [sym_text] = ACTIONS(343),
   },
   [124] = {
     [sym__common] = STATE(124),
@@ -8080,913 +8359,658 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_catcode_token] = STATE(22),
     [sym_emph] = STATE(124),
     [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(124),
+    [sym_footnote_token] = STATE(24),
     [sym_textbf] = STATE(124),
-    [sym_textbf_token] = STATE(24),
+    [sym_textbf_token] = STATE(25),
     [sym_textit] = STATE(124),
-    [sym_textit_token] = STATE(25),
+    [sym_textit_token] = STATE(26),
     [sym_texttt] = STATE(124),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
     [sym_text_group] = STATE(124),
     [sym_opt_text_group] = STATE(124),
     [sym_token] = STATE(124),
-    [sym_begin_opt] = STATE(29),
+    [sym_begin_opt] = STATE(30),
     [aux_sym_text_mode_repeat1] = STATE(124),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(297),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [ts_builtin_sym_end] = ACTIONS(345),
+    [anon_sym_LBRACK] = ACTIONS(347),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(300),
-    [sym_begin_group] = ACTIONS(303),
-    [sym_end_group] = ACTIONS(295),
-    [sym_math_shift] = ACTIONS(306),
-    [sym_alignment_tab] = ACTIONS(333),
-    [sym_parameter_char] = ACTIONS(312),
-    [sym_superscript] = ACTIONS(315),
-    [sym_subscript] = ACTIONS(315),
-    [sym_active_char] = ACTIONS(333),
-    [sym_text] = ACTIONS(333),
+    [sym__escape] = ACTIONS(350),
+    [sym_begin_group] = ACTIONS(353),
+    [sym_math_shift] = ACTIONS(356),
+    [sym_alignment_tab] = ACTIONS(359),
+    [sym_parameter_char] = ACTIONS(362),
+    [sym_superscript] = ACTIONS(365),
+    [sym_subscript] = ACTIONS(365),
+    [sym_active_char] = ACTIONS(359),
+    [sym_text] = ACTIONS(359),
   },
   [125] = {
+    [ts_builtin_sym_end] = ACTIONS(368),
+    [anon_sym_LBRACK] = ACTIONS(368),
+    [anon_sym_RBRACK] = ACTIONS(368),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(336),
+    [sym__escape] = ACTIONS(368),
+    [sym_begin_group] = ACTIONS(368),
+    [sym_end_group] = ACTIONS(368),
+    [sym_math_shift] = ACTIONS(368),
+    [sym_alignment_tab] = ACTIONS(368),
+    [sym_parameter_char] = ACTIONS(368),
+    [sym_superscript] = ACTIONS(368),
+    [sym_subscript] = ACTIONS(368),
+    [sym_active_char] = ACTIONS(368),
+    [sym_text] = ACTIONS(368),
   },
   [126] = {
-    [anon_sym_LBRACK] = ACTIONS(338),
-    [anon_sym_RBRACK] = ACTIONS(338),
+    [aux_sym_parameter_repeat1] = STATE(126),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(338),
-    [sym_begin_group] = ACTIONS(338),
-    [sym_end_group] = ACTIONS(338),
-    [sym_math_shift] = ACTIONS(338),
-    [sym_alignment_tab] = ACTIONS(338),
-    [sym_parameter_char] = ACTIONS(338),
-    [sym_superscript] = ACTIONS(338),
-    [sym_subscript] = ACTIONS(338),
-    [sym_active_char] = ACTIONS(338),
-    [sym_text] = ACTIONS(338),
+    [sym_parameter_char] = ACTIONS(370),
+    [sym_number] = ACTIONS(373),
   },
   [127] = {
-    [sym__common] = STATE(213),
-    [sym__math_mode_common] = STATE(213),
-    [sym__math_mode] = STATE(213),
-    [sym_parameter] = STATE(213),
-    [sym_math_env] = STATE(213),
-    [sym_tag] = STATE(213),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(213),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(213),
+    [sym_verb_delim] = ACTIONS(375),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [128] = {
+    [anon_sym_LBRACK] = ACTIONS(377),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(377),
+    [sym_begin_group] = ACTIONS(377),
+    [sym_alignment_tab] = ACTIONS(377),
+    [sym_parameter_char] = ACTIONS(377),
+    [sym_superscript] = ACTIONS(377),
+    [sym_subscript] = ACTIONS(377),
+    [sym_active_char] = ACTIONS(377),
+    [sym_text] = ACTIONS(377),
+  },
+  [129] = {
+    [anon_sym_LBRACK] = ACTIONS(379),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(379),
+    [sym_begin_group] = ACTIONS(379),
+    [sym_alignment_tab] = ACTIONS(379),
+    [sym_parameter_char] = ACTIONS(379),
+    [sym_superscript] = ACTIONS(379),
+    [sym_subscript] = ACTIONS(379),
+    [sym_active_char] = ACTIONS(379),
+    [sym_text] = ACTIONS(379),
+  },
+  [130] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(381),
+  },
+  [131] = {
+    [anon_sym_LBRACK] = ACTIONS(383),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(383),
+  },
+  [132] = {
+    [anon_sym_LBRACK] = ACTIONS(385),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(385),
+  },
+  [133] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(387),
+  },
+  [134] = {
+    [anon_sym_LBRACK] = ACTIONS(389),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(389),
+  },
+  [135] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(391),
+  },
+  [136] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(393),
+  },
+  [137] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(395),
+  },
+  [138] = {
+    [anon_sym_LBRACK] = ACTIONS(397),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(397),
+    [sym_begin_group] = ACTIONS(397),
+    [sym_math_shift] = ACTIONS(397),
+    [sym_alignment_tab] = ACTIONS(397),
+    [sym_parameter_char] = ACTIONS(397),
+    [sym_superscript] = ACTIONS(397),
+    [sym_subscript] = ACTIONS(397),
+    [sym_active_char] = ACTIONS(397),
+    [sym_text] = ACTIONS(397),
+  },
+  [139] = {
+    [ts_builtin_sym_end] = ACTIONS(399),
+    [anon_sym_LBRACK] = ACTIONS(399),
+    [anon_sym_RBRACK] = ACTIONS(399),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(399),
+    [sym_begin_group] = ACTIONS(399),
+    [sym_end_group] = ACTIONS(399),
+    [sym_math_shift] = ACTIONS(399),
+    [sym_alignment_tab] = ACTIONS(399),
+    [sym_parameter_char] = ACTIONS(399),
+    [sym_superscript] = ACTIONS(399),
+    [sym_subscript] = ACTIONS(399),
+    [sym_active_char] = ACTIONS(399),
+    [sym_text] = ACTIONS(399),
+  },
+  [140] = {
+    [ts_builtin_sym_end] = ACTIONS(401),
+    [anon_sym_LBRACK] = ACTIONS(401),
+    [anon_sym_RBRACK] = ACTIONS(401),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(401),
+    [sym_begin_group] = ACTIONS(401),
+    [sym_end_group] = ACTIONS(401),
+    [sym_math_shift] = ACTIONS(401),
+    [sym_alignment_tab] = ACTIONS(401),
+    [sym_parameter_char] = ACTIONS(401),
+    [sym_superscript] = ACTIONS(401),
+    [sym_subscript] = ACTIONS(401),
+    [sym_active_char] = ACTIONS(401),
+    [sym_text] = ACTIONS(401),
+  },
+  [141] = {
+    [sym__common] = STATE(141),
+    [sym__text_mode_common] = STATE(141),
+    [sym_inline_verbatim] = STATE(141),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(141),
+    [sym_text_mode_at_region] = STATE(141),
+    [sym_parameter] = STATE(141),
+    [sym_text_env] = STATE(141),
+    [sym__display_math] = STATE(141),
+    [sym_tex_display_math] = STATE(141),
+    [sym_latex_display_math] = STATE(141),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(141),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(141),
+    [sym_tex_inline_math] = STATE(141),
+    [sym_latex_inline_math] = STATE(141),
+    [sym_inline_math_env] = STATE(141),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(141),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(141),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(141),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(141),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(141),
     [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(213),
+    [sym_section] = STATE(141),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(141),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(213),
+    [sym_catcode] = STATE(141),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(213),
-    [sym_opt_math_group] = STATE(213),
-    [sym_token] = STATE(213),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(213),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_emph] = STATE(141),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(141),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(141),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(141),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(141),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(141),
+    [sym_opt_text_group] = STATE(141),
+    [sym_token] = STATE(141),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(141),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(347),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(350),
+    [sym_begin_group] = ACTIONS(353),
+    [sym_end_group] = ACTIONS(345),
+    [sym_math_shift] = ACTIONS(356),
+    [sym_alignment_tab] = ACTIONS(403),
+    [sym_parameter_char] = ACTIONS(362),
+    [sym_superscript] = ACTIONS(365),
+    [sym_subscript] = ACTIONS(365),
+    [sym_active_char] = ACTIONS(403),
+    [sym_text] = ACTIONS(403),
+  },
+  [142] = {
+    [sym__whitespace] = ACTIONS(406),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(408),
+  },
+  [143] = {
+    [anon_sym_LBRACK] = ACTIONS(410),
+    [anon_sym_RBRACK] = ACTIONS(410),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(410),
+    [sym_begin_group] = ACTIONS(410),
+    [sym_end_group] = ACTIONS(410),
+    [sym_math_shift] = ACTIONS(410),
+    [sym_alignment_tab] = ACTIONS(410),
+    [sym_parameter_char] = ACTIONS(410),
+    [sym_superscript] = ACTIONS(410),
+    [sym_subscript] = ACTIONS(410),
+    [sym_active_char] = ACTIONS(410),
+    [sym_text] = ACTIONS(410),
+  },
+  [144] = {
+    [sym__common] = STATE(240),
+    [sym__math_mode_common] = STATE(240),
+    [sym__math_mode] = STATE(240),
+    [sym_parameter] = STATE(240),
+    [sym_math_env] = STATE(240),
+    [sym_tag] = STATE(240),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(240),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(240),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(240),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(240),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(240),
+    [sym_opt_math_group] = STATE(240),
+    [sym_token] = STATE(240),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(240),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_end_group] = ACTIONS(340),
-    [sym_alignment_tab] = ACTIONS(342),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_end_group] = ACTIONS(412),
+    [sym_alignment_tab] = ACTIONS(414),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(342),
-    [sym_subscript] = ACTIONS(342),
-    [sym_active_char] = ACTIONS(342),
-    [sym_text] = ACTIONS(342),
+    [sym_superscript] = ACTIONS(414),
+    [sym_subscript] = ACTIONS(414),
+    [sym_active_char] = ACTIONS(414),
+    [sym_text] = ACTIONS(414),
   },
-  [128] = {
+  [145] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(344),
+    [sym_math_shift] = ACTIONS(416),
   },
-  [129] = {
-    [ts_builtin_sym_end] = ACTIONS(346),
-    [anon_sym_LBRACK] = ACTIONS(346),
-    [anon_sym_RBRACK] = ACTIONS(346),
+  [146] = {
+    [ts_builtin_sym_end] = ACTIONS(418),
+    [anon_sym_LBRACK] = ACTIONS(418),
+    [anon_sym_RBRACK] = ACTIONS(418),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(346),
-    [sym_begin_group] = ACTIONS(346),
-    [sym_end_group] = ACTIONS(346),
-    [sym_math_shift] = ACTIONS(346),
-    [sym_alignment_tab] = ACTIONS(346),
-    [sym_parameter_char] = ACTIONS(346),
-    [sym_superscript] = ACTIONS(346),
-    [sym_subscript] = ACTIONS(346),
-    [sym_active_char] = ACTIONS(346),
-    [sym_text] = ACTIONS(346),
+    [sym__escape] = ACTIONS(418),
+    [sym_begin_group] = ACTIONS(418),
+    [sym_end_group] = ACTIONS(418),
+    [sym_math_shift] = ACTIONS(418),
+    [sym_alignment_tab] = ACTIONS(418),
+    [sym_parameter_char] = ACTIONS(418),
+    [sym_superscript] = ACTIONS(418),
+    [sym_subscript] = ACTIONS(418),
+    [sym_active_char] = ACTIONS(418),
+    [sym_text] = ACTIONS(418),
   },
-  [130] = {
-    [sym__common] = STATE(217),
-    [sym__text_mode_common] = STATE(217),
-    [sym_inline_verbatim] = STATE(217),
+  [147] = {
+    [sym__common] = STATE(244),
+    [sym__text_mode_common] = STATE(244),
+    [sym_inline_verbatim] = STATE(244),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(217),
-    [sym_text_mode] = STATE(216),
-    [sym_text_mode_at_region] = STATE(217),
-    [sym_parameter] = STATE(217),
-    [sym_text_env] = STATE(217),
-    [sym__display_math] = STATE(217),
-    [sym_tex_display_math] = STATE(217),
-    [sym_latex_display_math] = STATE(217),
+    [sym__text_mode] = STATE(244),
+    [sym_text_mode] = STATE(243),
+    [sym_text_mode_at_region] = STATE(244),
+    [sym_parameter] = STATE(244),
+    [sym_text_env] = STATE(244),
+    [sym__display_math] = STATE(244),
+    [sym_tex_display_math] = STATE(244),
+    [sym_latex_display_math] = STATE(244),
     [sym_begin_display_math] = STATE(10),
     [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(217),
+    [sym_display_math_env] = STATE(244),
     [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(217),
-    [sym_tex_inline_math] = STATE(217),
-    [sym_latex_inline_math] = STATE(217),
-    [sym_inline_math_env] = STATE(217),
+    [sym__inline_math] = STATE(244),
+    [sym_tex_inline_math] = STATE(244),
+    [sym_latex_inline_math] = STATE(244),
+    [sym_inline_math_env] = STATE(244),
     [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(217),
+    [sym_verbatim_env] = STATE(244),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(217),
+    [sym_escaped] = STATE(244),
     [sym_begin] = STATE(15),
     [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(217),
+    [sym_documentclass] = STATE(244),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(217),
+    [sym_usepackage] = STATE(244),
     [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(217),
+    [sym_include] = STATE(244),
     [sym_include_token] = STATE(19),
-    [sym_section] = STATE(217),
+    [sym_section] = STATE(244),
     [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(217),
+    [sym_storage] = STATE(244),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(217),
+    [sym_catcode] = STATE(244),
     [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(217),
+    [sym_emph] = STATE(244),
     [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(217),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(217),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(217),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(217),
-    [sym_opt_text_group] = STATE(217),
-    [sym_token] = STATE(217),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(217),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_footnote] = STATE(244),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(244),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(244),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(244),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(244),
+    [sym_opt_text_group] = STATE(244),
+    [sym_token] = STATE(244),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(244),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(348),
+    [sym_end_group] = ACTIONS(420),
     [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(350),
+    [sym_alignment_tab] = ACTIONS(422),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(350),
-    [sym_text] = ACTIONS(350),
+    [sym_active_char] = ACTIONS(422),
+    [sym_text] = ACTIONS(422),
   },
-  [131] = {
-    [anon_sym_LBRACK] = ACTIONS(352),
-    [anon_sym_RBRACK] = ACTIONS(352),
+  [148] = {
+    [anon_sym_LBRACK] = ACTIONS(424),
+    [anon_sym_RBRACK] = ACTIONS(424),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(352),
-    [sym_begin_group] = ACTIONS(352),
-    [sym_end_group] = ACTIONS(352),
-    [sym_math_shift] = ACTIONS(352),
-    [sym_alignment_tab] = ACTIONS(352),
-    [sym_parameter_char] = ACTIONS(352),
-    [sym_superscript] = ACTIONS(352),
-    [sym_subscript] = ACTIONS(352),
-    [sym_active_char] = ACTIONS(352),
-    [sym_text] = ACTIONS(352),
+    [sym__escape] = ACTIONS(424),
+    [sym_begin_group] = ACTIONS(424),
+    [sym_end_group] = ACTIONS(424),
+    [sym_math_shift] = ACTIONS(424),
+    [sym_alignment_tab] = ACTIONS(424),
+    [sym_parameter_char] = ACTIONS(424),
+    [sym_superscript] = ACTIONS(424),
+    [sym_subscript] = ACTIONS(424),
+    [sym_active_char] = ACTIONS(424),
+    [sym_text] = ACTIONS(424),
   },
-  [132] = {
-    [anon_sym_tag] = ACTIONS(165),
+  [149] = {
+    [anon_sym_tag] = ACTIONS(201),
     [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
     [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_end] = ACTIONS(207),
+    [anon_sym_end] = ACTIONS(243),
     [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
     [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
     [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name] = ACTIONS(59),
-  },
-  [133] = {
-    [anon_sym_LBRACK] = ACTIONS(354),
-    [anon_sym_RBRACK] = ACTIONS(354),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(354),
-    [sym_begin_group] = ACTIONS(354),
-    [sym_end_group] = ACTIONS(354),
-    [sym_math_shift] = ACTIONS(354),
-    [sym_alignment_tab] = ACTIONS(354),
-    [sym_parameter_char] = ACTIONS(354),
-    [sym_superscript] = ACTIONS(354),
-    [sym_subscript] = ACTIONS(354),
-    [sym_active_char] = ACTIONS(354),
-    [sym_text] = ACTIONS(354),
-  },
-  [134] = {
-    [sym__common] = STATE(141),
-    [sym__math_mode_common] = STATE(141),
-    [sym__math_mode] = STATE(141),
-    [sym_parameter] = STATE(141),
-    [sym_math_env] = STATE(141),
-    [sym_tag] = STATE(141),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(141),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_end] = STATE(218),
-    [sym_end_token] = STATE(74),
-    [sym_include] = STATE(141),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(141),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(141),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(141),
-    [sym_opt_math_group] = STATE(141),
-    [sym_token] = STATE(141),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(141),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(175),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(189),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(189),
-    [sym_subscript] = ACTIONS(189),
-    [sym_active_char] = ACTIONS(189),
-    [sym_text] = ACTIONS(189),
-  },
-  [135] = {
-    [anon_sym_LBRACK] = ACTIONS(356),
-    [anon_sym_RBRACK] = ACTIONS(356),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(356),
-    [sym_begin_group] = ACTIONS(356),
-    [sym_end_group] = ACTIONS(356),
-    [sym_math_shift] = ACTIONS(356),
-    [sym_alignment_tab] = ACTIONS(356),
-    [sym_parameter_char] = ACTIONS(356),
-    [sym_superscript] = ACTIONS(356),
-    [sym_subscript] = ACTIONS(356),
-    [sym_active_char] = ACTIONS(356),
-    [sym_text] = ACTIONS(356),
-  },
-  [136] = {
-    [sym__common] = STATE(220),
-    [sym__math_mode_common] = STATE(220),
-    [sym__math_mode] = STATE(220),
-    [sym_parameter] = STATE(220),
-    [sym_math_env] = STATE(220),
-    [sym_tag] = STATE(220),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(220),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(220),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(220),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(220),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(220),
-    [sym_opt_math_group] = STATE(220),
-    [sym_token] = STATE(220),
-    [sym_begin_opt] = STATE(58),
-    [sym_end_opt] = STATE(219),
-    [aux_sym_math_mode_repeat1] = STATE(220),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(65),
-    [sym_begin_group] = ACTIONS(67),
-    [sym_alignment_tab] = ACTIONS(358),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(358),
-    [sym_subscript] = ACTIONS(358),
-    [sym_active_char] = ACTIONS(358),
-    [sym_text] = ACTIONS(358),
-  },
-  [137] = {
-    [sym__common] = STATE(137),
-    [sym__math_mode_common] = STATE(137),
-    [sym__math_mode] = STATE(137),
-    [sym_parameter] = STATE(137),
-    [sym_math_env] = STATE(137),
-    [sym_tag] = STATE(137),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(137),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(137),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(137),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(137),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(137),
-    [sym_opt_math_group] = STATE(137),
-    [sym_token] = STATE(137),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(137),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(360),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(363),
-    [sym_begin_group] = ACTIONS(366),
-    [sym_math_shift] = ACTIONS(369),
-    [sym_alignment_tab] = ACTIONS(371),
-    [sym_parameter_char] = ACTIONS(374),
-    [sym_superscript] = ACTIONS(371),
-    [sym_subscript] = ACTIONS(371),
-    [sym_active_char] = ACTIONS(371),
-    [sym_text] = ACTIONS(371),
-  },
-  [138] = {
-    [sym_verb_delim] = ACTIONS(377),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [139] = {
-    [anon_sym_RBRACK] = ACTIONS(379),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [140] = {
-    [ts_builtin_sym_end] = ACTIONS(381),
-    [anon_sym_LBRACK] = ACTIONS(381),
-    [anon_sym_RBRACK] = ACTIONS(381),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(381),
-    [sym_begin_group] = ACTIONS(381),
-    [sym_end_group] = ACTIONS(381),
-    [sym_math_shift] = ACTIONS(381),
-    [sym_alignment_tab] = ACTIONS(381),
-    [sym_parameter_char] = ACTIONS(381),
-    [sym_superscript] = ACTIONS(381),
-    [sym_subscript] = ACTIONS(381),
-    [sym_active_char] = ACTIONS(381),
-    [sym_text] = ACTIONS(381),
-  },
-  [141] = {
-    [sym__common] = STATE(141),
-    [sym__math_mode_common] = STATE(141),
-    [sym__math_mode] = STATE(141),
-    [sym_parameter] = STATE(141),
-    [sym_math_env] = STATE(141),
-    [sym_tag] = STATE(141),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(141),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(141),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(141),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(141),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(141),
-    [sym_opt_math_group] = STATE(141),
-    [sym_token] = STATE(141),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(141),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(360),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(363),
-    [sym_begin_group] = ACTIONS(366),
-    [sym_alignment_tab] = ACTIONS(383),
-    [sym_parameter_char] = ACTIONS(374),
-    [sym_superscript] = ACTIONS(383),
-    [sym_subscript] = ACTIONS(383),
-    [sym_active_char] = ACTIONS(383),
-    [sym_text] = ACTIONS(383),
-  },
-  [142] = {
-    [anon_sym_RPAREN] = ACTIONS(386),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [143] = {
-    [ts_builtin_sym_end] = ACTIONS(388),
-    [anon_sym_LBRACK] = ACTIONS(388),
-    [anon_sym_RBRACK] = ACTIONS(388),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(388),
-    [sym_begin_group] = ACTIONS(388),
-    [sym_end_group] = ACTIONS(388),
-    [sym_math_shift] = ACTIONS(388),
-    [sym_alignment_tab] = ACTIONS(388),
-    [sym_parameter_char] = ACTIONS(388),
-    [sym_superscript] = ACTIONS(388),
-    [sym_subscript] = ACTIONS(388),
-    [sym_active_char] = ACTIONS(388),
-    [sym_text] = ACTIONS(388),
-  },
-  [144] = {
-    [ts_builtin_sym_end] = ACTIONS(390),
-    [anon_sym_LBRACK] = ACTIONS(390),
-    [anon_sym_RBRACK] = ACTIONS(390),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(390),
-    [sym_begin_group] = ACTIONS(390),
-    [sym_end_group] = ACTIONS(390),
-    [sym_math_shift] = ACTIONS(390),
-    [sym_alignment_tab] = ACTIONS(390),
-    [sym_parameter_char] = ACTIONS(390),
-    [sym_superscript] = ACTIONS(390),
-    [sym_subscript] = ACTIONS(390),
-    [sym_active_char] = ACTIONS(390),
-    [sym_text] = ACTIONS(390),
-  },
-  [145] = {
-    [sym_display_math_env_group] = STATE(225),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(392),
-  },
-  [146] = {
-    [ts_builtin_sym_end] = ACTIONS(394),
-    [anon_sym_LBRACK] = ACTIONS(394),
-    [anon_sym_RBRACK] = ACTIONS(394),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(394),
-    [sym_begin_group] = ACTIONS(394),
-    [sym_end_group] = ACTIONS(394),
-    [sym_math_shift] = ACTIONS(394),
-    [sym_alignment_tab] = ACTIONS(394),
-    [sym_parameter_char] = ACTIONS(394),
-    [sym_superscript] = ACTIONS(394),
-    [sym_subscript] = ACTIONS(394),
-    [sym_active_char] = ACTIONS(394),
-    [sym_text] = ACTIONS(394),
-  },
-  [147] = {
-    [sym_inline_math_env_group] = STATE(227),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(396),
-  },
-  [148] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(398),
-  },
-  [149] = {
-    [ts_builtin_sym_end] = ACTIONS(400),
-    [anon_sym_LBRACK] = ACTIONS(400),
-    [anon_sym_RBRACK] = ACTIONS(400),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(400),
-    [sym_begin_group] = ACTIONS(400),
-    [sym_end_group] = ACTIONS(400),
-    [sym_math_shift] = ACTIONS(400),
-    [sym_alignment_tab] = ACTIONS(400),
-    [sym_parameter_char] = ACTIONS(400),
-    [sym_superscript] = ACTIONS(400),
-    [sym_subscript] = ACTIONS(400),
-    [sym_active_char] = ACTIONS(400),
-    [sym_text] = ACTIONS(400),
+    [sym__name] = ACTIONS(61),
   },
   [150] = {
-    [sym_verbatim_env_name] = ACTIONS(402),
+    [anon_sym_LBRACK] = ACTIONS(426),
+    [anon_sym_RBRACK] = ACTIONS(426),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(426),
+    [sym_begin_group] = ACTIONS(426),
+    [sym_end_group] = ACTIONS(426),
+    [sym_math_shift] = ACTIONS(426),
+    [sym_alignment_tab] = ACTIONS(426),
+    [sym_parameter_char] = ACTIONS(426),
+    [sym_superscript] = ACTIONS(426),
+    [sym_subscript] = ACTIONS(426),
+    [sym_active_char] = ACTIONS(426),
+    [sym_text] = ACTIONS(426),
   },
   [151] = {
-    [ts_builtin_sym_end] = ACTIONS(404),
-    [anon_sym_LBRACK] = ACTIONS(404),
-    [anon_sym_RBRACK] = ACTIONS(404),
+    [sym__common] = STATE(158),
+    [sym__math_mode_common] = STATE(158),
+    [sym__math_mode] = STATE(158),
+    [sym_parameter] = STATE(158),
+    [sym_math_env] = STATE(158),
+    [sym_tag] = STATE(158),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(158),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_end] = STATE(245),
+    [sym_end_token] = STATE(76),
+    [sym_include] = STATE(158),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(158),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(158),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(158),
+    [sym_opt_math_group] = STATE(158),
+    [sym_token] = STATE(158),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(158),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(404),
-    [sym_begin_group] = ACTIONS(404),
-    [sym_end_group] = ACTIONS(404),
-    [sym_math_shift] = ACTIONS(404),
-    [sym_alignment_tab] = ACTIONS(404),
-    [sym_parameter_char] = ACTIONS(404),
-    [sym_superscript] = ACTIONS(404),
-    [sym_subscript] = ACTIONS(404),
-    [sym_active_char] = ACTIONS(404),
-    [sym_text] = ACTIONS(404),
+    [sym__escape] = ACTIONS(211),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(225),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(225),
+    [sym_subscript] = ACTIONS(225),
+    [sym_active_char] = ACTIONS(225),
+    [sym_text] = ACTIONS(225),
   },
   [152] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(406),
+    [anon_sym_LBRACK] = ACTIONS(428),
+    [anon_sym_RBRACK] = ACTIONS(428),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(408),
-    [sym__end_of_line] = ACTIONS(408),
+    [sym__escape] = ACTIONS(428),
+    [sym_begin_group] = ACTIONS(428),
+    [sym_end_group] = ACTIONS(428),
+    [sym_math_shift] = ACTIONS(428),
+    [sym_alignment_tab] = ACTIONS(428),
+    [sym_parameter_char] = ACTIONS(428),
+    [sym_superscript] = ACTIONS(428),
+    [sym_subscript] = ACTIONS(428),
+    [sym_active_char] = ACTIONS(428),
+    [sym_text] = ACTIONS(428),
   },
   [153] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(153),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(410),
+    [sym__common] = STATE(247),
+    [sym__math_mode_common] = STATE(247),
+    [sym__math_mode] = STATE(247),
+    [sym_parameter] = STATE(247),
+    [sym_math_env] = STATE(247),
+    [sym_tag] = STATE(247),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(247),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(247),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(247),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(247),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(247),
+    [sym_opt_math_group] = STATE(247),
+    [sym_token] = STATE(247),
+    [sym_begin_opt] = STATE(60),
+    [sym_end_opt] = STATE(246),
+    [aux_sym_math_mode_repeat1] = STATE(247),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(413),
+    [sym__escape] = ACTIONS(67),
+    [sym_begin_group] = ACTIONS(69),
+    [sym_alignment_tab] = ACTIONS(430),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(430),
+    [sym_subscript] = ACTIONS(430),
+    [sym_active_char] = ACTIONS(430),
+    [sym_text] = ACTIONS(430),
   },
   [154] = {
-    [aux_sym_verbatim_text_repeat1] = STATE(70),
-    [aux_sym_verbatim_text_repeat2] = STATE(154),
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(415),
+    [sym__common] = STATE(154),
+    [sym__math_mode_common] = STATE(154),
+    [sym__math_mode] = STATE(154),
+    [sym_parameter] = STATE(154),
+    [sym_math_env] = STATE(154),
+    [sym_tag] = STATE(154),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(154),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(154),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(154),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(154),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(154),
+    [sym_opt_math_group] = STATE(154),
+    [sym_token] = STATE(154),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(154),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(432),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(408),
-    [sym__end_of_line] = ACTIONS(418),
+    [sym__escape] = ACTIONS(435),
+    [sym_begin_group] = ACTIONS(438),
+    [sym_math_shift] = ACTIONS(441),
+    [sym_alignment_tab] = ACTIONS(443),
+    [sym_parameter_char] = ACTIONS(446),
+    [sym_superscript] = ACTIONS(443),
+    [sym_subscript] = ACTIONS(443),
+    [sym_active_char] = ACTIONS(443),
+    [sym_text] = ACTIONS(443),
   },
   [155] = {
-    [ts_builtin_sym_end] = ACTIONS(421),
-    [anon_sym_LBRACK] = ACTIONS(421),
-    [anon_sym_RBRACK] = ACTIONS(421),
+    [sym_verb_delim] = ACTIONS(449),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(421),
-    [sym_begin_group] = ACTIONS(421),
-    [sym_end_group] = ACTIONS(421),
-    [sym_math_shift] = ACTIONS(421),
-    [sym_alignment_tab] = ACTIONS(421),
-    [sym_parameter_char] = ACTIONS(421),
-    [sym_superscript] = ACTIONS(421),
-    [sym_subscript] = ACTIONS(421),
-    [sym_active_char] = ACTIONS(421),
-    [sym_text] = ACTIONS(421),
   },
   [156] = {
-    [ts_builtin_sym_end] = ACTIONS(423),
-    [anon_sym_LBRACK] = ACTIONS(423),
-    [anon_sym_RBRACK] = ACTIONS(423),
+    [anon_sym_RBRACK] = ACTIONS(451),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(423),
-    [sym_begin_group] = ACTIONS(423),
-    [sym_end_group] = ACTIONS(423),
-    [sym_math_shift] = ACTIONS(423),
-    [sym_alignment_tab] = ACTIONS(423),
-    [sym_parameter_char] = ACTIONS(423),
-    [sym_superscript] = ACTIONS(423),
-    [sym_subscript] = ACTIONS(423),
-    [sym_active_char] = ACTIONS(423),
-    [sym_text] = ACTIONS(423),
   },
   [157] = {
-    [sym__common] = STATE(157),
-    [sym__text_mode_common] = STATE(157),
-    [sym_inline_verbatim] = STATE(157),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(157),
-    [sym_text_mode_at_region] = STATE(157),
-    [sym_parameter] = STATE(157),
-    [sym_text_env] = STATE(157),
-    [sym__display_math] = STATE(157),
-    [sym_tex_display_math] = STATE(157),
-    [sym_latex_display_math] = STATE(157),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(157),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(157),
-    [sym_tex_inline_math] = STATE(157),
-    [sym_latex_inline_math] = STATE(157),
-    [sym_inline_math_env] = STATE(157),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(157),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(157),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(157),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(157),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(157),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(157),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(157),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(157),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(157),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(157),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(157),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(157),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(157),
-    [sym_opt_text_group] = STATE(157),
-    [sym_token] = STATE(157),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(157),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(297),
+    [ts_builtin_sym_end] = ACTIONS(453),
+    [anon_sym_LBRACK] = ACTIONS(453),
+    [anon_sym_RBRACK] = ACTIONS(453),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(300),
-    [sym_begin_group] = ACTIONS(303),
-    [sym_math_shift] = ACTIONS(306),
-    [sym_alignment_tab] = ACTIONS(425),
-    [sym_parameter_char] = ACTIONS(312),
-    [sym_superscript] = ACTIONS(315),
-    [sym_subscript] = ACTIONS(315),
-    [sym_active_char] = ACTIONS(425),
-    [sym_text] = ACTIONS(425),
+    [sym__escape] = ACTIONS(453),
+    [sym_begin_group] = ACTIONS(453),
+    [sym_end_group] = ACTIONS(453),
+    [sym_math_shift] = ACTIONS(453),
+    [sym_alignment_tab] = ACTIONS(453),
+    [sym_parameter_char] = ACTIONS(453),
+    [sym_superscript] = ACTIONS(453),
+    [sym_subscript] = ACTIONS(453),
+    [sym_active_char] = ACTIONS(453),
+    [sym_text] = ACTIONS(453),
   },
   [158] = {
+    [sym__common] = STATE(158),
+    [sym__math_mode_common] = STATE(158),
+    [sym__math_mode] = STATE(158),
+    [sym_parameter] = STATE(158),
+    [sym_math_env] = STATE(158),
+    [sym_tag] = STATE(158),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(158),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(158),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(158),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(158),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(158),
+    [sym_opt_math_group] = STATE(158),
+    [sym_token] = STATE(158),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(158),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(432),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(428),
+    [sym__escape] = ACTIONS(435),
+    [sym_begin_group] = ACTIONS(438),
+    [sym_alignment_tab] = ACTIONS(455),
+    [sym_parameter_char] = ACTIONS(446),
+    [sym_superscript] = ACTIONS(455),
+    [sym_subscript] = ACTIONS(455),
+    [sym_active_char] = ACTIONS(455),
+    [sym_text] = ACTIONS(455),
   },
   [159] = {
+    [anon_sym_RPAREN] = ACTIONS(458),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(430),
   },
   [160] = {
+    [ts_builtin_sym_end] = ACTIONS(460),
+    [anon_sym_LBRACK] = ACTIONS(460),
+    [anon_sym_RBRACK] = ACTIONS(460),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(432),
+    [sym__escape] = ACTIONS(460),
+    [sym_begin_group] = ACTIONS(460),
+    [sym_end_group] = ACTIONS(460),
+    [sym_math_shift] = ACTIONS(460),
+    [sym_alignment_tab] = ACTIONS(460),
+    [sym_parameter_char] = ACTIONS(460),
+    [sym_superscript] = ACTIONS(460),
+    [sym_subscript] = ACTIONS(460),
+    [sym_active_char] = ACTIONS(460),
+    [sym_text] = ACTIONS(460),
   },
   [161] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(434),
-  },
-  [162] = {
-    [sym__common] = STATE(234),
-    [sym__text_mode_common] = STATE(234),
-    [sym_inline_verbatim] = STATE(234),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(234),
-    [sym_text_mode_at_region] = STATE(234),
-    [sym_parameter] = STATE(234),
-    [sym_text_env] = STATE(234),
-    [sym__display_math] = STATE(234),
-    [sym_tex_display_math] = STATE(234),
-    [sym_latex_display_math] = STATE(234),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(234),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(234),
-    [sym_tex_inline_math] = STATE(234),
-    [sym_latex_inline_math] = STATE(234),
-    [sym_inline_math_env] = STATE(234),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(234),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(234),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(234),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(234),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(234),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(234),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(234),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(234),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(234),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(234),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(234),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(234),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(234),
-    [sym_opt_text_group] = STATE(234),
-    [sym_token] = STATE(234),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(234),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(436),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(438),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(438),
-    [sym_text] = ACTIONS(438),
-  },
-  [163] = {
-    [anon_sym_LBRACK] = ACTIONS(440),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(440),
-    [sym_begin_group] = ACTIONS(440),
-    [sym_alignment_tab] = ACTIONS(440),
-    [sym_parameter_char] = ACTIONS(440),
-    [sym_superscript] = ACTIONS(440),
-    [sym_subscript] = ACTIONS(440),
-    [sym_active_char] = ACTIONS(440),
-    [sym_text] = ACTIONS(440),
-  },
-  [164] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(442),
-  },
-  [165] = {
-    [sym_text_group] = STATE(236),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(221),
-    [sym__end_of_line] = ACTIONS(442),
-  },
-  [166] = {
-    [sym__common] = STATE(239),
-    [sym__text_mode_common] = STATE(239),
-    [sym_inline_verbatim] = STATE(239),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(239),
-    [sym_text_mode_at_region] = STATE(239),
-    [sym_parameter] = STATE(239),
-    [sym_text_env] = STATE(239),
-    [sym__display_math] = STATE(239),
-    [sym_tex_display_math] = STATE(239),
-    [sym_latex_display_math] = STATE(239),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(239),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(239),
-    [sym_tex_inline_math] = STATE(239),
-    [sym_latex_inline_math] = STATE(239),
-    [sym_inline_math_env] = STATE(239),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(239),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(239),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(239),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(239),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(239),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(239),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(239),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(239),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(239),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(239),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(239),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(239),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(239),
-    [sym_opt_text_group] = STATE(239),
-    [sym_token] = STATE(239),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(238),
-    [aux_sym_text_mode_repeat1] = STATE(239),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(444),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(446),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(446),
-    [sym_text] = ACTIONS(446),
-  },
-  [167] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(448),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(450),
-    [sym__end_of_line] = ACTIONS(450),
-  },
-  [168] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(452),
-  },
-  [169] = {
-    [sym_text_group] = STATE(241),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(221),
-    [sym__end_of_line] = ACTIONS(452),
-  },
-  [170] = {
-    [ts_builtin_sym_end] = ACTIONS(454),
-    [anon_sym_LBRACK] = ACTIONS(454),
-    [anon_sym_RBRACK] = ACTIONS(454),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(454),
-    [sym_begin_group] = ACTIONS(454),
-    [sym_end_group] = ACTIONS(454),
-    [sym_math_shift] = ACTIONS(454),
-    [sym_alignment_tab] = ACTIONS(454),
-    [sym_parameter_char] = ACTIONS(454),
-    [sym_superscript] = ACTIONS(454),
-    [sym_subscript] = ACTIONS(454),
-    [sym_active_char] = ACTIONS(454),
-    [sym_text] = ACTIONS(454),
-  },
-  [171] = {
-    [ts_builtin_sym_end] = ACTIONS(456),
-    [anon_sym_LBRACK] = ACTIONS(456),
-    [anon_sym_RBRACK] = ACTIONS(456),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(456),
-    [sym_begin_group] = ACTIONS(456),
-    [sym_end_group] = ACTIONS(456),
-    [sym_math_shift] = ACTIONS(456),
-    [sym_alignment_tab] = ACTIONS(456),
-    [sym_parameter_char] = ACTIONS(456),
-    [sym_superscript] = ACTIONS(456),
-    [sym_subscript] = ACTIONS(456),
-    [sym_active_char] = ACTIONS(456),
-    [sym_text] = ACTIONS(456),
-  },
-  [172] = {
-    [ts_builtin_sym_end] = ACTIONS(458),
-    [anon_sym_LBRACK] = ACTIONS(458),
-    [anon_sym_RBRACK] = ACTIONS(458),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(458),
-    [sym_begin_group] = ACTIONS(458),
-    [sym_end_group] = ACTIONS(458),
-    [sym_math_shift] = ACTIONS(458),
-    [sym_alignment_tab] = ACTIONS(458),
-    [sym_parameter_char] = ACTIONS(458),
-    [sym_superscript] = ACTIONS(458),
-    [sym_subscript] = ACTIONS(458),
-    [sym_active_char] = ACTIONS(458),
-    [sym_text] = ACTIONS(458),
-  },
-  [173] = {
-    [anon_sym_EQ] = ACTIONS(131),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [174] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_number] = ACTIONS(460),
-  },
-  [175] = {
     [ts_builtin_sym_end] = ACTIONS(462),
     [anon_sym_LBRACK] = ACTIONS(462),
     [anon_sym_RBRACK] = ACTIONS(462),
@@ -9003,43 +9027,14 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(462),
     [sym_text] = ACTIONS(462),
   },
-  [176] = {
-    [anon_sym_LBRACK] = ACTIONS(464),
-    [anon_sym_RBRACK] = ACTIONS(464),
+  [162] = {
+    [sym_display_math_env_group] = STATE(252),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(464),
     [sym_begin_group] = ACTIONS(464),
-    [sym_end_group] = ACTIONS(464),
-    [sym_math_shift] = ACTIONS(464),
-    [sym_alignment_tab] = ACTIONS(464),
-    [sym_parameter_char] = ACTIONS(464),
-    [sym_superscript] = ACTIONS(464),
-    [sym_subscript] = ACTIONS(464),
-    [sym_active_char] = ACTIONS(464),
-    [sym_text] = ACTIONS(464),
   },
-  [177] = {
-    [anon_sym_verb] = ACTIONS(27),
-    [anon_sym_LBRACK] = ACTIONS(29),
-    [anon_sym_LPAREN] = ACTIONS(31),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_documentclass] = ACTIONS(37),
-    [anon_sym_usepackage] = ACTIONS(39),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
-    [anon_sym_emph] = ACTIONS(49),
-    [anon_sym_textbf] = ACTIONS(51),
-    [anon_sym_textit] = ACTIONS(53),
-    [anon_sym_texttt] = ACTIONS(55),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(255),
-  },
-  [178] = {
+  [163] = {
+    [ts_builtin_sym_end] = ACTIONS(466),
     [anon_sym_LBRACK] = ACTIONS(466),
     [anon_sym_RBRACK] = ACTIONS(466),
     [sym_magic_comment] = ACTIONS(9),
@@ -9055,582 +9050,279 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(466),
     [sym_text] = ACTIONS(466),
   },
-  [179] = {
-    [sym__common] = STATE(244),
-    [sym__text_mode_common] = STATE(244),
-    [sym_inline_verbatim] = STATE(244),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(244),
-    [sym_parameter] = STATE(244),
-    [sym_text_env_at] = STATE(244),
-    [sym__display_math_at] = STATE(244),
-    [sym_tex_display_math_at] = STATE(244),
-    [sym_latex_display_math_at] = STATE(244),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(244),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(244),
-    [sym_tex_inline_math_at] = STATE(244),
-    [sym_latex_inline_math_at] = STATE(244),
-    [sym_inline_math_env_at] = STATE(244),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(244),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(244),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(244),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(244),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(244),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(244),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(244),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(244),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(244),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(244),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(244),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(244),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(244),
-    [sym_opt_text_group_at] = STATE(244),
-    [sym_token_at] = STATE(244),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(244),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [164] = {
+    [sym_inline_math_env_group] = STATE(254),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_end_group] = ACTIONS(468),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(470),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(470),
-    [sym_text] = ACTIONS(470),
+    [sym_begin_group] = ACTIONS(468),
   },
-  [180] = {
-    [anon_sym_tag] = ACTIONS(165),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+  [165] = {
+    [sym__whitespace] = ACTIONS(470),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(255),
+    [sym_begin_group] = ACTIONS(472),
   },
-  [181] = {
-    [sym__common] = STATE(246),
-    [sym__math_mode_common] = STATE(246),
-    [sym__math_mode_at] = STATE(246),
-    [sym_parameter] = STATE(246),
-    [sym_math_env_at] = STATE(246),
-    [sym_tag_at] = STATE(246),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(246),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(246),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(246),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(246),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(246),
-    [sym_opt_math_group_at] = STATE(246),
-    [sym_token_at] = STATE(246),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(246),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [166] = {
+    [ts_builtin_sym_end] = ACTIONS(474),
+    [anon_sym_LBRACK] = ACTIONS(474),
+    [anon_sym_RBRACK] = ACTIONS(474),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_end_group] = ACTIONS(472),
+    [sym__escape] = ACTIONS(474),
+    [sym_begin_group] = ACTIONS(474),
+    [sym_end_group] = ACTIONS(474),
+    [sym_math_shift] = ACTIONS(474),
     [sym_alignment_tab] = ACTIONS(474),
-    [sym_parameter_char] = ACTIONS(21),
+    [sym_parameter_char] = ACTIONS(474),
     [sym_superscript] = ACTIONS(474),
     [sym_subscript] = ACTIONS(474),
     [sym_active_char] = ACTIONS(474),
     [sym_text] = ACTIONS(474),
   },
-  [182] = {
-    [sym__common] = STATE(187),
-    [sym__math_mode_common] = STATE(187),
-    [sym__math_mode_at] = STATE(187),
-    [sym_math_mode_at] = STATE(247),
-    [sym_parameter] = STATE(187),
-    [sym_math_env_at] = STATE(187),
-    [sym_tag_at] = STATE(187),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(187),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(187),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(187),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(187),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(187),
-    [sym_opt_math_group_at] = STATE(187),
-    [sym_token_at] = STATE(187),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(187),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [167] = {
+    [sym_verbatim_env_name] = ACTIONS(476),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(269),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(269),
-    [sym_subscript] = ACTIONS(269),
-    [sym_active_char] = ACTIONS(269),
-    [sym_text] = ACTIONS(269),
   },
-  [183] = {
+  [168] = {
+    [ts_builtin_sym_end] = ACTIONS(478),
+    [anon_sym_LBRACK] = ACTIONS(478),
+    [anon_sym_RBRACK] = ACTIONS(478),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(476),
-  },
-  [184] = {
-    [sym_math_text_group_at] = STATE(250),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(478),
     [sym_begin_group] = ACTIONS(478),
+    [sym_end_group] = ACTIONS(478),
+    [sym_math_shift] = ACTIONS(478),
+    [sym_alignment_tab] = ACTIONS(478),
+    [sym_parameter_char] = ACTIONS(478),
+    [sym_superscript] = ACTIONS(478),
+    [sym_subscript] = ACTIONS(478),
+    [sym_active_char] = ACTIONS(478),
+    [sym_text] = ACTIONS(478),
   },
-  [185] = {
-    [sym__common] = STATE(253),
-    [sym__math_mode_common] = STATE(253),
-    [sym__math_mode_at] = STATE(253),
-    [sym_parameter] = STATE(253),
-    [sym_math_env_at] = STATE(253),
-    [sym_tag_at] = STATE(253),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(253),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_end] = STATE(252),
-    [sym_end_token] = STATE(74),
-    [sym_include_at] = STATE(253),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(253),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(253),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(253),
-    [sym_opt_math_group_at] = STATE(253),
-    [sym_token_at] = STATE(253),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(253),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [169] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(480),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(480),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(482),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(482),
-    [sym_subscript] = ACTIONS(482),
-    [sym_active_char] = ACTIONS(482),
-    [sym_text] = ACTIONS(482),
+    [sym__escape] = ACTIONS(482),
+    [sym__end_of_line] = ACTIONS(482),
   },
-  [186] = {
-    [sym__common] = STATE(255),
-    [sym__math_mode_common] = STATE(255),
-    [sym__math_mode_at] = STATE(255),
-    [sym_parameter] = STATE(255),
-    [sym_math_env_at] = STATE(255),
-    [sym_tag_at] = STATE(255),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(255),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(255),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(255),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(255),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(255),
-    [sym_opt_math_group_at] = STATE(255),
-    [sym_token_at] = STATE(255),
-    [sym_begin_opt] = STATE(186),
-    [sym_end_opt] = STATE(254),
-    [aux_sym_math_mode_at_repeat1] = STATE(255),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+  [170] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(170),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(484),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(484),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(484),
-    [sym_subscript] = ACTIONS(484),
-    [sym_active_char] = ACTIONS(484),
-    [sym_text] = ACTIONS(484),
+    [sym__end_of_line] = ACTIONS(487),
   },
-  [187] = {
-    [sym__common] = STATE(256),
-    [sym__math_mode_common] = STATE(256),
-    [sym__math_mode_at] = STATE(256),
-    [sym_parameter] = STATE(256),
-    [sym_math_env_at] = STATE(256),
-    [sym_tag_at] = STATE(256),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(256),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(256),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(256),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(256),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(256),
-    [sym_opt_math_group_at] = STATE(256),
-    [sym_token_at] = STATE(256),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(256),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [171] = {
+    [aux_sym_verbatim_text_repeat1] = STATE(72),
+    [aux_sym_verbatim_text_repeat2] = STATE(171),
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(489),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_math_shift] = ACTIONS(486),
-    [sym_alignment_tab] = ACTIONS(488),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(488),
-    [sym_subscript] = ACTIONS(488),
-    [sym_active_char] = ACTIONS(488),
-    [sym_text] = ACTIONS(488),
+    [sym__escape] = ACTIONS(482),
+    [sym__end_of_line] = ACTIONS(492),
   },
-  [188] = {
-    [anon_sym_makeatother] = ACTIONS(490),
+  [172] = {
+    [ts_builtin_sym_end] = ACTIONS(495),
+    [anon_sym_LBRACK] = ACTIONS(495),
+    [anon_sym_RBRACK] = ACTIONS(495),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(495),
+    [sym_begin_group] = ACTIONS(495),
+    [sym_end_group] = ACTIONS(495),
+    [sym_math_shift] = ACTIONS(495),
+    [sym_alignment_tab] = ACTIONS(495),
+    [sym_parameter_char] = ACTIONS(495),
+    [sym_superscript] = ACTIONS(495),
+    [sym_subscript] = ACTIONS(495),
+    [sym_active_char] = ACTIONS(495),
+    [sym_text] = ACTIONS(495),
   },
-  [189] = {
-    [ts_builtin_sym_end] = ACTIONS(492),
-    [anon_sym_LBRACK] = ACTIONS(492),
-    [anon_sym_RBRACK] = ACTIONS(492),
+  [173] = {
+    [ts_builtin_sym_end] = ACTIONS(497),
+    [anon_sym_LBRACK] = ACTIONS(497),
+    [anon_sym_RBRACK] = ACTIONS(497),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(492),
-    [sym_begin_group] = ACTIONS(492),
-    [sym_end_group] = ACTIONS(492),
-    [sym_math_shift] = ACTIONS(492),
-    [sym_alignment_tab] = ACTIONS(492),
-    [sym_parameter_char] = ACTIONS(492),
-    [sym_superscript] = ACTIONS(492),
-    [sym_subscript] = ACTIONS(492),
-    [sym_active_char] = ACTIONS(492),
-    [sym_text] = ACTIONS(492),
+    [sym__escape] = ACTIONS(497),
+    [sym_begin_group] = ACTIONS(497),
+    [sym_end_group] = ACTIONS(497),
+    [sym_math_shift] = ACTIONS(497),
+    [sym_alignment_tab] = ACTIONS(497),
+    [sym_parameter_char] = ACTIONS(497),
+    [sym_superscript] = ACTIONS(497),
+    [sym_subscript] = ACTIONS(497),
+    [sym_active_char] = ACTIONS(497),
+    [sym_text] = ACTIONS(497),
   },
-  [190] = {
-    [sym_end_display_math] = STATE(257),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(187),
-  },
-  [191] = {
-    [sym__common] = STATE(258),
-    [sym__math_mode_common] = STATE(258),
-    [sym__math_mode_at] = STATE(258),
-    [sym_parameter] = STATE(258),
-    [sym_math_env_at] = STATE(258),
-    [sym_tag_at] = STATE(258),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(258),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(258),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(258),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(258),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(258),
-    [sym_opt_math_group_at] = STATE(258),
-    [sym_token_at] = STATE(258),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(258),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(486),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(494),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(494),
-    [sym_subscript] = ACTIONS(494),
-    [sym_active_char] = ACTIONS(494),
-    [sym_text] = ACTIONS(494),
-  },
-  [192] = {
-    [sym_end_inline_math] = STATE(259),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(191),
-  },
-  [193] = {
-    [sym_display_math_end] = STATE(260),
-    [sym_end_token] = STATE(145),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
-  },
-  [194] = {
-    [sym_inline_math_end] = STATE(261),
-    [sym_end_token] = STATE(147),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(85),
-  },
-  [195] = {
-    [anon_sym_verb] = ACTIONS(27),
-    [anon_sym_LBRACK] = ACTIONS(29),
-    [anon_sym_LPAREN] = ACTIONS(31),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_end] = ACTIONS(207),
-    [anon_sym_documentclass] = ACTIONS(37),
-    [anon_sym_usepackage] = ACTIONS(39),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
-    [anon_sym_emph] = ACTIONS(49),
-    [anon_sym_textbf] = ACTIONS(51),
-    [anon_sym_textit] = ACTIONS(53),
-    [anon_sym_texttt] = ACTIONS(55),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(255),
-  },
-  [196] = {
-    [anon_sym_LBRACK] = ACTIONS(496),
-    [anon_sym_RBRACK] = ACTIONS(496),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(496),
-    [sym_begin_group] = ACTIONS(496),
-    [sym_end_group] = ACTIONS(496),
-    [sym_math_shift] = ACTIONS(496),
-    [sym_alignment_tab] = ACTIONS(496),
-    [sym_parameter_char] = ACTIONS(496),
-    [sym_superscript] = ACTIONS(496),
-    [sym_subscript] = ACTIONS(496),
-    [sym_active_char] = ACTIONS(496),
-    [sym_text] = ACTIONS(496),
-  },
-  [197] = {
-    [sym__common] = STATE(208),
-    [sym__text_mode_common] = STATE(208),
-    [sym_inline_verbatim] = STATE(208),
+  [174] = {
+    [sym__common] = STATE(174),
+    [sym__text_mode_common] = STATE(174),
+    [sym_inline_verbatim] = STATE(174),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(208),
-    [sym_parameter] = STATE(208),
-    [sym_text_env_at] = STATE(208),
-    [sym__display_math_at] = STATE(208),
-    [sym_tex_display_math_at] = STATE(208),
-    [sym_latex_display_math_at] = STATE(208),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(208),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(208),
-    [sym_tex_inline_math_at] = STATE(208),
-    [sym_latex_inline_math_at] = STATE(208),
-    [sym_inline_math_env_at] = STATE(208),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(208),
+    [sym__text_mode] = STATE(174),
+    [sym_text_mode_at_region] = STATE(174),
+    [sym_parameter] = STATE(174),
+    [sym_text_env] = STATE(174),
+    [sym__display_math] = STATE(174),
+    [sym_tex_display_math] = STATE(174),
+    [sym_latex_display_math] = STATE(174),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(174),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(174),
+    [sym_tex_inline_math] = STATE(174),
+    [sym_latex_inline_math] = STATE(174),
+    [sym_inline_math_env] = STATE(174),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(174),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(208),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_end] = STATE(262),
-    [sym_end_token] = STATE(74),
-    [sym_documentclass] = STATE(208),
+    [sym_escaped] = STATE(174),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(174),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(208),
+    [sym_usepackage] = STATE(174),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(208),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(208),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(208),
+    [sym_include] = STATE(174),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(174),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(174),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(208),
+    [sym_catcode] = STATE(174),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(208),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(208),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(208),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(208),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(208),
-    [sym_opt_text_group_at] = STATE(208),
-    [sym_token_at] = STATE(208),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(208),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_emph] = STATE(174),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(174),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(174),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(174),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(174),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(174),
+    [sym_opt_text_group] = STATE(174),
+    [sym_token] = STATE(174),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(174),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(347),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(350),
+    [sym_begin_group] = ACTIONS(353),
+    [sym_math_shift] = ACTIONS(356),
+    [sym_alignment_tab] = ACTIONS(499),
+    [sym_parameter_char] = ACTIONS(362),
+    [sym_superscript] = ACTIONS(365),
+    [sym_subscript] = ACTIONS(365),
+    [sym_active_char] = ACTIONS(499),
+    [sym_text] = ACTIONS(499),
+  },
+  [175] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(502),
+  },
+  [176] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(504),
+  },
+  [177] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(506),
+  },
+  [178] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(508),
+  },
+  [179] = {
+    [sym__common] = STATE(262),
+    [sym__text_mode_common] = STATE(262),
+    [sym_inline_verbatim] = STATE(262),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(262),
+    [sym_text_mode_at_region] = STATE(262),
+    [sym_parameter] = STATE(262),
+    [sym_text_env] = STATE(262),
+    [sym__display_math] = STATE(262),
+    [sym_tex_display_math] = STATE(262),
+    [sym_latex_display_math] = STATE(262),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(262),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(262),
+    [sym_tex_inline_math] = STATE(262),
+    [sym_latex_inline_math] = STATE(262),
+    [sym_inline_math_env] = STATE(262),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(262),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(262),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(262),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(262),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(262),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(262),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(262),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(262),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(262),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(262),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(262),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(262),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(262),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(262),
+    [sym_opt_text_group] = STATE(262),
+    [sym_token] = STATE(262),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(262),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(275),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(287),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(510),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(512),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(287),
-    [sym_text] = ACTIONS(287),
-  },
-  [198] = {
-    [sym_text_group_at] = STATE(265),
-    [sym_opt_text_group_at] = STATE(266),
-    [sym_begin_opt] = STATE(267),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(498),
-    [sym__end_of_line] = ACTIONS(500),
-  },
-  [199] = {
-    [anon_sym_LBRACK] = ACTIONS(502),
-    [anon_sym_RBRACK] = ACTIONS(502),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(502),
-    [sym_begin_group] = ACTIONS(502),
-    [sym_end_group] = ACTIONS(502),
-    [sym_math_shift] = ACTIONS(502),
-    [sym_alignment_tab] = ACTIONS(502),
-    [sym_parameter_char] = ACTIONS(502),
-    [sym_superscript] = ACTIONS(502),
-    [sym_subscript] = ACTIONS(502),
-    [sym_active_char] = ACTIONS(502),
-    [sym_text] = ACTIONS(502),
-  },
-  [200] = {
-    [anon_sym_LBRACK] = ACTIONS(504),
-    [anon_sym_RBRACK] = ACTIONS(504),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(504),
-    [sym_begin_group] = ACTIONS(504),
-    [sym_end_group] = ACTIONS(504),
-    [sym_math_shift] = ACTIONS(504),
-    [sym_alignment_tab] = ACTIONS(504),
-    [sym_parameter_char] = ACTIONS(504),
-    [sym_superscript] = ACTIONS(504),
-    [sym_subscript] = ACTIONS(504),
-    [sym_active_char] = ACTIONS(504),
-    [sym_text] = ACTIONS(504),
-  },
-  [201] = {
-    [sym_text_group_at] = STATE(268),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(103),
-  },
-  [202] = {
-    [anon_sym_LBRACK] = ACTIONS(506),
-    [anon_sym_RBRACK] = ACTIONS(506),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(506),
-    [sym_begin_group] = ACTIONS(506),
-    [sym_end_group] = ACTIONS(506),
-    [sym_math_shift] = ACTIONS(506),
-    [sym_alignment_tab] = ACTIONS(506),
-    [sym_parameter_char] = ACTIONS(506),
-    [sym_superscript] = ACTIONS(506),
-    [sym_subscript] = ACTIONS(506),
-    [sym_active_char] = ACTIONS(506),
-    [sym_text] = ACTIONS(506),
-  },
-  [203] = {
-    [anon_sym_LBRACK] = ACTIONS(508),
-    [anon_sym_RBRACK] = ACTIONS(508),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(508),
-    [sym_begin_group] = ACTIONS(508),
-    [sym_end_group] = ACTIONS(508),
-    [sym_math_shift] = ACTIONS(508),
-    [sym_alignment_tab] = ACTIONS(508),
-    [sym_parameter_char] = ACTIONS(508),
-    [sym_superscript] = ACTIONS(508),
-    [sym_subscript] = ACTIONS(508),
-    [sym_active_char] = ACTIONS(508),
-    [sym_text] = ACTIONS(508),
-  },
-  [204] = {
-    [anon_sym_LBRACK] = ACTIONS(510),
-    [anon_sym_RBRACK] = ACTIONS(510),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(510),
-    [sym_begin_group] = ACTIONS(510),
-    [sym_end_group] = ACTIONS(510),
-    [sym_math_shift] = ACTIONS(510),
-    [sym_alignment_tab] = ACTIONS(510),
-    [sym_parameter_char] = ACTIONS(510),
-    [sym_superscript] = ACTIONS(510),
-    [sym_subscript] = ACTIONS(510),
-    [sym_active_char] = ACTIONS(510),
-    [sym_text] = ACTIONS(510),
-  },
-  [205] = {
-    [anon_sym_LBRACK] = ACTIONS(512),
-    [anon_sym_RBRACK] = ACTIONS(512),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(512),
-    [sym_begin_group] = ACTIONS(512),
-    [sym_end_group] = ACTIONS(512),
-    [sym_math_shift] = ACTIONS(512),
-    [sym_alignment_tab] = ACTIONS(512),
-    [sym_parameter_char] = ACTIONS(512),
-    [sym_superscript] = ACTIONS(512),
-    [sym_subscript] = ACTIONS(512),
     [sym_active_char] = ACTIONS(512),
     [sym_text] = ACTIONS(512),
   },
-  [206] = {
+  [180] = {
     [anon_sym_LBRACK] = ACTIONS(514),
-    [anon_sym_RBRACK] = ACTIONS(514),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
     [sym__escape] = ACTIONS(514),
     [sym_begin_group] = ACTIONS(514),
-    [sym_end_group] = ACTIONS(514),
-    [sym_math_shift] = ACTIONS(514),
     [sym_alignment_tab] = ACTIONS(514),
     [sym_parameter_char] = ACTIONS(514),
     [sym_superscript] = ACTIONS(514),
@@ -9638,901 +9330,389 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(514),
     [sym_text] = ACTIONS(514),
   },
-  [207] = {
-    [sym__common] = STATE(270),
-    [sym__text_mode_common] = STATE(270),
-    [sym_inline_verbatim] = STATE(270),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(270),
-    [sym_parameter] = STATE(270),
-    [sym_text_env_at] = STATE(270),
-    [sym__display_math_at] = STATE(270),
-    [sym_tex_display_math_at] = STATE(270),
-    [sym_latex_display_math_at] = STATE(270),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(270),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(270),
-    [sym_tex_inline_math_at] = STATE(270),
-    [sym_latex_inline_math_at] = STATE(270),
-    [sym_inline_math_env_at] = STATE(270),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(270),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(270),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(270),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(270),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(270),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(270),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(270),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(270),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(270),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(270),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(270),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(270),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(270),
-    [sym_opt_text_group_at] = STATE(270),
-    [sym_token_at] = STATE(270),
-    [sym_begin_opt] = STATE(113),
-    [sym_end_opt] = STATE(269),
-    [aux_sym_text_mode_at_repeat1] = STATE(270),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
+  [181] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(516),
+    [sym__end_of_line] = ACTIONS(516),
+  },
+  [182] = {
+    [sym_text_group] = STATE(265),
+    [sym__whitespace] = ACTIONS(518),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(516),
+  },
+  [183] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(520),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(522),
+    [sym__end_of_line] = ACTIONS(522),
+  },
+  [184] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(524),
+  },
+  [185] = {
+    [sym_text_group] = STATE(268),
+    [sym__whitespace] = ACTIONS(526),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(524),
+  },
+  [186] = {
+    [sym_simple_text_group] = STATE(269),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(97),
+  },
+  [187] = {
+    [ts_builtin_sym_end] = ACTIONS(528),
+    [anon_sym_LBRACK] = ACTIONS(528),
+    [anon_sym_RBRACK] = ACTIONS(528),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(528),
+    [sym_begin_group] = ACTIONS(528),
+    [sym_end_group] = ACTIONS(528),
+    [sym_math_shift] = ACTIONS(528),
+    [sym_alignment_tab] = ACTIONS(528),
+    [sym_parameter_char] = ACTIONS(528),
+    [sym_superscript] = ACTIONS(528),
+    [sym_subscript] = ACTIONS(528),
+    [sym_active_char] = ACTIONS(528),
+    [sym_text] = ACTIONS(528),
+  },
+  [188] = {
+    [sym__whitespace] = ACTIONS(339),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(339),
+    [sym__end_of_line] = ACTIONS(339),
+  },
+  [189] = {
+    [sym__whitespace] = ACTIONS(341),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(341),
+    [sym__end_of_line] = ACTIONS(341),
+  },
+  [190] = {
+    [sym__common] = STATE(237),
+    [sym__text_mode_common] = STATE(237),
+    [sym_inline_verbatim] = STATE(237),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(237),
+    [sym_text_mode_at_region] = STATE(237),
+    [sym_parameter] = STATE(237),
+    [sym_text_env] = STATE(237),
+    [sym__display_math] = STATE(237),
+    [sym_tex_display_math] = STATE(237),
+    [sym_latex_display_math] = STATE(237),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(237),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(237),
+    [sym_tex_inline_math] = STATE(237),
+    [sym_latex_inline_math] = STATE(237),
+    [sym_inline_math_env] = STATE(237),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(237),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(237),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(237),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(237),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(237),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(237),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(237),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(237),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(237),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(237),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(237),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(237),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(237),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(237),
+    [sym_opt_text_group] = STATE(237),
+    [sym_token] = STATE(237),
+    [sym_begin_opt] = STATE(30),
+    [sym_end_opt] = STATE(270),
+    [aux_sym_text_mode_repeat1] = STATE(237),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(273),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(343),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(516),
-    [sym_text] = ACTIONS(516),
+    [sym_active_char] = ACTIONS(343),
+    [sym_text] = ACTIONS(343),
   },
-  [208] = {
-    [sym__common] = STATE(208),
-    [sym__text_mode_common] = STATE(208),
-    [sym_inline_verbatim] = STATE(208),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(208),
-    [sym_parameter] = STATE(208),
-    [sym_text_env_at] = STATE(208),
-    [sym__display_math_at] = STATE(208),
-    [sym_tex_display_math_at] = STATE(208),
-    [sym_latex_display_math_at] = STATE(208),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(208),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(208),
-    [sym_tex_inline_math_at] = STATE(208),
-    [sym_latex_inline_math_at] = STATE(208),
-    [sym_inline_math_env_at] = STATE(208),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(208),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(208),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(208),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(208),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(208),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(208),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(208),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(208),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(208),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(208),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(208),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(208),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(208),
-    [sym_opt_text_group_at] = STATE(208),
-    [sym_token_at] = STATE(208),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(208),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(518),
+  [191] = {
+    [sym_simple_text_group] = STATE(271),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(521),
-    [sym_begin_group] = ACTIONS(524),
-    [sym_math_shift] = ACTIONS(527),
+    [sym_begin_group] = ACTIONS(97),
+  },
+  [192] = {
+    [ts_builtin_sym_end] = ACTIONS(530),
+    [anon_sym_LBRACK] = ACTIONS(530),
+    [anon_sym_RBRACK] = ACTIONS(530),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(530),
+    [sym_begin_group] = ACTIONS(530),
+    [sym_end_group] = ACTIONS(530),
+    [sym_math_shift] = ACTIONS(530),
     [sym_alignment_tab] = ACTIONS(530),
-    [sym_parameter_char] = ACTIONS(533),
-    [sym_superscript] = ACTIONS(536),
-    [sym_subscript] = ACTIONS(536),
+    [sym_parameter_char] = ACTIONS(530),
+    [sym_superscript] = ACTIONS(530),
+    [sym_subscript] = ACTIONS(530),
     [sym_active_char] = ACTIONS(530),
     [sym_text] = ACTIONS(530),
   },
-  [209] = {
-    [ts_builtin_sym_end] = ACTIONS(539),
-    [anon_sym_LBRACK] = ACTIONS(539),
-    [anon_sym_RBRACK] = ACTIONS(539),
+  [193] = {
+    [sym_text_group] = STATE(272),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(539),
-    [sym_begin_group] = ACTIONS(539),
-    [sym_end_group] = ACTIONS(539),
-    [sym_math_shift] = ACTIONS(539),
-    [sym_alignment_tab] = ACTIONS(539),
-    [sym_parameter_char] = ACTIONS(539),
-    [sym_superscript] = ACTIONS(539),
-    [sym_subscript] = ACTIONS(539),
-    [sym_active_char] = ACTIONS(539),
-    [sym_text] = ACTIONS(539),
-  },
-  [210] = {
-    [sym__common] = STATE(210),
-    [sym__text_mode_common] = STATE(210),
-    [sym_inline_verbatim] = STATE(210),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(210),
-    [sym_text_mode_at_region] = STATE(210),
-    [sym_parameter] = STATE(210),
-    [sym_text_env] = STATE(210),
-    [sym__display_math] = STATE(210),
-    [sym_tex_display_math] = STATE(210),
-    [sym_latex_display_math] = STATE(210),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(210),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(210),
-    [sym_tex_inline_math] = STATE(210),
-    [sym_latex_inline_math] = STATE(210),
-    [sym_inline_math_env] = STATE(210),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(210),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(210),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(210),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(210),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(210),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(210),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(210),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(210),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(210),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(210),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(210),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(210),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(210),
-    [sym_opt_text_group] = STATE(210),
-    [sym_token] = STATE(210),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(210),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(297),
-    [anon_sym_RBRACK] = ACTIONS(295),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(300),
-    [sym_begin_group] = ACTIONS(303),
-    [sym_math_shift] = ACTIONS(306),
-    [sym_alignment_tab] = ACTIONS(541),
-    [sym_parameter_char] = ACTIONS(312),
-    [sym_superscript] = ACTIONS(315),
-    [sym_subscript] = ACTIONS(315),
-    [sym_active_char] = ACTIONS(541),
-    [sym_text] = ACTIONS(541),
-  },
-  [211] = {
-    [aux_sym__whitespace_repeat1] = STATE(211),
-    [sym_verb_delim] = ACTIONS(544),
-    [aux_sym_SLASH_LBRACK_BSLASHs_BSLASHt_RBRACK_SLASH] = ACTIONS(546),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-  },
-  [212] = {
-    [anon_sym_LBRACK] = ACTIONS(549),
-    [anon_sym_RBRACK] = ACTIONS(549),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(549),
-    [sym_begin_group] = ACTIONS(549),
-    [sym_end_group] = ACTIONS(549),
-    [sym_math_shift] = ACTIONS(549),
-    [sym_alignment_tab] = ACTIONS(549),
-    [sym_parameter_char] = ACTIONS(549),
-    [sym_superscript] = ACTIONS(549),
-    [sym_subscript] = ACTIONS(549),
-    [sym_active_char] = ACTIONS(549),
-    [sym_text] = ACTIONS(549),
-  },
-  [213] = {
-    [sym__common] = STATE(213),
-    [sym__math_mode_common] = STATE(213),
-    [sym__math_mode] = STATE(213),
-    [sym_parameter] = STATE(213),
-    [sym_math_env] = STATE(213),
-    [sym_tag] = STATE(213),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(213),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(213),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(213),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(213),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(213),
-    [sym_opt_math_group] = STATE(213),
-    [sym_token] = STATE(213),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(213),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(360),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(363),
-    [sym_begin_group] = ACTIONS(366),
-    [sym_end_group] = ACTIONS(369),
-    [sym_alignment_tab] = ACTIONS(551),
-    [sym_parameter_char] = ACTIONS(374),
-    [sym_superscript] = ACTIONS(551),
-    [sym_subscript] = ACTIONS(551),
-    [sym_active_char] = ACTIONS(551),
-    [sym_text] = ACTIONS(551),
-  },
-  [214] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(554),
-  },
-  [215] = {
-    [anon_sym_LBRACK] = ACTIONS(556),
-    [anon_sym_RBRACK] = ACTIONS(556),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(556),
-    [sym_begin_group] = ACTIONS(556),
-    [sym_end_group] = ACTIONS(556),
-    [sym_math_shift] = ACTIONS(556),
-    [sym_alignment_tab] = ACTIONS(556),
-    [sym_parameter_char] = ACTIONS(556),
-    [sym_superscript] = ACTIONS(556),
-    [sym_subscript] = ACTIONS(556),
-    [sym_active_char] = ACTIONS(556),
-    [sym_text] = ACTIONS(556),
-  },
-  [216] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(558),
-  },
-  [217] = {
-    [sym__common] = STATE(124),
-    [sym__text_mode_common] = STATE(124),
-    [sym_inline_verbatim] = STATE(124),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(124),
-    [sym_text_mode_at_region] = STATE(124),
-    [sym_parameter] = STATE(124),
-    [sym_text_env] = STATE(124),
-    [sym__display_math] = STATE(124),
-    [sym_tex_display_math] = STATE(124),
-    [sym_latex_display_math] = STATE(124),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(124),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(124),
-    [sym_tex_inline_math] = STATE(124),
-    [sym_latex_inline_math] = STATE(124),
-    [sym_inline_math_env] = STATE(124),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(124),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(124),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(124),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(124),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(124),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(124),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(124),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(124),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(124),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(124),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(124),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(124),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(124),
-    [sym_opt_text_group] = STATE(124),
-    [sym_token] = STATE(124),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(124),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(115),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(163),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(163),
-    [sym_text] = ACTIONS(163),
   },
-  [218] = {
-    [anon_sym_LBRACK] = ACTIONS(560),
-    [anon_sym_RBRACK] = ACTIONS(560),
+  [194] = {
+    [ts_builtin_sym_end] = ACTIONS(532),
+    [anon_sym_LBRACK] = ACTIONS(532),
+    [anon_sym_RBRACK] = ACTIONS(532),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(560),
-    [sym_begin_group] = ACTIONS(560),
-    [sym_end_group] = ACTIONS(560),
-    [sym_math_shift] = ACTIONS(560),
-    [sym_alignment_tab] = ACTIONS(560),
-    [sym_parameter_char] = ACTIONS(560),
-    [sym_superscript] = ACTIONS(560),
-    [sym_subscript] = ACTIONS(560),
-    [sym_active_char] = ACTIONS(560),
-    [sym_text] = ACTIONS(560),
+    [sym__escape] = ACTIONS(532),
+    [sym_begin_group] = ACTIONS(532),
+    [sym_end_group] = ACTIONS(532),
+    [sym_math_shift] = ACTIONS(532),
+    [sym_alignment_tab] = ACTIONS(532),
+    [sym_parameter_char] = ACTIONS(532),
+    [sym_superscript] = ACTIONS(532),
+    [sym_subscript] = ACTIONS(532),
+    [sym_active_char] = ACTIONS(532),
+    [sym_text] = ACTIONS(532),
   },
-  [219] = {
-    [anon_sym_LBRACK] = ACTIONS(562),
-    [anon_sym_RBRACK] = ACTIONS(562),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(562),
-    [sym_begin_group] = ACTIONS(562),
-    [sym_end_group] = ACTIONS(562),
-    [sym_math_shift] = ACTIONS(562),
-    [sym_alignment_tab] = ACTIONS(562),
-    [sym_parameter_char] = ACTIONS(562),
-    [sym_superscript] = ACTIONS(562),
-    [sym_subscript] = ACTIONS(562),
-    [sym_active_char] = ACTIONS(562),
-    [sym_text] = ACTIONS(562),
-  },
-  [220] = {
-    [sym__common] = STATE(220),
-    [sym__math_mode_common] = STATE(220),
-    [sym__math_mode] = STATE(220),
-    [sym_parameter] = STATE(220),
-    [sym_math_env] = STATE(220),
-    [sym_tag] = STATE(220),
-    [sym_tag_token] = STATE(55),
-    [sym_escaped] = STATE(220),
-    [sym_begin] = STATE(56),
-    [sym_begin_token] = STATE(57),
-    [sym_include] = STATE(220),
-    [sym_include_token] = STATE(19),
-    [sym_storage] = STATE(220),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(220),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group] = STATE(220),
-    [sym_opt_math_group] = STATE(220),
-    [sym_token] = STATE(220),
-    [sym_begin_opt] = STATE(58),
-    [aux_sym_math_mode_repeat1] = STATE(220),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(360),
-    [anon_sym_RBRACK] = ACTIONS(369),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(363),
-    [sym_begin_group] = ACTIONS(366),
-    [sym_alignment_tab] = ACTIONS(564),
-    [sym_parameter_char] = ACTIONS(374),
-    [sym_superscript] = ACTIONS(564),
-    [sym_subscript] = ACTIONS(564),
-    [sym_active_char] = ACTIONS(564),
-    [sym_text] = ACTIONS(564),
-  },
-  [221] = {
-    [ts_builtin_sym_end] = ACTIONS(567),
-    [anon_sym_LBRACK] = ACTIONS(567),
-    [anon_sym_RBRACK] = ACTIONS(567),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(567),
-    [sym_begin_group] = ACTIONS(567),
-    [sym_end_group] = ACTIONS(567),
-    [sym_math_shift] = ACTIONS(567),
-    [sym_alignment_tab] = ACTIONS(567),
-    [sym_parameter_char] = ACTIONS(567),
-    [sym_superscript] = ACTIONS(567),
-    [sym_subscript] = ACTIONS(567),
-    [sym_active_char] = ACTIONS(567),
-    [sym_text] = ACTIONS(567),
-  },
-  [222] = {
-    [ts_builtin_sym_end] = ACTIONS(569),
-    [anon_sym_LBRACK] = ACTIONS(569),
-    [anon_sym_RBRACK] = ACTIONS(569),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(569),
-    [sym_begin_group] = ACTIONS(569),
-    [sym_end_group] = ACTIONS(569),
-    [sym_math_shift] = ACTIONS(569),
-    [sym_alignment_tab] = ACTIONS(569),
-    [sym_parameter_char] = ACTIONS(569),
-    [sym_superscript] = ACTIONS(569),
-    [sym_subscript] = ACTIONS(569),
-    [sym_active_char] = ACTIONS(569),
-    [sym_text] = ACTIONS(569),
-  },
-  [223] = {
-    [ts_builtin_sym_end] = ACTIONS(571),
-    [anon_sym_LBRACK] = ACTIONS(571),
-    [anon_sym_RBRACK] = ACTIONS(571),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(571),
-    [sym_begin_group] = ACTIONS(571),
-    [sym_end_group] = ACTIONS(571),
-    [sym_math_shift] = ACTIONS(571),
-    [sym_alignment_tab] = ACTIONS(571),
-    [sym_parameter_char] = ACTIONS(571),
-    [sym_superscript] = ACTIONS(571),
-    [sym_subscript] = ACTIONS(571),
-    [sym_active_char] = ACTIONS(571),
-    [sym_text] = ACTIONS(571),
-  },
-  [224] = {
-    [sym_display_math_env_name] = ACTIONS(573),
+  [195] = {
+    [anon_sym_EQ] = ACTIONS(141),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
   },
-  [225] = {
-    [ts_builtin_sym_end] = ACTIONS(575),
-    [anon_sym_LBRACK] = ACTIONS(575),
-    [anon_sym_RBRACK] = ACTIONS(575),
+  [196] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(575),
-    [sym_begin_group] = ACTIONS(575),
-    [sym_end_group] = ACTIONS(575),
-    [sym_math_shift] = ACTIONS(575),
-    [sym_alignment_tab] = ACTIONS(575),
-    [sym_parameter_char] = ACTIONS(575),
-    [sym_superscript] = ACTIONS(575),
-    [sym_subscript] = ACTIONS(575),
-    [sym_active_char] = ACTIONS(575),
-    [sym_text] = ACTIONS(575),
+    [sym_number] = ACTIONS(534),
   },
-  [226] = {
-    [sym_inline_math_env_name] = ACTIONS(577),
+  [197] = {
+    [sym_text_group] = STATE(274),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-  },
-  [227] = {
-    [ts_builtin_sym_end] = ACTIONS(579),
-    [anon_sym_LBRACK] = ACTIONS(579),
-    [anon_sym_RBRACK] = ACTIONS(579),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(579),
-    [sym_begin_group] = ACTIONS(579),
-    [sym_end_group] = ACTIONS(579),
-    [sym_math_shift] = ACTIONS(579),
-    [sym_alignment_tab] = ACTIONS(579),
-    [sym_parameter_char] = ACTIONS(579),
-    [sym_superscript] = ACTIONS(579),
-    [sym_subscript] = ACTIONS(579),
-    [sym_active_char] = ACTIONS(579),
-    [sym_text] = ACTIONS(579),
-  },
-  [228] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(581),
-  },
-  [229] = {
-    [anon_sym_LBRACK] = ACTIONS(583),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(583),
-    [sym__end_of_line] = ACTIONS(583),
-  },
-  [230] = {
-    [ts_builtin_sym_end] = ACTIONS(585),
-    [anon_sym_LBRACK] = ACTIONS(585),
-    [anon_sym_RBRACK] = ACTIONS(585),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(585),
-    [sym_begin_group] = ACTIONS(585),
-    [sym_end_group] = ACTIONS(585),
-    [sym_math_shift] = ACTIONS(585),
-    [sym_alignment_tab] = ACTIONS(585),
-    [sym_parameter_char] = ACTIONS(585),
-    [sym_superscript] = ACTIONS(585),
-    [sym_subscript] = ACTIONS(585),
-    [sym_active_char] = ACTIONS(585),
-    [sym_text] = ACTIONS(585),
-  },
-  [231] = {
-    [anon_sym_LBRACK] = ACTIONS(587),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(587),
-    [sym__end_of_line] = ACTIONS(587),
-  },
-  [232] = {
-    [ts_builtin_sym_end] = ACTIONS(589),
-    [anon_sym_LBRACK] = ACTIONS(589),
-    [anon_sym_RBRACK] = ACTIONS(589),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(589),
-    [sym_begin_group] = ACTIONS(589),
-    [sym_end_group] = ACTIONS(589),
-    [sym_math_shift] = ACTIONS(589),
-    [sym_alignment_tab] = ACTIONS(589),
-    [sym_parameter_char] = ACTIONS(589),
-    [sym_superscript] = ACTIONS(589),
-    [sym_subscript] = ACTIONS(589),
-    [sym_active_char] = ACTIONS(589),
-    [sym_text] = ACTIONS(589),
-  },
-  [233] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(159),
-  },
-  [234] = {
-    [sym__common] = STATE(124),
-    [sym__text_mode_common] = STATE(124),
-    [sym_inline_verbatim] = STATE(124),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(124),
-    [sym_text_mode_at_region] = STATE(124),
-    [sym_parameter] = STATE(124),
-    [sym_text_env] = STATE(124),
-    [sym__display_math] = STATE(124),
-    [sym_tex_display_math] = STATE(124),
-    [sym_latex_display_math] = STATE(124),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(124),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(124),
-    [sym_tex_inline_math] = STATE(124),
-    [sym_latex_inline_math] = STATE(124),
-    [sym_inline_math_env] = STATE(124),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(124),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(124),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(124),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(124),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(124),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(124),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(124),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(124),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(124),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(124),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(124),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(124),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(124),
-    [sym_opt_text_group] = STATE(124),
-    [sym_token] = STATE(124),
-    [sym_begin_opt] = STATE(29),
-    [aux_sym_text_mode_repeat1] = STATE(124),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
     [sym_begin_group] = ACTIONS(15),
-    [sym_end_group] = ACTIONS(591),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(163),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(163),
-    [sym_text] = ACTIONS(163),
   },
-  [235] = {
-    [anon_sym_LBRACK] = ACTIONS(593),
+  [198] = {
+    [ts_builtin_sym_end] = ACTIONS(536),
+    [anon_sym_LBRACK] = ACTIONS(536),
+    [anon_sym_RBRACK] = ACTIONS(536),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(593),
-    [sym_begin_group] = ACTIONS(593),
-    [sym_alignment_tab] = ACTIONS(593),
-    [sym_parameter_char] = ACTIONS(593),
-    [sym_superscript] = ACTIONS(593),
-    [sym_subscript] = ACTIONS(593),
-    [sym_active_char] = ACTIONS(593),
-    [sym_text] = ACTIONS(593),
-  },
-  [236] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(595),
-  },
-  [237] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(289),
-    [sym__end_of_line] = ACTIONS(289),
-  },
-  [238] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(291),
-    [sym__end_of_line] = ACTIONS(291),
-  },
-  [239] = {
-    [sym__common] = STATE(210),
-    [sym__text_mode_common] = STATE(210),
-    [sym_inline_verbatim] = STATE(210),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode] = STATE(210),
-    [sym_text_mode_at_region] = STATE(210),
-    [sym_parameter] = STATE(210),
-    [sym_text_env] = STATE(210),
-    [sym__display_math] = STATE(210),
-    [sym_tex_display_math] = STATE(210),
-    [sym_latex_display_math] = STATE(210),
-    [sym_begin_display_math] = STATE(10),
-    [sym_begin_inline_math] = STATE(11),
-    [sym_display_math_env] = STATE(210),
-    [sym_display_math_begin] = STATE(12),
-    [sym__inline_math] = STATE(210),
-    [sym_tex_inline_math] = STATE(210),
-    [sym_latex_inline_math] = STATE(210),
-    [sym_inline_math_env] = STATE(210),
-    [sym_inline_math_begin] = STATE(13),
-    [sym_verbatim_env] = STATE(210),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(210),
-    [sym_begin] = STATE(15),
-    [sym_begin_token] = STATE(16),
-    [sym_documentclass] = STATE(210),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(210),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include] = STATE(210),
-    [sym_include_token] = STATE(19),
-    [sym_section] = STATE(210),
-    [sym_section_token] = STATE(20),
-    [sym_storage] = STATE(210),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(210),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph] = STATE(210),
-    [sym_emph_token] = STATE(23),
-    [sym_textbf] = STATE(210),
-    [sym_textbf_token] = STATE(24),
-    [sym_textit] = STATE(210),
-    [sym_textit_token] = STATE(25),
-    [sym_texttt] = STATE(210),
-    [sym_texttt_token] = STATE(26),
-    [sym_makeatletter] = STATE(27),
-    [sym_makeatletter_token] = STATE(28),
-    [sym_text_group] = STATE(210),
-    [sym_opt_text_group] = STATE(210),
-    [sym_token] = STATE(210),
-    [sym_begin_opt] = STATE(29),
-    [sym_end_opt] = STATE(277),
-    [aux_sym_text_mode_repeat1] = STATE(210),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(444),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(13),
-    [sym_begin_group] = ACTIONS(15),
-    [sym_math_shift] = ACTIONS(17),
-    [sym_alignment_tab] = ACTIONS(293),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(293),
-    [sym_text] = ACTIONS(293),
-  },
-  [240] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(597),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(599),
-    [sym__end_of_line] = ACTIONS(599),
-  },
-  [241] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(601),
-  },
-  [242] = {
-    [ts_builtin_sym_end] = ACTIONS(603),
-    [anon_sym_LBRACK] = ACTIONS(603),
-    [anon_sym_RBRACK] = ACTIONS(603),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(603),
-    [sym_begin_group] = ACTIONS(603),
-    [sym_end_group] = ACTIONS(603),
-    [sym_math_shift] = ACTIONS(603),
-    [sym_alignment_tab] = ACTIONS(603),
-    [sym_parameter_char] = ACTIONS(603),
-    [sym_superscript] = ACTIONS(603),
-    [sym_subscript] = ACTIONS(603),
-    [sym_active_char] = ACTIONS(603),
-    [sym_text] = ACTIONS(603),
-  },
-  [243] = {
-    [anon_sym_LBRACK] = ACTIONS(605),
-    [anon_sym_RBRACK] = ACTIONS(605),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(605),
-    [sym_begin_group] = ACTIONS(605),
-    [sym_end_group] = ACTIONS(605),
-    [sym_math_shift] = ACTIONS(605),
-    [sym_alignment_tab] = ACTIONS(605),
-    [sym_parameter_char] = ACTIONS(605),
-    [sym_superscript] = ACTIONS(605),
-    [sym_subscript] = ACTIONS(605),
-    [sym_active_char] = ACTIONS(605),
-    [sym_text] = ACTIONS(605),
-  },
-  [244] = {
-    [sym__common] = STATE(244),
-    [sym__text_mode_common] = STATE(244),
-    [sym_inline_verbatim] = STATE(244),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(244),
-    [sym_parameter] = STATE(244),
-    [sym_text_env_at] = STATE(244),
-    [sym__display_math_at] = STATE(244),
-    [sym_tex_display_math_at] = STATE(244),
-    [sym_latex_display_math_at] = STATE(244),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(244),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(244),
-    [sym_tex_inline_math_at] = STATE(244),
-    [sym_latex_inline_math_at] = STATE(244),
-    [sym_inline_math_env_at] = STATE(244),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(244),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(244),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(244),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(244),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(244),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(244),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(244),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(244),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(244),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(244),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(244),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(244),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(244),
-    [sym_opt_text_group_at] = STATE(244),
-    [sym_token_at] = STATE(244),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(244),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(518),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(521),
-    [sym_begin_group] = ACTIONS(524),
-    [sym_end_group] = ACTIONS(607),
-    [sym_math_shift] = ACTIONS(527),
-    [sym_alignment_tab] = ACTIONS(609),
-    [sym_parameter_char] = ACTIONS(533),
+    [sym__escape] = ACTIONS(536),
+    [sym_begin_group] = ACTIONS(536),
+    [sym_end_group] = ACTIONS(536),
+    [sym_math_shift] = ACTIONS(536),
+    [sym_alignment_tab] = ACTIONS(536),
+    [sym_parameter_char] = ACTIONS(536),
     [sym_superscript] = ACTIONS(536),
     [sym_subscript] = ACTIONS(536),
-    [sym_active_char] = ACTIONS(609),
-    [sym_text] = ACTIONS(609),
+    [sym_active_char] = ACTIONS(536),
+    [sym_text] = ACTIONS(536),
   },
-  [245] = {
-    [anon_sym_LBRACK] = ACTIONS(612),
-    [anon_sym_RBRACK] = ACTIONS(612),
+  [199] = {
+    [ts_builtin_sym_end] = ACTIONS(538),
+    [sym__whitespace] = ACTIONS(540),
+    [anon_sym_LBRACK] = ACTIONS(538),
+    [anon_sym_RBRACK] = ACTIONS(538),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(612),
-    [sym_begin_group] = ACTIONS(612),
-    [sym_end_group] = ACTIONS(612),
-    [sym_math_shift] = ACTIONS(612),
-    [sym_alignment_tab] = ACTIONS(612),
-    [sym_parameter_char] = ACTIONS(612),
-    [sym_superscript] = ACTIONS(612),
-    [sym_subscript] = ACTIONS(612),
-    [sym_active_char] = ACTIONS(612),
-    [sym_text] = ACTIONS(612),
+    [sym__escape] = ACTIONS(538),
+    [sym_begin_group] = ACTIONS(538),
+    [sym_end_group] = ACTIONS(538),
+    [sym_math_shift] = ACTIONS(538),
+    [sym_alignment_tab] = ACTIONS(538),
+    [sym_parameter_char] = ACTIONS(538),
+    [sym_superscript] = ACTIONS(538),
+    [sym_subscript] = ACTIONS(538),
+    [sym_active_char] = ACTIONS(538),
+    [sym_text] = ACTIONS(542),
   },
-  [246] = {
+  [200] = {
+    [sym__whitespace] = ACTIONS(544),
+    [anon_sym_LBRACK] = ACTIONS(546),
+    [anon_sym_RBRACK] = ACTIONS(546),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(546),
+    [sym_begin_group] = ACTIONS(546),
+    [sym_end_group] = ACTIONS(546),
+    [sym_math_shift] = ACTIONS(546),
+    [sym_alignment_tab] = ACTIONS(546),
+    [sym_parameter_char] = ACTIONS(546),
+    [sym_superscript] = ACTIONS(546),
+    [sym_subscript] = ACTIONS(546),
+    [sym_active_char] = ACTIONS(546),
+    [sym_text] = ACTIONS(548),
+  },
+  [201] = {
+    [anon_sym_verb] = ACTIONS(27),
+    [anon_sym_LBRACK] = ACTIONS(29),
+    [anon_sym_LPAREN] = ACTIONS(31),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [anon_sym_documentclass] = ACTIONS(37),
+    [anon_sym_usepackage] = ACTIONS(39),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [anon_sym_emph] = ACTIONS(49),
+    [anon_sym_footnote] = ACTIONS(51),
+    [anon_sym_textbf] = ACTIONS(53),
+    [anon_sym_textit] = ACTIONS(55),
+    [anon_sym_texttt] = ACTIONS(57),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(305),
+  },
+  [202] = {
+    [anon_sym_LBRACK] = ACTIONS(550),
+    [anon_sym_RBRACK] = ACTIONS(550),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(550),
+    [sym_begin_group] = ACTIONS(550),
+    [sym_end_group] = ACTIONS(550),
+    [sym_math_shift] = ACTIONS(550),
+    [sym_alignment_tab] = ACTIONS(550),
+    [sym_parameter_char] = ACTIONS(550),
+    [sym_superscript] = ACTIONS(550),
+    [sym_subscript] = ACTIONS(550),
+    [sym_active_char] = ACTIONS(550),
+    [sym_text] = ACTIONS(550),
+  },
+  [203] = {
+    [sym__common] = STATE(278),
+    [sym__text_mode_common] = STATE(278),
+    [sym_inline_verbatim] = STATE(278),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(278),
+    [sym_parameter] = STATE(278),
+    [sym_text_env_at] = STATE(278),
+    [sym__display_math_at] = STATE(278),
+    [sym_tex_display_math_at] = STATE(278),
+    [sym_latex_display_math_at] = STATE(278),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(278),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(278),
+    [sym_tex_inline_math_at] = STATE(278),
+    [sym_latex_inline_math_at] = STATE(278),
+    [sym_inline_math_env_at] = STATE(278),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(278),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(278),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(278),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(278),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(278),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(278),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(278),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(278),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(278),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(278),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(278),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(278),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(278),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(278),
+    [sym_opt_text_group_at] = STATE(278),
+    [sym_token_at] = STATE(278),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(278),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(552),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(554),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(554),
+    [sym_text] = ACTIONS(554),
+  },
+  [204] = {
+    [anon_sym_tag] = ACTIONS(201),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(305),
+  },
+  [205] = {
     [sym__common] = STATE(280),
     [sym__math_mode_common] = STATE(280),
     [sym__math_mode_at] = STATE(280),
     [sym_parameter] = STATE(280),
     [sym_math_env_at] = STATE(280),
     [sym_tag_at] = STATE(280),
-    [sym_tag_token] = STATE(184),
+    [sym_tag_token] = STATE(208),
     [sym_escaped] = STATE(280),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
     [sym_include_at] = STATE(280),
-    [sym_include_token] = STATE(105),
+    [sym_include_token] = STATE(110),
     [sym_storage] = STATE(280),
     [sym_storage_token] = STATE(21),
     [sym_catcode] = STATE(280),
@@ -10540,219 +9720,84 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_math_group_at] = STATE(280),
     [sym_opt_math_group_at] = STATE(280),
     [sym_token_at] = STATE(280),
-    [sym_begin_opt] = STATE(186),
+    [sym_begin_opt] = STATE(210),
     [aux_sym_math_mode_at_repeat1] = STATE(280),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_end_group] = ACTIONS(614),
-    [sym_alignment_tab] = ACTIONS(616),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_end_group] = ACTIONS(556),
+    [sym_alignment_tab] = ACTIONS(558),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(616),
-    [sym_subscript] = ACTIONS(616),
-    [sym_active_char] = ACTIONS(616),
-    [sym_text] = ACTIONS(616),
+    [sym_superscript] = ACTIONS(558),
+    [sym_subscript] = ACTIONS(558),
+    [sym_active_char] = ACTIONS(558),
+    [sym_text] = ACTIONS(558),
   },
-  [247] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(618),
-  },
-  [248] = {
-    [anon_sym_LBRACK] = ACTIONS(620),
-    [anon_sym_RBRACK] = ACTIONS(620),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(620),
-    [sym_begin_group] = ACTIONS(620),
-    [sym_end_group] = ACTIONS(620),
-    [sym_math_shift] = ACTIONS(620),
-    [sym_alignment_tab] = ACTIONS(620),
-    [sym_parameter_char] = ACTIONS(620),
-    [sym_superscript] = ACTIONS(620),
-    [sym_subscript] = ACTIONS(620),
-    [sym_active_char] = ACTIONS(620),
-    [sym_text] = ACTIONS(620),
-  },
-  [249] = {
-    [sym__common] = STATE(284),
-    [sym__text_mode_common] = STATE(284),
-    [sym_inline_verbatim] = STATE(284),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(284),
-    [sym_text_mode_at] = STATE(283),
-    [sym_parameter] = STATE(284),
-    [sym_text_env_at] = STATE(284),
-    [sym__display_math_at] = STATE(284),
-    [sym_tex_display_math_at] = STATE(284),
-    [sym_latex_display_math_at] = STATE(284),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(284),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(284),
-    [sym_tex_inline_math_at] = STATE(284),
-    [sym_latex_inline_math_at] = STATE(284),
-    [sym_inline_math_env_at] = STATE(284),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(284),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(284),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(284),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(284),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(284),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(284),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(284),
+  [206] = {
+    [sym__common] = STATE(211),
+    [sym__math_mode_common] = STATE(211),
+    [sym__math_mode_at] = STATE(211),
+    [sym_math_mode_at] = STATE(281),
+    [sym_parameter] = STATE(211),
+    [sym_math_env_at] = STATE(211),
+    [sym_tag_at] = STATE(211),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(211),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(211),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(211),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(284),
+    [sym_catcode] = STATE(211),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(284),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(284),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(284),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(284),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(284),
-    [sym_opt_text_group_at] = STATE(284),
-    [sym_token_at] = STATE(284),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(284),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group_at] = STATE(211),
+    [sym_opt_math_group_at] = STATE(211),
+    [sym_token_at] = STATE(211),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(211),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_end_group] = ACTIONS(622),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(624),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(319),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(624),
-    [sym_text] = ACTIONS(624),
+    [sym_superscript] = ACTIONS(319),
+    [sym_subscript] = ACTIONS(319),
+    [sym_active_char] = ACTIONS(319),
+    [sym_text] = ACTIONS(319),
   },
-  [250] = {
-    [anon_sym_LBRACK] = ACTIONS(626),
-    [anon_sym_RBRACK] = ACTIONS(626),
+  [207] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(626),
-    [sym_begin_group] = ACTIONS(626),
-    [sym_end_group] = ACTIONS(626),
-    [sym_math_shift] = ACTIONS(626),
-    [sym_alignment_tab] = ACTIONS(626),
-    [sym_parameter_char] = ACTIONS(626),
-    [sym_superscript] = ACTIONS(626),
-    [sym_subscript] = ACTIONS(626),
-    [sym_active_char] = ACTIONS(626),
-    [sym_text] = ACTIONS(626),
+    [sym_math_shift] = ACTIONS(560),
   },
-  [251] = {
-    [anon_sym_tag] = ACTIONS(165),
-    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
-    [anon_sym_begin] = ACTIONS(35),
-    [anon_sym_end] = ACTIONS(207),
-    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
-    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
-    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+  [208] = {
+    [sym_math_text_group_at] = STATE(284),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__name_at] = ACTIONS(255),
+    [sym_begin_group] = ACTIONS(562),
   },
-  [252] = {
-    [anon_sym_LBRACK] = ACTIONS(628),
-    [anon_sym_RBRACK] = ACTIONS(628),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(628),
-    [sym_begin_group] = ACTIONS(628),
-    [sym_end_group] = ACTIONS(628),
-    [sym_math_shift] = ACTIONS(628),
-    [sym_alignment_tab] = ACTIONS(628),
-    [sym_parameter_char] = ACTIONS(628),
-    [sym_superscript] = ACTIONS(628),
-    [sym_subscript] = ACTIONS(628),
-    [sym_active_char] = ACTIONS(628),
-    [sym_text] = ACTIONS(628),
-  },
-  [253] = {
-    [sym__common] = STATE(258),
-    [sym__math_mode_common] = STATE(258),
-    [sym__math_mode_at] = STATE(258),
-    [sym_parameter] = STATE(258),
-    [sym_math_env_at] = STATE(258),
-    [sym_tag_at] = STATE(258),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(258),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_end] = STATE(285),
-    [sym_end_token] = STATE(74),
-    [sym_include_at] = STATE(258),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(258),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(258),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(258),
-    [sym_opt_math_group_at] = STATE(258),
-    [sym_token_at] = STATE(258),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(258),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(480),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(494),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(494),
-    [sym_subscript] = ACTIONS(494),
-    [sym_active_char] = ACTIONS(494),
-    [sym_text] = ACTIONS(494),
-  },
-  [254] = {
-    [anon_sym_LBRACK] = ACTIONS(630),
-    [anon_sym_RBRACK] = ACTIONS(630),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(630),
-    [sym_begin_group] = ACTIONS(630),
-    [sym_end_group] = ACTIONS(630),
-    [sym_math_shift] = ACTIONS(630),
-    [sym_alignment_tab] = ACTIONS(630),
-    [sym_parameter_char] = ACTIONS(630),
-    [sym_superscript] = ACTIONS(630),
-    [sym_subscript] = ACTIONS(630),
-    [sym_active_char] = ACTIONS(630),
-    [sym_text] = ACTIONS(630),
-  },
-  [255] = {
+  [209] = {
     [sym__common] = STATE(287),
     [sym__math_mode_common] = STATE(287),
     [sym__math_mode_at] = STATE(287),
     [sym_parameter] = STATE(287),
     [sym_math_env_at] = STATE(287),
     [sym_tag_at] = STATE(287),
-    [sym_tag_token] = STATE(184),
+    [sym_tag_token] = STATE(208),
     [sym_escaped] = STATE(287),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_end] = STATE(286),
+    [sym_end_token] = STATE(76),
     [sym_include_at] = STATE(287),
-    [sym_include_token] = STATE(105),
+    [sym_include_token] = STATE(110),
     [sym_storage] = STATE(287),
     [sym_storage_token] = STATE(21),
     [sym_catcode] = STATE(287),
@@ -10760,60 +9805,894 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_math_group_at] = STATE(287),
     [sym_opt_math_group_at] = STATE(287),
     [sym_token_at] = STATE(287),
-    [sym_begin_opt] = STATE(186),
-    [sym_end_opt] = STATE(286),
+    [sym_begin_opt] = STATE(210),
     [aux_sym_math_mode_at_repeat1] = STATE(287),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(111),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(263),
-    [sym_begin_group] = ACTIONS(265),
-    [sym_alignment_tab] = ACTIONS(632),
+    [sym__escape] = ACTIONS(564),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(566),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(632),
-    [sym_subscript] = ACTIONS(632),
-    [sym_active_char] = ACTIONS(632),
-    [sym_text] = ACTIONS(632),
+    [sym_superscript] = ACTIONS(566),
+    [sym_subscript] = ACTIONS(566),
+    [sym_active_char] = ACTIONS(566),
+    [sym_text] = ACTIONS(566),
   },
-  [256] = {
-    [sym__common] = STATE(256),
-    [sym__math_mode_common] = STATE(256),
-    [sym__math_mode_at] = STATE(256),
-    [sym_parameter] = STATE(256),
-    [sym_math_env_at] = STATE(256),
-    [sym_tag_at] = STATE(256),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(256),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(256),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(256),
+  [210] = {
+    [sym__common] = STATE(289),
+    [sym__math_mode_common] = STATE(289),
+    [sym__math_mode_at] = STATE(289),
+    [sym_parameter] = STATE(289),
+    [sym_math_env_at] = STATE(289),
+    [sym_tag_at] = STATE(289),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(289),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(289),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(289),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(256),
+    [sym_catcode] = STATE(289),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(256),
-    [sym_opt_math_group_at] = STATE(256),
-    [sym_token_at] = STATE(256),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(256),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(634),
+    [sym_math_group_at] = STATE(289),
+    [sym_opt_math_group_at] = STATE(289),
+    [sym_token_at] = STATE(289),
+    [sym_begin_opt] = STATE(210),
+    [sym_end_opt] = STATE(288),
+    [aux_sym_math_mode_at_repeat1] = STATE(289),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(637),
-    [sym_begin_group] = ACTIONS(640),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(568),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(568),
+    [sym_subscript] = ACTIONS(568),
+    [sym_active_char] = ACTIONS(568),
+    [sym_text] = ACTIONS(568),
+  },
+  [211] = {
+    [sym__common] = STATE(290),
+    [sym__math_mode_common] = STATE(290),
+    [sym__math_mode_at] = STATE(290),
+    [sym_parameter] = STATE(290),
+    [sym_math_env_at] = STATE(290),
+    [sym_tag_at] = STATE(290),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(290),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(290),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(290),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(290),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(290),
+    [sym_opt_math_group_at] = STATE(290),
+    [sym_token_at] = STATE(290),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(290),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_math_shift] = ACTIONS(570),
+    [sym_alignment_tab] = ACTIONS(572),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(572),
+    [sym_subscript] = ACTIONS(572),
+    [sym_active_char] = ACTIONS(572),
+    [sym_text] = ACTIONS(572),
+  },
+  [212] = {
+    [anon_sym_makeatother] = ACTIONS(574),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+  },
+  [213] = {
+    [ts_builtin_sym_end] = ACTIONS(576),
+    [anon_sym_LBRACK] = ACTIONS(576),
+    [anon_sym_RBRACK] = ACTIONS(576),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(576),
+    [sym_begin_group] = ACTIONS(576),
+    [sym_end_group] = ACTIONS(576),
+    [sym_math_shift] = ACTIONS(576),
+    [sym_alignment_tab] = ACTIONS(576),
+    [sym_parameter_char] = ACTIONS(576),
+    [sym_superscript] = ACTIONS(576),
+    [sym_subscript] = ACTIONS(576),
+    [sym_active_char] = ACTIONS(576),
+    [sym_text] = ACTIONS(576),
+  },
+  [214] = {
+    [sym_end_display_math] = STATE(291),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(223),
+  },
+  [215] = {
+    [sym__common] = STATE(292),
+    [sym__math_mode_common] = STATE(292),
+    [sym__math_mode_at] = STATE(292),
+    [sym_parameter] = STATE(292),
+    [sym_math_env_at] = STATE(292),
+    [sym_tag_at] = STATE(292),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(292),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(292),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(292),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(292),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(292),
+    [sym_opt_math_group_at] = STATE(292),
+    [sym_token_at] = STATE(292),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(292),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(570),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(578),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(578),
+    [sym_subscript] = ACTIONS(578),
+    [sym_active_char] = ACTIONS(578),
+    [sym_text] = ACTIONS(578),
+  },
+  [216] = {
+    [sym_end_inline_math] = STATE(293),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(227),
+  },
+  [217] = {
+    [sym_display_math_end] = STATE(294),
+    [sym_end_token] = STATE(162),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(87),
+  },
+  [218] = {
+    [sym_inline_math_end] = STATE(295),
+    [sym_end_token] = STATE(164),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(87),
+  },
+  [219] = {
+    [anon_sym_verb] = ACTIONS(27),
+    [anon_sym_LBRACK] = ACTIONS(29),
+    [anon_sym_LPAREN] = ACTIONS(31),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [anon_sym_end] = ACTIONS(243),
+    [anon_sym_documentclass] = ACTIONS(37),
+    [anon_sym_usepackage] = ACTIONS(39),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASHsection_PIPEsubsection_PIPEsubsubsection_PIPEparagraph_PIPEsubparagraph_PIPEchapter_PIPEpart_PIPEaddpart_PIPEaddchap_PIPEaddsec_PIPEminisec_SLASH] = ACTIONS(43),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [anon_sym_emph] = ACTIONS(49),
+    [anon_sym_footnote] = ACTIONS(51),
+    [anon_sym_textbf] = ACTIONS(53),
+    [anon_sym_textit] = ACTIONS(55),
+    [anon_sym_texttt] = ACTIONS(57),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(305),
+  },
+  [220] = {
+    [anon_sym_LBRACK] = ACTIONS(580),
+    [anon_sym_RBRACK] = ACTIONS(580),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(580),
+    [sym_begin_group] = ACTIONS(580),
+    [sym_end_group] = ACTIONS(580),
+    [sym_math_shift] = ACTIONS(580),
+    [sym_alignment_tab] = ACTIONS(580),
+    [sym_parameter_char] = ACTIONS(580),
+    [sym_superscript] = ACTIONS(580),
+    [sym_subscript] = ACTIONS(580),
+    [sym_active_char] = ACTIONS(580),
+    [sym_text] = ACTIONS(580),
+  },
+  [221] = {
+    [sym__common] = STATE(235),
+    [sym__text_mode_common] = STATE(235),
+    [sym_inline_verbatim] = STATE(235),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(235),
+    [sym_parameter] = STATE(235),
+    [sym_text_env_at] = STATE(235),
+    [sym__display_math_at] = STATE(235),
+    [sym_tex_display_math_at] = STATE(235),
+    [sym_latex_display_math_at] = STATE(235),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(235),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(235),
+    [sym_tex_inline_math_at] = STATE(235),
+    [sym_latex_inline_math_at] = STATE(235),
+    [sym_inline_math_env_at] = STATE(235),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(235),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(235),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_end] = STATE(296),
+    [sym_end_token] = STATE(76),
+    [sym_documentclass] = STATE(235),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(235),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(235),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(235),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(235),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(235),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(235),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(235),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(235),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(235),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(235),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(235),
+    [sym_opt_text_group_at] = STATE(235),
+    [sym_token_at] = STATE(235),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(235),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(325),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(337),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(337),
+    [sym_text] = ACTIONS(337),
+  },
+  [222] = {
+    [sym_text_group_at] = STATE(299),
+    [sym_opt_text_group_at] = STATE(300),
+    [sym_begin_opt] = STATE(226),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(582),
+    [sym__end_of_line] = ACTIONS(584),
+  },
+  [223] = {
+    [anon_sym_LBRACK] = ACTIONS(586),
+    [anon_sym_RBRACK] = ACTIONS(586),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(586),
+    [sym_begin_group] = ACTIONS(586),
+    [sym_end_group] = ACTIONS(586),
+    [sym_math_shift] = ACTIONS(586),
+    [sym_alignment_tab] = ACTIONS(586),
+    [sym_parameter_char] = ACTIONS(586),
+    [sym_superscript] = ACTIONS(586),
+    [sym_subscript] = ACTIONS(586),
+    [sym_active_char] = ACTIONS(586),
+    [sym_text] = ACTIONS(586),
+  },
+  [224] = {
+    [anon_sym_LBRACK] = ACTIONS(588),
+    [anon_sym_RBRACK] = ACTIONS(588),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(588),
+    [sym_begin_group] = ACTIONS(588),
+    [sym_end_group] = ACTIONS(588),
+    [sym_math_shift] = ACTIONS(588),
+    [sym_alignment_tab] = ACTIONS(588),
+    [sym_parameter_char] = ACTIONS(588),
+    [sym_superscript] = ACTIONS(588),
+    [sym_subscript] = ACTIONS(588),
+    [sym_active_char] = ACTIONS(588),
+    [sym_text] = ACTIONS(588),
+  },
+  [225] = {
+    [sym_text_group_at] = STATE(302),
+    [sym__whitespace] = ACTIONS(590),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [226] = {
+    [sym__common] = STATE(304),
+    [sym__text_mode_common] = STATE(304),
+    [sym_inline_verbatim] = STATE(304),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(304),
+    [sym_parameter] = STATE(304),
+    [sym_text_env_at] = STATE(304),
+    [sym__display_math_at] = STATE(304),
+    [sym_tex_display_math_at] = STATE(304),
+    [sym_latex_display_math_at] = STATE(304),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(304),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(304),
+    [sym_tex_inline_math_at] = STATE(304),
+    [sym_latex_inline_math_at] = STATE(304),
+    [sym_inline_math_env_at] = STATE(304),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(304),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(304),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(304),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(304),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(304),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(304),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(304),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(304),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(304),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(304),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(304),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(304),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(304),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(304),
+    [sym_opt_text_group_at] = STATE(304),
+    [sym_token_at] = STATE(304),
+    [sym_begin_opt] = STATE(119),
+    [sym_end_opt] = STATE(303),
+    [aux_sym_text_mode_at_repeat1] = STATE(304),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(273),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(592),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(592),
+    [sym_text] = ACTIONS(592),
+  },
+  [227] = {
+    [anon_sym_LBRACK] = ACTIONS(594),
+    [anon_sym_RBRACK] = ACTIONS(594),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(594),
+    [sym_begin_group] = ACTIONS(594),
+    [sym_end_group] = ACTIONS(594),
+    [sym_math_shift] = ACTIONS(594),
+    [sym_alignment_tab] = ACTIONS(594),
+    [sym_parameter_char] = ACTIONS(594),
+    [sym_superscript] = ACTIONS(594),
+    [sym_subscript] = ACTIONS(594),
+    [sym_active_char] = ACTIONS(594),
+    [sym_text] = ACTIONS(594),
+  },
+  [228] = {
+    [anon_sym_LBRACK] = ACTIONS(596),
+    [anon_sym_RBRACK] = ACTIONS(596),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(596),
+    [sym_begin_group] = ACTIONS(596),
+    [sym_end_group] = ACTIONS(596),
+    [sym_math_shift] = ACTIONS(596),
+    [sym_alignment_tab] = ACTIONS(596),
+    [sym_parameter_char] = ACTIONS(596),
+    [sym_superscript] = ACTIONS(596),
+    [sym_subscript] = ACTIONS(596),
+    [sym_active_char] = ACTIONS(596),
+    [sym_text] = ACTIONS(596),
+  },
+  [229] = {
+    [sym_text_group_at] = STATE(306),
+    [sym__whitespace] = ACTIONS(598),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [230] = {
+    [anon_sym_LBRACK] = ACTIONS(600),
+    [anon_sym_RBRACK] = ACTIONS(600),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(600),
+    [sym_begin_group] = ACTIONS(600),
+    [sym_end_group] = ACTIONS(600),
+    [sym_math_shift] = ACTIONS(600),
+    [sym_alignment_tab] = ACTIONS(600),
+    [sym_parameter_char] = ACTIONS(600),
+    [sym_superscript] = ACTIONS(600),
+    [sym_subscript] = ACTIONS(600),
+    [sym_active_char] = ACTIONS(600),
+    [sym_text] = ACTIONS(600),
+  },
+  [231] = {
+    [anon_sym_LBRACK] = ACTIONS(602),
+    [anon_sym_RBRACK] = ACTIONS(602),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(602),
+    [sym_begin_group] = ACTIONS(602),
+    [sym_end_group] = ACTIONS(602),
+    [sym_math_shift] = ACTIONS(602),
+    [sym_alignment_tab] = ACTIONS(602),
+    [sym_parameter_char] = ACTIONS(602),
+    [sym_superscript] = ACTIONS(602),
+    [sym_subscript] = ACTIONS(602),
+    [sym_active_char] = ACTIONS(602),
+    [sym_text] = ACTIONS(602),
+  },
+  [232] = {
+    [anon_sym_LBRACK] = ACTIONS(604),
+    [anon_sym_RBRACK] = ACTIONS(604),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(604),
+    [sym_begin_group] = ACTIONS(604),
+    [sym_end_group] = ACTIONS(604),
+    [sym_math_shift] = ACTIONS(604),
+    [sym_alignment_tab] = ACTIONS(604),
+    [sym_parameter_char] = ACTIONS(604),
+    [sym_superscript] = ACTIONS(604),
+    [sym_subscript] = ACTIONS(604),
+    [sym_active_char] = ACTIONS(604),
+    [sym_text] = ACTIONS(604),
+  },
+  [233] = {
+    [anon_sym_LBRACK] = ACTIONS(606),
+    [anon_sym_RBRACK] = ACTIONS(606),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(606),
+    [sym_begin_group] = ACTIONS(606),
+    [sym_end_group] = ACTIONS(606),
+    [sym_math_shift] = ACTIONS(606),
+    [sym_alignment_tab] = ACTIONS(606),
+    [sym_parameter_char] = ACTIONS(606),
+    [sym_superscript] = ACTIONS(606),
+    [sym_subscript] = ACTIONS(606),
+    [sym_active_char] = ACTIONS(606),
+    [sym_text] = ACTIONS(606),
+  },
+  [234] = {
+    [sym__common] = STATE(308),
+    [sym__text_mode_common] = STATE(308),
+    [sym_inline_verbatim] = STATE(308),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(308),
+    [sym_parameter] = STATE(308),
+    [sym_text_env_at] = STATE(308),
+    [sym__display_math_at] = STATE(308),
+    [sym_tex_display_math_at] = STATE(308),
+    [sym_latex_display_math_at] = STATE(308),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(308),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(308),
+    [sym_tex_inline_math_at] = STATE(308),
+    [sym_latex_inline_math_at] = STATE(308),
+    [sym_inline_math_env_at] = STATE(308),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(308),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(308),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(308),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(308),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(308),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(308),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(308),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(308),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(308),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(308),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(308),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(308),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(308),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(308),
+    [sym_opt_text_group_at] = STATE(308),
+    [sym_token_at] = STATE(308),
+    [sym_begin_opt] = STATE(119),
+    [sym_end_opt] = STATE(307),
+    [aux_sym_text_mode_at_repeat1] = STATE(308),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(608),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(608),
+    [sym_text] = ACTIONS(608),
+  },
+  [235] = {
+    [sym__common] = STATE(235),
+    [sym__text_mode_common] = STATE(235),
+    [sym_inline_verbatim] = STATE(235),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(235),
+    [sym_parameter] = STATE(235),
+    [sym_text_env_at] = STATE(235),
+    [sym__display_math_at] = STATE(235),
+    [sym_tex_display_math_at] = STATE(235),
+    [sym_latex_display_math_at] = STATE(235),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(235),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(235),
+    [sym_tex_inline_math_at] = STATE(235),
+    [sym_latex_inline_math_at] = STATE(235),
+    [sym_inline_math_env_at] = STATE(235),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(235),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(235),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(235),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(235),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(235),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(235),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(235),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(235),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(235),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(235),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(235),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(235),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(235),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(235),
+    [sym_opt_text_group_at] = STATE(235),
+    [sym_token_at] = STATE(235),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(235),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(610),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(613),
+    [sym_begin_group] = ACTIONS(616),
+    [sym_math_shift] = ACTIONS(619),
+    [sym_alignment_tab] = ACTIONS(622),
+    [sym_parameter_char] = ACTIONS(625),
+    [sym_superscript] = ACTIONS(628),
+    [sym_subscript] = ACTIONS(628),
+    [sym_active_char] = ACTIONS(622),
+    [sym_text] = ACTIONS(622),
+  },
+  [236] = {
+    [ts_builtin_sym_end] = ACTIONS(631),
+    [anon_sym_LBRACK] = ACTIONS(631),
+    [anon_sym_RBRACK] = ACTIONS(631),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(631),
+    [sym_begin_group] = ACTIONS(631),
+    [sym_end_group] = ACTIONS(631),
+    [sym_math_shift] = ACTIONS(631),
+    [sym_alignment_tab] = ACTIONS(631),
+    [sym_parameter_char] = ACTIONS(631),
+    [sym_superscript] = ACTIONS(631),
+    [sym_subscript] = ACTIONS(631),
+    [sym_active_char] = ACTIONS(631),
+    [sym_text] = ACTIONS(631),
+  },
+  [237] = {
+    [sym__common] = STATE(237),
+    [sym__text_mode_common] = STATE(237),
+    [sym_inline_verbatim] = STATE(237),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(237),
+    [sym_text_mode_at_region] = STATE(237),
+    [sym_parameter] = STATE(237),
+    [sym_text_env] = STATE(237),
+    [sym__display_math] = STATE(237),
+    [sym_tex_display_math] = STATE(237),
+    [sym_latex_display_math] = STATE(237),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(237),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(237),
+    [sym_tex_inline_math] = STATE(237),
+    [sym_latex_inline_math] = STATE(237),
+    [sym_inline_math_env] = STATE(237),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(237),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(237),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(237),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(237),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(237),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(237),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(237),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(237),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(237),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(237),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(237),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(237),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(237),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(237),
+    [sym_opt_text_group] = STATE(237),
+    [sym_token] = STATE(237),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(237),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(347),
+    [anon_sym_RBRACK] = ACTIONS(345),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(350),
+    [sym_begin_group] = ACTIONS(353),
+    [sym_math_shift] = ACTIONS(356),
+    [sym_alignment_tab] = ACTIONS(633),
+    [sym_parameter_char] = ACTIONS(362),
+    [sym_superscript] = ACTIONS(365),
+    [sym_subscript] = ACTIONS(365),
+    [sym_active_char] = ACTIONS(633),
+    [sym_text] = ACTIONS(633),
+  },
+  [238] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(636),
+  },
+  [239] = {
+    [anon_sym_LBRACK] = ACTIONS(638),
+    [anon_sym_RBRACK] = ACTIONS(638),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(638),
+    [sym_begin_group] = ACTIONS(638),
+    [sym_end_group] = ACTIONS(638),
+    [sym_math_shift] = ACTIONS(638),
+    [sym_alignment_tab] = ACTIONS(638),
+    [sym_parameter_char] = ACTIONS(638),
+    [sym_superscript] = ACTIONS(638),
+    [sym_subscript] = ACTIONS(638),
+    [sym_active_char] = ACTIONS(638),
+    [sym_text] = ACTIONS(638),
+  },
+  [240] = {
+    [sym__common] = STATE(240),
+    [sym__math_mode_common] = STATE(240),
+    [sym__math_mode] = STATE(240),
+    [sym_parameter] = STATE(240),
+    [sym_math_env] = STATE(240),
+    [sym_tag] = STATE(240),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(240),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(240),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(240),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(240),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group] = STATE(240),
+    [sym_opt_math_group] = STATE(240),
+    [sym_token] = STATE(240),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(240),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(432),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(435),
+    [sym_begin_group] = ACTIONS(438),
+    [sym_end_group] = ACTIONS(441),
+    [sym_alignment_tab] = ACTIONS(640),
+    [sym_parameter_char] = ACTIONS(446),
+    [sym_superscript] = ACTIONS(640),
+    [sym_subscript] = ACTIONS(640),
+    [sym_active_char] = ACTIONS(640),
+    [sym_text] = ACTIONS(640),
+  },
+  [241] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
     [sym_math_shift] = ACTIONS(643),
+  },
+  [242] = {
+    [anon_sym_LBRACK] = ACTIONS(645),
+    [anon_sym_RBRACK] = ACTIONS(645),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(645),
+    [sym_begin_group] = ACTIONS(645),
+    [sym_end_group] = ACTIONS(645),
+    [sym_math_shift] = ACTIONS(645),
     [sym_alignment_tab] = ACTIONS(645),
-    [sym_parameter_char] = ACTIONS(648),
+    [sym_parameter_char] = ACTIONS(645),
     [sym_superscript] = ACTIONS(645),
     [sym_subscript] = ACTIONS(645),
     [sym_active_char] = ACTIONS(645),
     [sym_text] = ACTIONS(645),
   },
-  [257] = {
+  [243] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(647),
+  },
+  [244] = {
+    [sym__common] = STATE(141),
+    [sym__text_mode_common] = STATE(141),
+    [sym_inline_verbatim] = STATE(141),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode] = STATE(141),
+    [sym_text_mode_at_region] = STATE(141),
+    [sym_parameter] = STATE(141),
+    [sym_text_env] = STATE(141),
+    [sym__display_math] = STATE(141),
+    [sym_tex_display_math] = STATE(141),
+    [sym_latex_display_math] = STATE(141),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(141),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(141),
+    [sym_tex_inline_math] = STATE(141),
+    [sym_latex_inline_math] = STATE(141),
+    [sym_inline_math_env] = STATE(141),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(141),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(141),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(141),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(141),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include] = STATE(141),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(141),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(141),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(141),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph] = STATE(141),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(141),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(141),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(141),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(141),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(141),
+    [sym_opt_text_group] = STATE(141),
+    [sym_token] = STATE(141),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(141),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(117),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(199),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(199),
+    [sym_text] = ACTIONS(199),
+  },
+  [245] = {
+    [anon_sym_LBRACK] = ACTIONS(649),
+    [anon_sym_RBRACK] = ACTIONS(649),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(649),
+    [sym_begin_group] = ACTIONS(649),
+    [sym_end_group] = ACTIONS(649),
+    [sym_math_shift] = ACTIONS(649),
+    [sym_alignment_tab] = ACTIONS(649),
+    [sym_parameter_char] = ACTIONS(649),
+    [sym_superscript] = ACTIONS(649),
+    [sym_subscript] = ACTIONS(649),
+    [sym_active_char] = ACTIONS(649),
+    [sym_text] = ACTIONS(649),
+  },
+  [246] = {
     [anon_sym_LBRACK] = ACTIONS(651),
     [anon_sym_RBRACK] = ACTIONS(651),
     [sym_magic_comment] = ACTIONS(9),
@@ -10829,42 +10708,44 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(651),
     [sym_text] = ACTIONS(651),
   },
-  [258] = {
-    [sym__common] = STATE(258),
-    [sym__math_mode_common] = STATE(258),
-    [sym__math_mode_at] = STATE(258),
-    [sym_parameter] = STATE(258),
-    [sym_math_env_at] = STATE(258),
-    [sym_tag_at] = STATE(258),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(258),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(258),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(258),
+  [247] = {
+    [sym__common] = STATE(247),
+    [sym__math_mode_common] = STATE(247),
+    [sym__math_mode] = STATE(247),
+    [sym_parameter] = STATE(247),
+    [sym_math_env] = STATE(247),
+    [sym_tag] = STATE(247),
+    [sym_tag_token] = STATE(57),
+    [sym_escaped] = STATE(247),
+    [sym_begin] = STATE(58),
+    [sym_begin_token] = STATE(59),
+    [sym_include] = STATE(247),
+    [sym_include_token] = STATE(19),
+    [sym_storage] = STATE(247),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(258),
+    [sym_catcode] = STATE(247),
     [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(258),
-    [sym_opt_math_group_at] = STATE(258),
-    [sym_token_at] = STATE(258),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(258),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(634),
+    [sym_math_group] = STATE(247),
+    [sym_opt_math_group] = STATE(247),
+    [sym_token] = STATE(247),
+    [sym_begin_opt] = STATE(60),
+    [aux_sym_math_mode_repeat1] = STATE(247),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(432),
+    [anon_sym_RBRACK] = ACTIONS(441),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(637),
-    [sym_begin_group] = ACTIONS(640),
+    [sym__escape] = ACTIONS(435),
+    [sym_begin_group] = ACTIONS(438),
     [sym_alignment_tab] = ACTIONS(653),
-    [sym_parameter_char] = ACTIONS(648),
+    [sym_parameter_char] = ACTIONS(446),
     [sym_superscript] = ACTIONS(653),
     [sym_subscript] = ACTIONS(653),
     [sym_active_char] = ACTIONS(653),
     [sym_text] = ACTIONS(653),
   },
-  [259] = {
+  [248] = {
+    [ts_builtin_sym_end] = ACTIONS(656),
     [anon_sym_LBRACK] = ACTIONS(656),
     [anon_sym_RBRACK] = ACTIONS(656),
     [sym_magic_comment] = ACTIONS(9),
@@ -10880,7 +10761,9 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(656),
     [sym_text] = ACTIONS(656),
   },
-  [260] = {
+  [249] = {
+    [ts_builtin_sym_end] = ACTIONS(658),
+    [sym__whitespace] = ACTIONS(660),
     [anon_sym_LBRACK] = ACTIONS(658),
     [anon_sym_RBRACK] = ACTIONS(658),
     [sym_magic_comment] = ACTIONS(9),
@@ -10894,213 +10777,55 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_superscript] = ACTIONS(658),
     [sym_subscript] = ACTIONS(658),
     [sym_active_char] = ACTIONS(658),
-    [sym_text] = ACTIONS(658),
-  },
-  [261] = {
-    [anon_sym_LBRACK] = ACTIONS(660),
-    [anon_sym_RBRACK] = ACTIONS(660),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(660),
-    [sym_begin_group] = ACTIONS(660),
-    [sym_end_group] = ACTIONS(660),
-    [sym_math_shift] = ACTIONS(660),
-    [sym_alignment_tab] = ACTIONS(660),
-    [sym_parameter_char] = ACTIONS(660),
-    [sym_superscript] = ACTIONS(660),
-    [sym_subscript] = ACTIONS(660),
-    [sym_active_char] = ACTIONS(660),
-    [sym_text] = ACTIONS(660),
-  },
-  [262] = {
-    [anon_sym_LBRACK] = ACTIONS(662),
-    [anon_sym_RBRACK] = ACTIONS(662),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(662),
-    [sym_begin_group] = ACTIONS(662),
-    [sym_end_group] = ACTIONS(662),
-    [sym_math_shift] = ACTIONS(662),
-    [sym_alignment_tab] = ACTIONS(662),
-    [sym_parameter_char] = ACTIONS(662),
-    [sym_superscript] = ACTIONS(662),
-    [sym_subscript] = ACTIONS(662),
-    [sym_active_char] = ACTIONS(662),
     [sym_text] = ACTIONS(662),
   },
-  [263] = {
-    [sym__common] = STATE(289),
-    [sym__text_mode_common] = STATE(289),
-    [sym_inline_verbatim] = STATE(289),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(289),
-    [sym_parameter] = STATE(289),
-    [sym_text_env_at] = STATE(289),
-    [sym__display_math_at] = STATE(289),
-    [sym_tex_display_math_at] = STATE(289),
-    [sym_latex_display_math_at] = STATE(289),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(289),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(289),
-    [sym_tex_inline_math_at] = STATE(289),
-    [sym_latex_inline_math_at] = STATE(289),
-    [sym_inline_math_env_at] = STATE(289),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(289),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(289),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(289),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(289),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(289),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(289),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(289),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(289),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(289),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(289),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(289),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(289),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(289),
-    [sym_opt_text_group_at] = STATE(289),
-    [sym_token_at] = STATE(289),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(289),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
+  [250] = {
+    [ts_builtin_sym_end] = ACTIONS(664),
+    [sym__whitespace] = ACTIONS(666),
+    [anon_sym_LBRACK] = ACTIONS(664),
+    [anon_sym_RBRACK] = ACTIONS(664),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
+    [sym__escape] = ACTIONS(664),
+    [sym_begin_group] = ACTIONS(664),
     [sym_end_group] = ACTIONS(664),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(666),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(666),
-    [sym_text] = ACTIONS(666),
-  },
-  [264] = {
-    [anon_sym_LBRACK] = ACTIONS(668),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(668),
-    [sym_begin_group] = ACTIONS(668),
-    [sym_alignment_tab] = ACTIONS(668),
-    [sym_parameter_char] = ACTIONS(668),
-    [sym_superscript] = ACTIONS(668),
-    [sym_subscript] = ACTIONS(668),
-    [sym_active_char] = ACTIONS(668),
+    [sym_math_shift] = ACTIONS(664),
+    [sym_alignment_tab] = ACTIONS(664),
+    [sym_parameter_char] = ACTIONS(664),
+    [sym_superscript] = ACTIONS(664),
+    [sym_subscript] = ACTIONS(664),
+    [sym_active_char] = ACTIONS(664),
     [sym_text] = ACTIONS(668),
   },
-  [265] = {
+  [251] = {
+    [sym_display_math_env_name] = ACTIONS(670),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(670),
   },
-  [266] = {
-    [sym_text_group_at] = STATE(291),
+  [252] = {
+    [ts_builtin_sym_end] = ACTIONS(672),
+    [anon_sym_LBRACK] = ACTIONS(672),
+    [anon_sym_RBRACK] = ACTIONS(672),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(498),
-    [sym__end_of_line] = ACTIONS(670),
-  },
-  [267] = {
-    [sym__common] = STATE(293),
-    [sym__text_mode_common] = STATE(293),
-    [sym_inline_verbatim] = STATE(293),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(293),
-    [sym_parameter] = STATE(293),
-    [sym_text_env_at] = STATE(293),
-    [sym__display_math_at] = STATE(293),
-    [sym_tex_display_math_at] = STATE(293),
-    [sym_latex_display_math_at] = STATE(293),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(293),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(293),
-    [sym_tex_inline_math_at] = STATE(293),
-    [sym_latex_inline_math_at] = STATE(293),
-    [sym_inline_math_env_at] = STATE(293),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(293),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(293),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(293),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(293),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(293),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(293),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(293),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(293),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(293),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(293),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(293),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(293),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(293),
-    [sym_opt_text_group_at] = STATE(293),
-    [sym_token_at] = STATE(293),
-    [sym_begin_opt] = STATE(113),
-    [sym_end_opt] = STATE(292),
-    [aux_sym_text_mode_at_repeat1] = STATE(293),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(444),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
+    [sym__escape] = ACTIONS(672),
+    [sym_begin_group] = ACTIONS(672),
+    [sym_end_group] = ACTIONS(672),
+    [sym_math_shift] = ACTIONS(672),
     [sym_alignment_tab] = ACTIONS(672),
-    [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
+    [sym_parameter_char] = ACTIONS(672),
+    [sym_superscript] = ACTIONS(672),
+    [sym_subscript] = ACTIONS(672),
     [sym_active_char] = ACTIONS(672),
     [sym_text] = ACTIONS(672),
   },
-  [268] = {
-    [anon_sym_LBRACK] = ACTIONS(674),
-    [anon_sym_RBRACK] = ACTIONS(674),
+  [253] = {
+    [sym_inline_math_env_name] = ACTIONS(674),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(674),
-    [sym_begin_group] = ACTIONS(674),
-    [sym_end_group] = ACTIONS(674),
-    [sym_math_shift] = ACTIONS(674),
-    [sym_alignment_tab] = ACTIONS(674),
-    [sym_parameter_char] = ACTIONS(674),
-    [sym_superscript] = ACTIONS(674),
-    [sym_subscript] = ACTIONS(674),
-    [sym_active_char] = ACTIONS(674),
-    [sym_text] = ACTIONS(674),
   },
-  [269] = {
+  [254] = {
+    [ts_builtin_sym_end] = ACTIONS(676),
     [anon_sym_LBRACK] = ACTIONS(676),
     [anon_sym_RBRACK] = ACTIONS(676),
     [sym_magic_comment] = ACTIONS(9),
@@ -11116,301 +10841,209 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(676),
     [sym_text] = ACTIONS(676),
   },
-  [270] = {
-    [sym__common] = STATE(270),
-    [sym__text_mode_common] = STATE(270),
-    [sym_inline_verbatim] = STATE(270),
+  [255] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(678),
+  },
+  [256] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(680),
+  },
+  [257] = {
+    [anon_sym_LBRACK] = ACTIONS(682),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(682),
+    [sym__end_of_line] = ACTIONS(682),
+  },
+  [258] = {
+    [ts_builtin_sym_end] = ACTIONS(684),
+    [anon_sym_LBRACK] = ACTIONS(684),
+    [anon_sym_RBRACK] = ACTIONS(684),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(684),
+    [sym_begin_group] = ACTIONS(684),
+    [sym_end_group] = ACTIONS(684),
+    [sym_math_shift] = ACTIONS(684),
+    [sym_alignment_tab] = ACTIONS(684),
+    [sym_parameter_char] = ACTIONS(684),
+    [sym_superscript] = ACTIONS(684),
+    [sym_subscript] = ACTIONS(684),
+    [sym_active_char] = ACTIONS(684),
+    [sym_text] = ACTIONS(684),
+  },
+  [259] = {
+    [anon_sym_LBRACK] = ACTIONS(686),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(686),
+    [sym__end_of_line] = ACTIONS(686),
+  },
+  [260] = {
+    [ts_builtin_sym_end] = ACTIONS(688),
+    [anon_sym_LBRACK] = ACTIONS(688),
+    [anon_sym_RBRACK] = ACTIONS(688),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(688),
+    [sym_begin_group] = ACTIONS(688),
+    [sym_end_group] = ACTIONS(688),
+    [sym_math_shift] = ACTIONS(688),
+    [sym_alignment_tab] = ACTIONS(688),
+    [sym_parameter_char] = ACTIONS(688),
+    [sym_superscript] = ACTIONS(688),
+    [sym_subscript] = ACTIONS(688),
+    [sym_active_char] = ACTIONS(688),
+    [sym_text] = ACTIONS(688),
+  },
+  [261] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(195),
+  },
+  [262] = {
+    [sym__common] = STATE(141),
+    [sym__text_mode_common] = STATE(141),
+    [sym_inline_verbatim] = STATE(141),
     [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(270),
-    [sym_parameter] = STATE(270),
-    [sym_text_env_at] = STATE(270),
-    [sym__display_math_at] = STATE(270),
-    [sym_tex_display_math_at] = STATE(270),
-    [sym_latex_display_math_at] = STATE(270),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(270),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(270),
-    [sym_tex_inline_math_at] = STATE(270),
-    [sym_latex_inline_math_at] = STATE(270),
-    [sym_inline_math_env_at] = STATE(270),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(270),
+    [sym__text_mode] = STATE(141),
+    [sym_text_mode_at_region] = STATE(141),
+    [sym_parameter] = STATE(141),
+    [sym_text_env] = STATE(141),
+    [sym__display_math] = STATE(141),
+    [sym_tex_display_math] = STATE(141),
+    [sym_latex_display_math] = STATE(141),
+    [sym_begin_display_math] = STATE(10),
+    [sym_begin_inline_math] = STATE(11),
+    [sym_display_math_env] = STATE(141),
+    [sym_display_math_begin] = STATE(12),
+    [sym__inline_math] = STATE(141),
+    [sym_tex_inline_math] = STATE(141),
+    [sym_latex_inline_math] = STATE(141),
+    [sym_inline_math_env] = STATE(141),
+    [sym_inline_math_begin] = STATE(13),
+    [sym_verbatim_env] = STATE(141),
     [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(270),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(270),
+    [sym_escaped] = STATE(141),
+    [sym_begin] = STATE(15),
+    [sym_begin_token] = STATE(16),
+    [sym_documentclass] = STATE(141),
     [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(270),
+    [sym_usepackage] = STATE(141),
     [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(270),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(270),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(270),
+    [sym_include] = STATE(141),
+    [sym_include_token] = STATE(19),
+    [sym_section] = STATE(141),
+    [sym_section_token] = STATE(20),
+    [sym_storage] = STATE(141),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(270),
+    [sym_catcode] = STATE(141),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(270),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(270),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(270),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(270),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(270),
-    [sym_opt_text_group_at] = STATE(270),
-    [sym_token_at] = STATE(270),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(270),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(518),
-    [anon_sym_RBRACK] = ACTIONS(607),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(521),
-    [sym_begin_group] = ACTIONS(524),
-    [sym_math_shift] = ACTIONS(527),
-    [sym_alignment_tab] = ACTIONS(678),
-    [sym_parameter_char] = ACTIONS(533),
-    [sym_superscript] = ACTIONS(536),
-    [sym_subscript] = ACTIONS(536),
-    [sym_active_char] = ACTIONS(678),
-    [sym_text] = ACTIONS(678),
-  },
-  [271] = {
-    [ts_builtin_sym_end] = ACTIONS(681),
-    [anon_sym_LBRACK] = ACTIONS(681),
-    [anon_sym_RBRACK] = ACTIONS(681),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(681),
-    [sym_begin_group] = ACTIONS(681),
-    [sym_end_group] = ACTIONS(681),
-    [sym_math_shift] = ACTIONS(681),
-    [sym_alignment_tab] = ACTIONS(681),
-    [sym_parameter_char] = ACTIONS(681),
-    [sym_superscript] = ACTIONS(681),
-    [sym_subscript] = ACTIONS(681),
-    [sym_active_char] = ACTIONS(681),
-    [sym_text] = ACTIONS(681),
-  },
-  [272] = {
-    [anon_sym_LBRACK] = ACTIONS(683),
-    [anon_sym_RBRACK] = ACTIONS(683),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(683),
-    [sym_begin_group] = ACTIONS(683),
-    [sym_end_group] = ACTIONS(683),
-    [sym_math_shift] = ACTIONS(683),
-    [sym_alignment_tab] = ACTIONS(683),
-    [sym_parameter_char] = ACTIONS(683),
-    [sym_superscript] = ACTIONS(683),
-    [sym_subscript] = ACTIONS(683),
-    [sym_active_char] = ACTIONS(683),
-    [sym_text] = ACTIONS(683),
-  },
-  [273] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(685),
-  },
-  [274] = {
-    [ts_builtin_sym_end] = ACTIONS(587),
-    [anon_sym_LBRACK] = ACTIONS(587),
-    [anon_sym_RBRACK] = ACTIONS(587),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(587),
-    [sym_begin_group] = ACTIONS(587),
-    [sym_end_group] = ACTIONS(587),
-    [sym_math_shift] = ACTIONS(587),
-    [sym_alignment_tab] = ACTIONS(587),
-    [sym_parameter_char] = ACTIONS(587),
-    [sym_superscript] = ACTIONS(587),
-    [sym_subscript] = ACTIONS(587),
-    [sym_active_char] = ACTIONS(587),
-    [sym_text] = ACTIONS(587),
-  },
-  [275] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(331),
-  },
-  [276] = {
-    [anon_sym_LBRACK] = ACTIONS(687),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(687),
-    [sym_begin_group] = ACTIONS(687),
-    [sym_alignment_tab] = ACTIONS(687),
-    [sym_parameter_char] = ACTIONS(687),
-    [sym_superscript] = ACTIONS(687),
-    [sym_subscript] = ACTIONS(687),
-    [sym_active_char] = ACTIONS(687),
-    [sym_text] = ACTIONS(687),
-  },
-  [277] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(539),
-    [sym__end_of_line] = ACTIONS(539),
-  },
-  [278] = {
-    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(689),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(691),
-    [sym__end_of_line] = ACTIONS(691),
-  },
-  [279] = {
-    [anon_sym_LBRACK] = ACTIONS(693),
-    [anon_sym_RBRACK] = ACTIONS(693),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(693),
-    [sym_begin_group] = ACTIONS(693),
-    [sym_end_group] = ACTIONS(693),
-    [sym_math_shift] = ACTIONS(693),
-    [sym_alignment_tab] = ACTIONS(693),
-    [sym_parameter_char] = ACTIONS(693),
-    [sym_superscript] = ACTIONS(693),
-    [sym_subscript] = ACTIONS(693),
-    [sym_active_char] = ACTIONS(693),
-    [sym_text] = ACTIONS(693),
-  },
-  [280] = {
-    [sym__common] = STATE(280),
-    [sym__math_mode_common] = STATE(280),
-    [sym__math_mode_at] = STATE(280),
-    [sym_parameter] = STATE(280),
-    [sym_math_env_at] = STATE(280),
-    [sym_tag_at] = STATE(280),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(280),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(280),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(280),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(280),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(280),
-    [sym_opt_math_group_at] = STATE(280),
-    [sym_token_at] = STATE(280),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(280),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(634),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(637),
-    [sym_begin_group] = ACTIONS(640),
-    [sym_end_group] = ACTIONS(643),
-    [sym_alignment_tab] = ACTIONS(695),
-    [sym_parameter_char] = ACTIONS(648),
-    [sym_superscript] = ACTIONS(695),
-    [sym_subscript] = ACTIONS(695),
-    [sym_active_char] = ACTIONS(695),
-    [sym_text] = ACTIONS(695),
-  },
-  [281] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_math_shift] = ACTIONS(698),
-  },
-  [282] = {
-    [anon_sym_LBRACK] = ACTIONS(700),
-    [anon_sym_RBRACK] = ACTIONS(700),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(700),
-    [sym_begin_group] = ACTIONS(700),
-    [sym_end_group] = ACTIONS(700),
-    [sym_math_shift] = ACTIONS(700),
-    [sym_alignment_tab] = ACTIONS(700),
-    [sym_parameter_char] = ACTIONS(700),
-    [sym_superscript] = ACTIONS(700),
-    [sym_subscript] = ACTIONS(700),
-    [sym_active_char] = ACTIONS(700),
-    [sym_text] = ACTIONS(700),
-  },
-  [283] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym_end_group] = ACTIONS(702),
-  },
-  [284] = {
-    [sym__common] = STATE(244),
-    [sym__text_mode_common] = STATE(244),
-    [sym_inline_verbatim] = STATE(244),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(244),
-    [sym_parameter] = STATE(244),
-    [sym_text_env_at] = STATE(244),
-    [sym__display_math_at] = STATE(244),
-    [sym_tex_display_math_at] = STATE(244),
-    [sym_latex_display_math_at] = STATE(244),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(244),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(244),
-    [sym_tex_inline_math_at] = STATE(244),
-    [sym_latex_inline_math_at] = STATE(244),
-    [sym_inline_math_env_at] = STATE(244),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(244),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(244),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(244),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(244),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(244),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(244),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(244),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(244),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(244),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(244),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(244),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(244),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(244),
-    [sym_opt_text_group_at] = STATE(244),
-    [sym_token_at] = STATE(244),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(244),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_emph] = STATE(141),
+    [sym_emph_token] = STATE(23),
+    [sym_footnote] = STATE(141),
+    [sym_footnote_token] = STATE(24),
+    [sym_textbf] = STATE(141),
+    [sym_textbf_token] = STATE(25),
+    [sym_textit] = STATE(141),
+    [sym_textit_token] = STATE(26),
+    [sym_texttt] = STATE(141),
+    [sym_texttt_token] = STATE(27),
+    [sym_makeatletter] = STATE(28),
+    [sym_makeatletter_token] = STATE(29),
+    [sym_text_group] = STATE(141),
+    [sym_opt_text_group] = STATE(141),
+    [sym_token] = STATE(141),
+    [sym_begin_opt] = STATE(30),
+    [aux_sym_text_mode_repeat1] = STATE(141),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_end_group] = ACTIONS(285),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(470),
+    [sym__escape] = ACTIONS(13),
+    [sym_begin_group] = ACTIONS(15),
+    [sym_end_group] = ACTIONS(690),
+    [sym_math_shift] = ACTIONS(17),
+    [sym_alignment_tab] = ACTIONS(199),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(470),
-    [sym_text] = ACTIONS(470),
+    [sym_active_char] = ACTIONS(199),
+    [sym_text] = ACTIONS(199),
   },
-  [285] = {
+  [263] = {
+    [anon_sym_LBRACK] = ACTIONS(692),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(692),
+    [sym_begin_group] = ACTIONS(692),
+    [sym_alignment_tab] = ACTIONS(692),
+    [sym_parameter_char] = ACTIONS(692),
+    [sym_superscript] = ACTIONS(692),
+    [sym_subscript] = ACTIONS(692),
+    [sym_active_char] = ACTIONS(692),
+    [sym_text] = ACTIONS(692),
+  },
+  [264] = {
+    [sym_text_group] = STATE(317),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(694),
+  },
+  [265] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(694),
+  },
+  [266] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(696),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(698),
+    [sym__end_of_line] = ACTIONS(698),
+  },
+  [267] = {
+    [sym_text_group] = STATE(319),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(257),
+    [sym__end_of_line] = ACTIONS(700),
+  },
+  [268] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(700),
+  },
+  [269] = {
+    [ts_builtin_sym_end] = ACTIONS(702),
+    [anon_sym_LBRACK] = ACTIONS(702),
+    [anon_sym_RBRACK] = ACTIONS(702),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(702),
+    [sym_begin_group] = ACTIONS(702),
+    [sym_end_group] = ACTIONS(702),
+    [sym_math_shift] = ACTIONS(702),
+    [sym_alignment_tab] = ACTIONS(702),
+    [sym_parameter_char] = ACTIONS(702),
+    [sym_superscript] = ACTIONS(702),
+    [sym_subscript] = ACTIONS(702),
+    [sym_active_char] = ACTIONS(702),
+    [sym_text] = ACTIONS(702),
+  },
+  [270] = {
+    [sym__whitespace] = ACTIONS(631),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(631),
+    [sym__end_of_line] = ACTIONS(631),
+  },
+  [271] = {
+    [ts_builtin_sym_end] = ACTIONS(704),
     [anon_sym_LBRACK] = ACTIONS(704),
     [anon_sym_RBRACK] = ACTIONS(704),
     [sym_magic_comment] = ACTIONS(9),
@@ -11426,7 +11059,8 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(704),
     [sym_text] = ACTIONS(704),
   },
-  [286] = {
+  [272] = {
+    [ts_builtin_sym_end] = ACTIONS(706),
     [anon_sym_LBRACK] = ACTIONS(706),
     [anon_sym_RBRACK] = ACTIONS(706),
     [sym_magic_comment] = ACTIONS(9),
@@ -11442,274 +11076,1454 @@ static uint16_t ts_parse_table[STATE_COUNT][SYMBOL_COUNT] = {
     [sym_active_char] = ACTIONS(706),
     [sym_text] = ACTIONS(706),
   },
-  [287] = {
-    [sym__common] = STATE(287),
-    [sym__math_mode_common] = STATE(287),
-    [sym__math_mode_at] = STATE(287),
-    [sym_parameter] = STATE(287),
-    [sym_math_env_at] = STATE(287),
-    [sym_tag_at] = STATE(287),
-    [sym_tag_token] = STATE(184),
-    [sym_escaped] = STATE(287),
-    [sym_begin] = STATE(185),
-    [sym_begin_token] = STATE(57),
-    [sym_include_at] = STATE(287),
-    [sym_include_token] = STATE(105),
-    [sym_storage] = STATE(287),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(287),
-    [sym_catcode_token] = STATE(22),
-    [sym_math_group_at] = STATE(287),
-    [sym_opt_math_group_at] = STATE(287),
-    [sym_token_at] = STATE(287),
-    [sym_begin_opt] = STATE(186),
-    [aux_sym_math_mode_at_repeat1] = STATE(287),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(634),
-    [anon_sym_RBRACK] = ACTIONS(643),
+  [273] = {
+    [ts_builtin_sym_end] = ACTIONS(708),
+    [anon_sym_LBRACK] = ACTIONS(708),
+    [anon_sym_RBRACK] = ACTIONS(708),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(637),
-    [sym_begin_group] = ACTIONS(640),
+    [sym__escape] = ACTIONS(708),
+    [sym_begin_group] = ACTIONS(708),
+    [sym_end_group] = ACTIONS(708),
+    [sym_math_shift] = ACTIONS(708),
     [sym_alignment_tab] = ACTIONS(708),
-    [sym_parameter_char] = ACTIONS(648),
+    [sym_parameter_char] = ACTIONS(708),
     [sym_superscript] = ACTIONS(708),
     [sym_subscript] = ACTIONS(708),
     [sym_active_char] = ACTIONS(708),
     [sym_text] = ACTIONS(708),
   },
-  [288] = {
+  [274] = {
+    [ts_builtin_sym_end] = ACTIONS(710),
+    [anon_sym_LBRACK] = ACTIONS(710),
+    [anon_sym_RBRACK] = ACTIONS(710),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(466),
+    [sym__escape] = ACTIONS(710),
+    [sym_begin_group] = ACTIONS(710),
+    [sym_end_group] = ACTIONS(710),
+    [sym_math_shift] = ACTIONS(710),
+    [sym_alignment_tab] = ACTIONS(710),
+    [sym_parameter_char] = ACTIONS(710),
+    [sym_superscript] = ACTIONS(710),
+    [sym_subscript] = ACTIONS(710),
+    [sym_active_char] = ACTIONS(710),
+    [sym_text] = ACTIONS(710),
+  },
+  [275] = {
+    [ts_builtin_sym_end] = ACTIONS(712),
+    [anon_sym_LBRACK] = ACTIONS(712),
+    [anon_sym_RBRACK] = ACTIONS(712),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(712),
+    [sym_begin_group] = ACTIONS(712),
+    [sym_end_group] = ACTIONS(712),
+    [sym_math_shift] = ACTIONS(712),
+    [sym_alignment_tab] = ACTIONS(712),
+    [sym_parameter_char] = ACTIONS(712),
+    [sym_superscript] = ACTIONS(712),
+    [sym_subscript] = ACTIONS(712),
+    [sym_active_char] = ACTIONS(712),
+    [sym_text] = ACTIONS(712),
+  },
+  [276] = {
+    [anon_sym_LBRACK] = ACTIONS(714),
+    [anon_sym_RBRACK] = ACTIONS(714),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(714),
+    [sym_begin_group] = ACTIONS(714),
+    [sym_end_group] = ACTIONS(714),
+    [sym_math_shift] = ACTIONS(714),
+    [sym_alignment_tab] = ACTIONS(714),
+    [sym_parameter_char] = ACTIONS(714),
+    [sym_superscript] = ACTIONS(714),
+    [sym_subscript] = ACTIONS(714),
+    [sym_active_char] = ACTIONS(714),
+    [sym_text] = ACTIONS(714),
+  },
+  [277] = {
+    [anon_sym_LBRACK] = ACTIONS(716),
+    [anon_sym_RBRACK] = ACTIONS(716),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(716),
+    [sym_begin_group] = ACTIONS(716),
+    [sym_end_group] = ACTIONS(716),
+    [sym_math_shift] = ACTIONS(716),
+    [sym_alignment_tab] = ACTIONS(716),
+    [sym_parameter_char] = ACTIONS(716),
+    [sym_superscript] = ACTIONS(716),
+    [sym_subscript] = ACTIONS(716),
+    [sym_active_char] = ACTIONS(716),
+    [sym_text] = ACTIONS(716),
+  },
+  [278] = {
+    [sym__common] = STATE(278),
+    [sym__text_mode_common] = STATE(278),
+    [sym_inline_verbatim] = STATE(278),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(278),
+    [sym_parameter] = STATE(278),
+    [sym_text_env_at] = STATE(278),
+    [sym__display_math_at] = STATE(278),
+    [sym_tex_display_math_at] = STATE(278),
+    [sym_latex_display_math_at] = STATE(278),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(278),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(278),
+    [sym_tex_inline_math_at] = STATE(278),
+    [sym_latex_inline_math_at] = STATE(278),
+    [sym_inline_math_env_at] = STATE(278),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(278),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(278),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(278),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(278),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(278),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(278),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(278),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(278),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(278),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(278),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(278),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(278),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(278),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(278),
+    [sym_opt_text_group_at] = STATE(278),
+    [sym_token_at] = STATE(278),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(278),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(610),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(613),
+    [sym_begin_group] = ACTIONS(616),
+    [sym_end_group] = ACTIONS(718),
+    [sym_math_shift] = ACTIONS(619),
+    [sym_alignment_tab] = ACTIONS(720),
+    [sym_parameter_char] = ACTIONS(625),
+    [sym_superscript] = ACTIONS(628),
+    [sym_subscript] = ACTIONS(628),
+    [sym_active_char] = ACTIONS(720),
+    [sym_text] = ACTIONS(720),
+  },
+  [279] = {
+    [anon_sym_LBRACK] = ACTIONS(723),
+    [anon_sym_RBRACK] = ACTIONS(723),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(723),
+    [sym_begin_group] = ACTIONS(723),
+    [sym_end_group] = ACTIONS(723),
+    [sym_math_shift] = ACTIONS(723),
+    [sym_alignment_tab] = ACTIONS(723),
+    [sym_parameter_char] = ACTIONS(723),
+    [sym_superscript] = ACTIONS(723),
+    [sym_subscript] = ACTIONS(723),
+    [sym_active_char] = ACTIONS(723),
+    [sym_text] = ACTIONS(723),
+  },
+  [280] = {
+    [sym__common] = STATE(321),
+    [sym__math_mode_common] = STATE(321),
+    [sym__math_mode_at] = STATE(321),
+    [sym_parameter] = STATE(321),
+    [sym_math_env_at] = STATE(321),
+    [sym_tag_at] = STATE(321),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(321),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(321),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(321),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(321),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(321),
+    [sym_opt_math_group_at] = STATE(321),
+    [sym_token_at] = STATE(321),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(321),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_end_group] = ACTIONS(725),
+    [sym_alignment_tab] = ACTIONS(727),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(727),
+    [sym_subscript] = ACTIONS(727),
+    [sym_active_char] = ACTIONS(727),
+    [sym_text] = ACTIONS(727),
+  },
+  [281] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(729),
+  },
+  [282] = {
+    [anon_sym_LBRACK] = ACTIONS(731),
+    [anon_sym_RBRACK] = ACTIONS(731),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(731),
+    [sym_begin_group] = ACTIONS(731),
+    [sym_end_group] = ACTIONS(731),
+    [sym_math_shift] = ACTIONS(731),
+    [sym_alignment_tab] = ACTIONS(731),
+    [sym_parameter_char] = ACTIONS(731),
+    [sym_superscript] = ACTIONS(731),
+    [sym_subscript] = ACTIONS(731),
+    [sym_active_char] = ACTIONS(731),
+    [sym_text] = ACTIONS(731),
+  },
+  [283] = {
+    [sym__common] = STATE(325),
+    [sym__text_mode_common] = STATE(325),
+    [sym_inline_verbatim] = STATE(325),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(325),
+    [sym_text_mode_at] = STATE(324),
+    [sym_parameter] = STATE(325),
+    [sym_text_env_at] = STATE(325),
+    [sym__display_math_at] = STATE(325),
+    [sym_tex_display_math_at] = STATE(325),
+    [sym_latex_display_math_at] = STATE(325),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(325),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(325),
+    [sym_tex_inline_math_at] = STATE(325),
+    [sym_latex_inline_math_at] = STATE(325),
+    [sym_inline_math_env_at] = STATE(325),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(325),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(325),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(325),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(325),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(325),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(325),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(325),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(325),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(325),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(325),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(325),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(325),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(325),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(325),
+    [sym_opt_text_group_at] = STATE(325),
+    [sym_token_at] = STATE(325),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(325),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(733),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(735),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(735),
+    [sym_text] = ACTIONS(735),
+  },
+  [284] = {
+    [anon_sym_LBRACK] = ACTIONS(737),
+    [anon_sym_RBRACK] = ACTIONS(737),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(737),
+    [sym_begin_group] = ACTIONS(737),
+    [sym_end_group] = ACTIONS(737),
+    [sym_math_shift] = ACTIONS(737),
+    [sym_alignment_tab] = ACTIONS(737),
+    [sym_parameter_char] = ACTIONS(737),
+    [sym_superscript] = ACTIONS(737),
+    [sym_subscript] = ACTIONS(737),
+    [sym_active_char] = ACTIONS(737),
+    [sym_text] = ACTIONS(737),
+  },
+  [285] = {
+    [anon_sym_tag] = ACTIONS(201),
+    [aux_sym_SLASH_LBRACK_CARET_LPAREN_RPAREN_BSLASH_LBRACK_BSLASH_RBRACK_RBRACK_SLASH] = ACTIONS(33),
+    [anon_sym_begin] = ACTIONS(35),
+    [anon_sym_end] = ACTIONS(243),
+    [aux_sym_SLASHinclude_PIPEinput_SLASH] = ACTIONS(41),
+    [aux_sym_SLASH_LBRACKegx_RBRACK_QMARKdef_SLASH] = ACTIONS(45),
+    [aux_sym_SLASHk_QMARKcatcode_BQUOTE_SLASH] = ACTIONS(47),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__name_at] = ACTIONS(305),
+  },
+  [286] = {
+    [anon_sym_LBRACK] = ACTIONS(739),
+    [anon_sym_RBRACK] = ACTIONS(739),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(739),
+    [sym_begin_group] = ACTIONS(739),
+    [sym_end_group] = ACTIONS(739),
+    [sym_math_shift] = ACTIONS(739),
+    [sym_alignment_tab] = ACTIONS(739),
+    [sym_parameter_char] = ACTIONS(739),
+    [sym_superscript] = ACTIONS(739),
+    [sym_subscript] = ACTIONS(739),
+    [sym_active_char] = ACTIONS(739),
+    [sym_text] = ACTIONS(739),
+  },
+  [287] = {
+    [sym__common] = STATE(292),
+    [sym__math_mode_common] = STATE(292),
+    [sym__math_mode_at] = STATE(292),
+    [sym_parameter] = STATE(292),
+    [sym_math_env_at] = STATE(292),
+    [sym_tag_at] = STATE(292),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(292),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_end] = STATE(326),
+    [sym_end_token] = STATE(76),
+    [sym_include_at] = STATE(292),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(292),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(292),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(292),
+    [sym_opt_math_group_at] = STATE(292),
+    [sym_token_at] = STATE(292),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(292),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(564),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(578),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(578),
+    [sym_subscript] = ACTIONS(578),
+    [sym_active_char] = ACTIONS(578),
+    [sym_text] = ACTIONS(578),
+  },
+  [288] = {
+    [anon_sym_LBRACK] = ACTIONS(741),
+    [anon_sym_RBRACK] = ACTIONS(741),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(741),
+    [sym_begin_group] = ACTIONS(741),
+    [sym_end_group] = ACTIONS(741),
+    [sym_math_shift] = ACTIONS(741),
+    [sym_alignment_tab] = ACTIONS(741),
+    [sym_parameter_char] = ACTIONS(741),
+    [sym_superscript] = ACTIONS(741),
+    [sym_subscript] = ACTIONS(741),
+    [sym_active_char] = ACTIONS(741),
+    [sym_text] = ACTIONS(741),
   },
   [289] = {
-    [sym__common] = STATE(244),
-    [sym__text_mode_common] = STATE(244),
-    [sym_inline_verbatim] = STATE(244),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(244),
-    [sym_parameter] = STATE(244),
-    [sym_text_env_at] = STATE(244),
-    [sym__display_math_at] = STATE(244),
-    [sym_tex_display_math_at] = STATE(244),
-    [sym_latex_display_math_at] = STATE(244),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(244),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(244),
-    [sym_tex_inline_math_at] = STATE(244),
-    [sym_latex_inline_math_at] = STATE(244),
-    [sym_inline_math_env_at] = STATE(244),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(244),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(244),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(244),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(244),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(244),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(244),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(244),
+    [sym__common] = STATE(328),
+    [sym__math_mode_common] = STATE(328),
+    [sym__math_mode_at] = STATE(328),
+    [sym_parameter] = STATE(328),
+    [sym_math_env_at] = STATE(328),
+    [sym_tag_at] = STATE(328),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(328),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(328),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(328),
     [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(244),
+    [sym_catcode] = STATE(328),
     [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(244),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(244),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(244),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(244),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(244),
-    [sym_opt_text_group_at] = STATE(244),
-    [sym_token_at] = STATE(244),
-    [sym_begin_opt] = STATE(113),
-    [aux_sym_text_mode_at_repeat1] = STATE(244),
-    [aux_sym_parameter_repeat1] = STATE(31),
+    [sym_math_group_at] = STATE(328),
+    [sym_opt_math_group_at] = STATE(328),
+    [sym_token_at] = STATE(328),
+    [sym_begin_opt] = STATE(210),
+    [sym_end_opt] = STATE(327),
+    [aux_sym_math_mode_at_repeat1] = STATE(328),
+    [aux_sym_parameter_repeat1] = STATE(32),
     [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(113),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_end_group] = ACTIONS(711),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(470),
+    [sym__escape] = ACTIONS(313),
+    [sym_begin_group] = ACTIONS(315),
+    [sym_alignment_tab] = ACTIONS(743),
     [sym_parameter_char] = ACTIONS(21),
-    [sym_superscript] = ACTIONS(23),
-    [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(470),
-    [sym_text] = ACTIONS(470),
+    [sym_superscript] = ACTIONS(743),
+    [sym_subscript] = ACTIONS(743),
+    [sym_active_char] = ACTIONS(743),
+    [sym_text] = ACTIONS(743),
   },
   [290] = {
-    [anon_sym_LBRACK] = ACTIONS(713),
+    [sym__common] = STATE(290),
+    [sym__math_mode_common] = STATE(290),
+    [sym__math_mode_at] = STATE(290),
+    [sym_parameter] = STATE(290),
+    [sym_math_env_at] = STATE(290),
+    [sym_tag_at] = STATE(290),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(290),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(290),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(290),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(290),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(290),
+    [sym_opt_math_group_at] = STATE(290),
+    [sym_token_at] = STATE(290),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(290),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(745),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(713),
-    [sym_begin_group] = ACTIONS(713),
-    [sym_alignment_tab] = ACTIONS(713),
-    [sym_parameter_char] = ACTIONS(713),
-    [sym_superscript] = ACTIONS(713),
-    [sym_subscript] = ACTIONS(713),
-    [sym_active_char] = ACTIONS(713),
-    [sym_text] = ACTIONS(713),
+    [sym__escape] = ACTIONS(748),
+    [sym_begin_group] = ACTIONS(751),
+    [sym_math_shift] = ACTIONS(754),
+    [sym_alignment_tab] = ACTIONS(756),
+    [sym_parameter_char] = ACTIONS(759),
+    [sym_superscript] = ACTIONS(756),
+    [sym_subscript] = ACTIONS(756),
+    [sym_active_char] = ACTIONS(756),
+    [sym_text] = ACTIONS(756),
   },
   [291] = {
+    [anon_sym_LBRACK] = ACTIONS(762),
+    [anon_sym_RBRACK] = ACTIONS(762),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(715),
+    [sym__escape] = ACTIONS(762),
+    [sym_begin_group] = ACTIONS(762),
+    [sym_end_group] = ACTIONS(762),
+    [sym_math_shift] = ACTIONS(762),
+    [sym_alignment_tab] = ACTIONS(762),
+    [sym_parameter_char] = ACTIONS(762),
+    [sym_superscript] = ACTIONS(762),
+    [sym_subscript] = ACTIONS(762),
+    [sym_active_char] = ACTIONS(762),
+    [sym_text] = ACTIONS(762),
   },
   [292] = {
+    [sym__common] = STATE(292),
+    [sym__math_mode_common] = STATE(292),
+    [sym__math_mode_at] = STATE(292),
+    [sym_parameter] = STATE(292),
+    [sym_math_env_at] = STATE(292),
+    [sym_tag_at] = STATE(292),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(292),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(292),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(292),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(292),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(292),
+    [sym_opt_math_group_at] = STATE(292),
+    [sym_token_at] = STATE(292),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(292),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(745),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(514),
-    [sym__end_of_line] = ACTIONS(514),
+    [sym__escape] = ACTIONS(748),
+    [sym_begin_group] = ACTIONS(751),
+    [sym_alignment_tab] = ACTIONS(764),
+    [sym_parameter_char] = ACTIONS(759),
+    [sym_superscript] = ACTIONS(764),
+    [sym_subscript] = ACTIONS(764),
+    [sym_active_char] = ACTIONS(764),
+    [sym_text] = ACTIONS(764),
   },
   [293] = {
-    [sym__common] = STATE(270),
-    [sym__text_mode_common] = STATE(270),
-    [sym_inline_verbatim] = STATE(270),
-    [sym_verb_token] = STATE(8),
-    [sym__text_mode_at] = STATE(270),
-    [sym_parameter] = STATE(270),
-    [sym_text_env_at] = STATE(270),
-    [sym__display_math_at] = STATE(270),
-    [sym_tex_display_math_at] = STATE(270),
-    [sym_latex_display_math_at] = STATE(270),
-    [sym_begin_display_math] = STATE(99),
-    [sym_begin_inline_math] = STATE(100),
-    [sym_display_math_env_at] = STATE(270),
-    [sym_display_math_begin_at] = STATE(101),
-    [sym__inline_math_at] = STATE(270),
-    [sym_tex_inline_math_at] = STATE(270),
-    [sym_latex_inline_math_at] = STATE(270),
-    [sym_inline_math_env_at] = STATE(270),
-    [sym_inline_math_begin] = STATE(102),
-    [sym_verbatim_env] = STATE(270),
-    [sym_verbatim_begin] = STATE(14),
-    [sym_escaped] = STATE(270),
-    [sym_begin] = STATE(103),
-    [sym_begin_token] = STATE(104),
-    [sym_documentclass] = STATE(270),
-    [sym_documentclass_token] = STATE(17),
-    [sym_usepackage] = STATE(270),
-    [sym_usepackage_token] = STATE(18),
-    [sym_include_at] = STATE(270),
-    [sym_include_token] = STATE(105),
-    [sym_section_at] = STATE(270),
-    [sym_section_token] = STATE(106),
-    [sym_storage] = STATE(270),
-    [sym_storage_token] = STATE(21),
-    [sym_catcode] = STATE(270),
-    [sym_catcode_token] = STATE(22),
-    [sym_emph_at] = STATE(270),
-    [sym_emph_token] = STATE(107),
-    [sym_textbf_at] = STATE(270),
-    [sym_textbf_token] = STATE(108),
-    [sym_textit_at] = STATE(270),
-    [sym_textit_token] = STATE(109),
-    [sym_texttt_at] = STATE(270),
-    [sym_texttt_token] = STATE(110),
-    [sym_text_group_at] = STATE(270),
-    [sym_opt_text_group_at] = STATE(270),
-    [sym_token_at] = STATE(270),
-    [sym_begin_opt] = STATE(113),
-    [sym_end_opt] = STATE(299),
-    [aux_sym_text_mode_at_repeat1] = STATE(270),
-    [aux_sym_parameter_repeat1] = STATE(31),
-    [anon_sym_LBRACK] = ACTIONS(7),
-    [anon_sym_RBRACK] = ACTIONS(444),
+    [anon_sym_LBRACK] = ACTIONS(767),
+    [anon_sym_RBRACK] = ACTIONS(767),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(257),
-    [sym_begin_group] = ACTIONS(103),
-    [sym_math_shift] = ACTIONS(105),
-    [sym_alignment_tab] = ACTIONS(516),
+    [sym__escape] = ACTIONS(767),
+    [sym_begin_group] = ACTIONS(767),
+    [sym_end_group] = ACTIONS(767),
+    [sym_math_shift] = ACTIONS(767),
+    [sym_alignment_tab] = ACTIONS(767),
+    [sym_parameter_char] = ACTIONS(767),
+    [sym_superscript] = ACTIONS(767),
+    [sym_subscript] = ACTIONS(767),
+    [sym_active_char] = ACTIONS(767),
+    [sym_text] = ACTIONS(767),
+  },
+  [294] = {
+    [anon_sym_LBRACK] = ACTIONS(769),
+    [anon_sym_RBRACK] = ACTIONS(769),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(769),
+    [sym_begin_group] = ACTIONS(769),
+    [sym_end_group] = ACTIONS(769),
+    [sym_math_shift] = ACTIONS(769),
+    [sym_alignment_tab] = ACTIONS(769),
+    [sym_parameter_char] = ACTIONS(769),
+    [sym_superscript] = ACTIONS(769),
+    [sym_subscript] = ACTIONS(769),
+    [sym_active_char] = ACTIONS(769),
+    [sym_text] = ACTIONS(769),
+  },
+  [295] = {
+    [anon_sym_LBRACK] = ACTIONS(771),
+    [anon_sym_RBRACK] = ACTIONS(771),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(771),
+    [sym_begin_group] = ACTIONS(771),
+    [sym_end_group] = ACTIONS(771),
+    [sym_math_shift] = ACTIONS(771),
+    [sym_alignment_tab] = ACTIONS(771),
+    [sym_parameter_char] = ACTIONS(771),
+    [sym_superscript] = ACTIONS(771),
+    [sym_subscript] = ACTIONS(771),
+    [sym_active_char] = ACTIONS(771),
+    [sym_text] = ACTIONS(771),
+  },
+  [296] = {
+    [anon_sym_LBRACK] = ACTIONS(773),
+    [anon_sym_RBRACK] = ACTIONS(773),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(773),
+    [sym_begin_group] = ACTIONS(773),
+    [sym_end_group] = ACTIONS(773),
+    [sym_math_shift] = ACTIONS(773),
+    [sym_alignment_tab] = ACTIONS(773),
+    [sym_parameter_char] = ACTIONS(773),
+    [sym_superscript] = ACTIONS(773),
+    [sym_subscript] = ACTIONS(773),
+    [sym_active_char] = ACTIONS(773),
+    [sym_text] = ACTIONS(773),
+  },
+  [297] = {
+    [sym__common] = STATE(330),
+    [sym__text_mode_common] = STATE(330),
+    [sym_inline_verbatim] = STATE(330),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(330),
+    [sym_parameter] = STATE(330),
+    [sym_text_env_at] = STATE(330),
+    [sym__display_math_at] = STATE(330),
+    [sym_tex_display_math_at] = STATE(330),
+    [sym_latex_display_math_at] = STATE(330),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(330),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(330),
+    [sym_tex_inline_math_at] = STATE(330),
+    [sym_latex_inline_math_at] = STATE(330),
+    [sym_inline_math_env_at] = STATE(330),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(330),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(330),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(330),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(330),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(330),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(330),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(330),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(330),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(330),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(330),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(330),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(330),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(330),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(330),
+    [sym_opt_text_group_at] = STATE(330),
+    [sym_token_at] = STATE(330),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(330),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(775),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(777),
     [sym_parameter_char] = ACTIONS(21),
     [sym_superscript] = ACTIONS(23),
     [sym_subscript] = ACTIONS(23),
-    [sym_active_char] = ACTIONS(516),
-    [sym_text] = ACTIONS(516),
-  },
-  [294] = {
-    [ts_builtin_sym_end] = ACTIONS(583),
-    [anon_sym_LBRACK] = ACTIONS(583),
-    [anon_sym_RBRACK] = ACTIONS(583),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(583),
-    [sym_begin_group] = ACTIONS(583),
-    [sym_end_group] = ACTIONS(583),
-    [sym_math_shift] = ACTIONS(583),
-    [sym_alignment_tab] = ACTIONS(583),
-    [sym_parameter_char] = ACTIONS(583),
-    [sym_superscript] = ACTIONS(583),
-    [sym_subscript] = ACTIONS(583),
-    [sym_active_char] = ACTIONS(583),
-    [sym_text] = ACTIONS(583),
-  },
-  [295] = {
-    [anon_sym_LBRACK] = ACTIONS(717),
-    [anon_sym_RBRACK] = ACTIONS(717),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(717),
-    [sym_begin_group] = ACTIONS(717),
-    [sym_end_group] = ACTIONS(717),
-    [sym_math_shift] = ACTIONS(717),
-    [sym_alignment_tab] = ACTIONS(717),
-    [sym_parameter_char] = ACTIONS(717),
-    [sym_superscript] = ACTIONS(717),
-    [sym_subscript] = ACTIONS(717),
-    [sym_active_char] = ACTIONS(717),
-    [sym_text] = ACTIONS(717),
-  },
-  [296] = {
-    [anon_sym_LBRACK] = ACTIONS(719),
-    [anon_sym_RBRACK] = ACTIONS(719),
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(719),
-    [sym_begin_group] = ACTIONS(719),
-    [sym_end_group] = ACTIONS(719),
-    [sym_math_shift] = ACTIONS(719),
-    [sym_alignment_tab] = ACTIONS(719),
-    [sym_parameter_char] = ACTIONS(719),
-    [sym_superscript] = ACTIONS(719),
-    [sym_subscript] = ACTIONS(719),
-    [sym_active_char] = ACTIONS(719),
-    [sym_text] = ACTIONS(719),
-  },
-  [297] = {
-    [sym_magic_comment] = ACTIONS(9),
-    [sym_comment] = ACTIONS(11),
-    [sym__end_of_line] = ACTIONS(605),
+    [sym_active_char] = ACTIONS(777),
+    [sym_text] = ACTIONS(777),
   },
   [298] = {
-    [anon_sym_LBRACK] = ACTIONS(721),
+    [anon_sym_LBRACK] = ACTIONS(779),
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym__escape] = ACTIONS(721),
-    [sym_begin_group] = ACTIONS(721),
-    [sym_alignment_tab] = ACTIONS(721),
-    [sym_parameter_char] = ACTIONS(721),
-    [sym_superscript] = ACTIONS(721),
-    [sym_subscript] = ACTIONS(721),
-    [sym_active_char] = ACTIONS(721),
-    [sym_text] = ACTIONS(721),
+    [sym__escape] = ACTIONS(779),
+    [sym_begin_group] = ACTIONS(779),
+    [sym_alignment_tab] = ACTIONS(779),
+    [sym_parameter_char] = ACTIONS(779),
+    [sym_superscript] = ACTIONS(779),
+    [sym_subscript] = ACTIONS(779),
+    [sym_active_char] = ACTIONS(779),
+    [sym_text] = ACTIONS(779),
   },
   [299] = {
     [sym_magic_comment] = ACTIONS(9),
     [sym_comment] = ACTIONS(11),
-    [sym_begin_group] = ACTIONS(676),
-    [sym__end_of_line] = ACTIONS(676),
+    [sym__end_of_line] = ACTIONS(781),
+  },
+  [300] = {
+    [sym_text_group_at] = STATE(333),
+    [sym__whitespace] = ACTIONS(783),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(582),
+    [sym__end_of_line] = ACTIONS(781),
+  },
+  [301] = {
+    [sym_text_group_at] = STATE(334),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [302] = {
+    [anon_sym_LBRACK] = ACTIONS(785),
+    [anon_sym_RBRACK] = ACTIONS(785),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(785),
+    [sym_begin_group] = ACTIONS(785),
+    [sym_end_group] = ACTIONS(785),
+    [sym_math_shift] = ACTIONS(785),
+    [sym_alignment_tab] = ACTIONS(785),
+    [sym_parameter_char] = ACTIONS(785),
+    [sym_superscript] = ACTIONS(785),
+    [sym_subscript] = ACTIONS(785),
+    [sym_active_char] = ACTIONS(785),
+    [sym_text] = ACTIONS(785),
+  },
+  [303] = {
+    [sym__whitespace] = ACTIONS(606),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(606),
+    [sym__end_of_line] = ACTIONS(606),
+  },
+  [304] = {
+    [sym__common] = STATE(308),
+    [sym__text_mode_common] = STATE(308),
+    [sym_inline_verbatim] = STATE(308),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(308),
+    [sym_parameter] = STATE(308),
+    [sym_text_env_at] = STATE(308),
+    [sym__display_math_at] = STATE(308),
+    [sym_tex_display_math_at] = STATE(308),
+    [sym_latex_display_math_at] = STATE(308),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(308),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(308),
+    [sym_tex_inline_math_at] = STATE(308),
+    [sym_latex_inline_math_at] = STATE(308),
+    [sym_inline_math_env_at] = STATE(308),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(308),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(308),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(308),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(308),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(308),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(308),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(308),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(308),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(308),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(308),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(308),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(308),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(308),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(308),
+    [sym_opt_text_group_at] = STATE(308),
+    [sym_token_at] = STATE(308),
+    [sym_begin_opt] = STATE(119),
+    [sym_end_opt] = STATE(335),
+    [aux_sym_text_mode_at_repeat1] = STATE(308),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [anon_sym_RBRACK] = ACTIONS(273),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(608),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(608),
+    [sym_text] = ACTIONS(608),
+  },
+  [305] = {
+    [sym_text_group_at] = STATE(336),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(105),
+  },
+  [306] = {
+    [anon_sym_LBRACK] = ACTIONS(787),
+    [anon_sym_RBRACK] = ACTIONS(787),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(787),
+    [sym_begin_group] = ACTIONS(787),
+    [sym_end_group] = ACTIONS(787),
+    [sym_math_shift] = ACTIONS(787),
+    [sym_alignment_tab] = ACTIONS(787),
+    [sym_parameter_char] = ACTIONS(787),
+    [sym_superscript] = ACTIONS(787),
+    [sym_subscript] = ACTIONS(787),
+    [sym_active_char] = ACTIONS(787),
+    [sym_text] = ACTIONS(787),
+  },
+  [307] = {
+    [anon_sym_LBRACK] = ACTIONS(789),
+    [anon_sym_RBRACK] = ACTIONS(789),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(789),
+    [sym_begin_group] = ACTIONS(789),
+    [sym_end_group] = ACTIONS(789),
+    [sym_math_shift] = ACTIONS(789),
+    [sym_alignment_tab] = ACTIONS(789),
+    [sym_parameter_char] = ACTIONS(789),
+    [sym_superscript] = ACTIONS(789),
+    [sym_subscript] = ACTIONS(789),
+    [sym_active_char] = ACTIONS(789),
+    [sym_text] = ACTIONS(789),
+  },
+  [308] = {
+    [sym__common] = STATE(308),
+    [sym__text_mode_common] = STATE(308),
+    [sym_inline_verbatim] = STATE(308),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(308),
+    [sym_parameter] = STATE(308),
+    [sym_text_env_at] = STATE(308),
+    [sym__display_math_at] = STATE(308),
+    [sym_tex_display_math_at] = STATE(308),
+    [sym_latex_display_math_at] = STATE(308),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(308),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(308),
+    [sym_tex_inline_math_at] = STATE(308),
+    [sym_latex_inline_math_at] = STATE(308),
+    [sym_inline_math_env_at] = STATE(308),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(308),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(308),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(308),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(308),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(308),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(308),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(308),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(308),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(308),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(308),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(308),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(308),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(308),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(308),
+    [sym_opt_text_group_at] = STATE(308),
+    [sym_token_at] = STATE(308),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(308),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(610),
+    [anon_sym_RBRACK] = ACTIONS(718),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(613),
+    [sym_begin_group] = ACTIONS(616),
+    [sym_math_shift] = ACTIONS(619),
+    [sym_alignment_tab] = ACTIONS(791),
+    [sym_parameter_char] = ACTIONS(625),
+    [sym_superscript] = ACTIONS(628),
+    [sym_subscript] = ACTIONS(628),
+    [sym_active_char] = ACTIONS(791),
+    [sym_text] = ACTIONS(791),
+  },
+  [309] = {
+    [ts_builtin_sym_end] = ACTIONS(794),
+    [anon_sym_LBRACK] = ACTIONS(794),
+    [anon_sym_RBRACK] = ACTIONS(794),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(794),
+    [sym_begin_group] = ACTIONS(794),
+    [sym_end_group] = ACTIONS(794),
+    [sym_math_shift] = ACTIONS(794),
+    [sym_alignment_tab] = ACTIONS(794),
+    [sym_parameter_char] = ACTIONS(794),
+    [sym_superscript] = ACTIONS(794),
+    [sym_subscript] = ACTIONS(794),
+    [sym_active_char] = ACTIONS(794),
+    [sym_text] = ACTIONS(794),
+  },
+  [310] = {
+    [anon_sym_LBRACK] = ACTIONS(796),
+    [anon_sym_RBRACK] = ACTIONS(796),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(796),
+    [sym_begin_group] = ACTIONS(796),
+    [sym_end_group] = ACTIONS(796),
+    [sym_math_shift] = ACTIONS(796),
+    [sym_alignment_tab] = ACTIONS(796),
+    [sym_parameter_char] = ACTIONS(796),
+    [sym_superscript] = ACTIONS(796),
+    [sym_subscript] = ACTIONS(796),
+    [sym_active_char] = ACTIONS(796),
+    [sym_text] = ACTIONS(796),
+  },
+  [311] = {
+    [ts_builtin_sym_end] = ACTIONS(798),
+    [anon_sym_LBRACK] = ACTIONS(798),
+    [anon_sym_RBRACK] = ACTIONS(798),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(798),
+    [sym_begin_group] = ACTIONS(798),
+    [sym_end_group] = ACTIONS(798),
+    [sym_math_shift] = ACTIONS(798),
+    [sym_alignment_tab] = ACTIONS(798),
+    [sym_parameter_char] = ACTIONS(798),
+    [sym_superscript] = ACTIONS(798),
+    [sym_subscript] = ACTIONS(798),
+    [sym_active_char] = ACTIONS(798),
+    [sym_text] = ACTIONS(798),
+  },
+  [312] = {
+    [ts_builtin_sym_end] = ACTIONS(800),
+    [anon_sym_LBRACK] = ACTIONS(800),
+    [anon_sym_RBRACK] = ACTIONS(800),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(800),
+    [sym_begin_group] = ACTIONS(800),
+    [sym_end_group] = ACTIONS(800),
+    [sym_math_shift] = ACTIONS(800),
+    [sym_alignment_tab] = ACTIONS(800),
+    [sym_parameter_char] = ACTIONS(800),
+    [sym_superscript] = ACTIONS(800),
+    [sym_subscript] = ACTIONS(800),
+    [sym_active_char] = ACTIONS(800),
+    [sym_text] = ACTIONS(800),
+  },
+  [313] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(802),
+  },
+  [314] = {
+    [ts_builtin_sym_end] = ACTIONS(686),
+    [anon_sym_LBRACK] = ACTIONS(686),
+    [anon_sym_RBRACK] = ACTIONS(686),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(686),
+    [sym_begin_group] = ACTIONS(686),
+    [sym_end_group] = ACTIONS(686),
+    [sym_math_shift] = ACTIONS(686),
+    [sym_alignment_tab] = ACTIONS(686),
+    [sym_parameter_char] = ACTIONS(686),
+    [sym_superscript] = ACTIONS(686),
+    [sym_subscript] = ACTIONS(686),
+    [sym_active_char] = ACTIONS(686),
+    [sym_text] = ACTIONS(686),
+  },
+  [315] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(401),
+  },
+  [316] = {
+    [anon_sym_LBRACK] = ACTIONS(804),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(804),
+    [sym_begin_group] = ACTIONS(804),
+    [sym_alignment_tab] = ACTIONS(804),
+    [sym_parameter_char] = ACTIONS(804),
+    [sym_superscript] = ACTIONS(804),
+    [sym_subscript] = ACTIONS(804),
+    [sym_active_char] = ACTIONS(804),
+    [sym_text] = ACTIONS(804),
+  },
+  [317] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(806),
+  },
+  [318] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(808),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(810),
+    [sym__end_of_line] = ACTIONS(810),
+  },
+  [319] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(812),
+  },
+  [320] = {
+    [anon_sym_LBRACK] = ACTIONS(814),
+    [anon_sym_RBRACK] = ACTIONS(814),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(814),
+    [sym_begin_group] = ACTIONS(814),
+    [sym_end_group] = ACTIONS(814),
+    [sym_math_shift] = ACTIONS(814),
+    [sym_alignment_tab] = ACTIONS(814),
+    [sym_parameter_char] = ACTIONS(814),
+    [sym_superscript] = ACTIONS(814),
+    [sym_subscript] = ACTIONS(814),
+    [sym_active_char] = ACTIONS(814),
+    [sym_text] = ACTIONS(814),
+  },
+  [321] = {
+    [sym__common] = STATE(321),
+    [sym__math_mode_common] = STATE(321),
+    [sym__math_mode_at] = STATE(321),
+    [sym_parameter] = STATE(321),
+    [sym_math_env_at] = STATE(321),
+    [sym_tag_at] = STATE(321),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(321),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(321),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(321),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(321),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(321),
+    [sym_opt_math_group_at] = STATE(321),
+    [sym_token_at] = STATE(321),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(321),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(745),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(748),
+    [sym_begin_group] = ACTIONS(751),
+    [sym_end_group] = ACTIONS(754),
+    [sym_alignment_tab] = ACTIONS(816),
+    [sym_parameter_char] = ACTIONS(759),
+    [sym_superscript] = ACTIONS(816),
+    [sym_subscript] = ACTIONS(816),
+    [sym_active_char] = ACTIONS(816),
+    [sym_text] = ACTIONS(816),
+  },
+  [322] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_math_shift] = ACTIONS(819),
+  },
+  [323] = {
+    [anon_sym_LBRACK] = ACTIONS(821),
+    [anon_sym_RBRACK] = ACTIONS(821),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(821),
+    [sym_begin_group] = ACTIONS(821),
+    [sym_end_group] = ACTIONS(821),
+    [sym_math_shift] = ACTIONS(821),
+    [sym_alignment_tab] = ACTIONS(821),
+    [sym_parameter_char] = ACTIONS(821),
+    [sym_superscript] = ACTIONS(821),
+    [sym_subscript] = ACTIONS(821),
+    [sym_active_char] = ACTIONS(821),
+    [sym_text] = ACTIONS(821),
+  },
+  [324] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_end_group] = ACTIONS(823),
+  },
+  [325] = {
+    [sym__common] = STATE(278),
+    [sym__text_mode_common] = STATE(278),
+    [sym_inline_verbatim] = STATE(278),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(278),
+    [sym_parameter] = STATE(278),
+    [sym_text_env_at] = STATE(278),
+    [sym__display_math_at] = STATE(278),
+    [sym_tex_display_math_at] = STATE(278),
+    [sym_latex_display_math_at] = STATE(278),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(278),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(278),
+    [sym_tex_inline_math_at] = STATE(278),
+    [sym_latex_inline_math_at] = STATE(278),
+    [sym_inline_math_env_at] = STATE(278),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(278),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(278),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(278),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(278),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(278),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(278),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(278),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(278),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(278),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(278),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(278),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(278),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(278),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(278),
+    [sym_opt_text_group_at] = STATE(278),
+    [sym_token_at] = STATE(278),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(278),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(335),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(554),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(554),
+    [sym_text] = ACTIONS(554),
+  },
+  [326] = {
+    [anon_sym_LBRACK] = ACTIONS(825),
+    [anon_sym_RBRACK] = ACTIONS(825),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(825),
+    [sym_begin_group] = ACTIONS(825),
+    [sym_end_group] = ACTIONS(825),
+    [sym_math_shift] = ACTIONS(825),
+    [sym_alignment_tab] = ACTIONS(825),
+    [sym_parameter_char] = ACTIONS(825),
+    [sym_superscript] = ACTIONS(825),
+    [sym_subscript] = ACTIONS(825),
+    [sym_active_char] = ACTIONS(825),
+    [sym_text] = ACTIONS(825),
+  },
+  [327] = {
+    [anon_sym_LBRACK] = ACTIONS(827),
+    [anon_sym_RBRACK] = ACTIONS(827),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(827),
+    [sym_begin_group] = ACTIONS(827),
+    [sym_end_group] = ACTIONS(827),
+    [sym_math_shift] = ACTIONS(827),
+    [sym_alignment_tab] = ACTIONS(827),
+    [sym_parameter_char] = ACTIONS(827),
+    [sym_superscript] = ACTIONS(827),
+    [sym_subscript] = ACTIONS(827),
+    [sym_active_char] = ACTIONS(827),
+    [sym_text] = ACTIONS(827),
+  },
+  [328] = {
+    [sym__common] = STATE(328),
+    [sym__math_mode_common] = STATE(328),
+    [sym__math_mode_at] = STATE(328),
+    [sym_parameter] = STATE(328),
+    [sym_math_env_at] = STATE(328),
+    [sym_tag_at] = STATE(328),
+    [sym_tag_token] = STATE(208),
+    [sym_escaped] = STATE(328),
+    [sym_begin] = STATE(209),
+    [sym_begin_token] = STATE(59),
+    [sym_include_at] = STATE(328),
+    [sym_include_token] = STATE(110),
+    [sym_storage] = STATE(328),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(328),
+    [sym_catcode_token] = STATE(22),
+    [sym_math_group_at] = STATE(328),
+    [sym_opt_math_group_at] = STATE(328),
+    [sym_token_at] = STATE(328),
+    [sym_begin_opt] = STATE(210),
+    [aux_sym_math_mode_at_repeat1] = STATE(328),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(745),
+    [anon_sym_RBRACK] = ACTIONS(754),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(748),
+    [sym_begin_group] = ACTIONS(751),
+    [sym_alignment_tab] = ACTIONS(829),
+    [sym_parameter_char] = ACTIONS(759),
+    [sym_superscript] = ACTIONS(829),
+    [sym_subscript] = ACTIONS(829),
+    [sym_active_char] = ACTIONS(829),
+    [sym_text] = ACTIONS(829),
+  },
+  [329] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(550),
+  },
+  [330] = {
+    [sym__common] = STATE(278),
+    [sym__text_mode_common] = STATE(278),
+    [sym_inline_verbatim] = STATE(278),
+    [sym_verb_token] = STATE(8),
+    [sym__text_mode_at] = STATE(278),
+    [sym_parameter] = STATE(278),
+    [sym_text_env_at] = STATE(278),
+    [sym__display_math_at] = STATE(278),
+    [sym_tex_display_math_at] = STATE(278),
+    [sym_latex_display_math_at] = STATE(278),
+    [sym_begin_display_math] = STATE(104),
+    [sym_begin_inline_math] = STATE(105),
+    [sym_display_math_env_at] = STATE(278),
+    [sym_display_math_begin_at] = STATE(106),
+    [sym__inline_math_at] = STATE(278),
+    [sym_tex_inline_math_at] = STATE(278),
+    [sym_latex_inline_math_at] = STATE(278),
+    [sym_inline_math_env_at] = STATE(278),
+    [sym_inline_math_begin] = STATE(107),
+    [sym_verbatim_env] = STATE(278),
+    [sym_verbatim_begin] = STATE(14),
+    [sym_escaped] = STATE(278),
+    [sym_begin] = STATE(108),
+    [sym_begin_token] = STATE(109),
+    [sym_documentclass] = STATE(278),
+    [sym_documentclass_token] = STATE(17),
+    [sym_usepackage] = STATE(278),
+    [sym_usepackage_token] = STATE(18),
+    [sym_include_at] = STATE(278),
+    [sym_include_token] = STATE(110),
+    [sym_section_at] = STATE(278),
+    [sym_section_token] = STATE(111),
+    [sym_storage] = STATE(278),
+    [sym_storage_token] = STATE(21),
+    [sym_catcode] = STATE(278),
+    [sym_catcode_token] = STATE(22),
+    [sym_emph_at] = STATE(278),
+    [sym_emph_token] = STATE(112),
+    [sym_footnote_at] = STATE(278),
+    [sym_footnote_token] = STATE(113),
+    [sym_textbf_at] = STATE(278),
+    [sym_textbf_token] = STATE(114),
+    [sym_textit_at] = STATE(278),
+    [sym_textit_token] = STATE(115),
+    [sym_texttt_at] = STATE(278),
+    [sym_texttt_token] = STATE(116),
+    [sym_text_group_at] = STATE(278),
+    [sym_opt_text_group_at] = STATE(278),
+    [sym_token_at] = STATE(278),
+    [sym_begin_opt] = STATE(119),
+    [aux_sym_text_mode_at_repeat1] = STATE(278),
+    [aux_sym_parameter_repeat1] = STATE(32),
+    [anon_sym_LBRACK] = ACTIONS(7),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(307),
+    [sym_begin_group] = ACTIONS(105),
+    [sym_end_group] = ACTIONS(832),
+    [sym_math_shift] = ACTIONS(107),
+    [sym_alignment_tab] = ACTIONS(554),
+    [sym_parameter_char] = ACTIONS(21),
+    [sym_superscript] = ACTIONS(23),
+    [sym_subscript] = ACTIONS(23),
+    [sym_active_char] = ACTIONS(554),
+    [sym_text] = ACTIONS(554),
+  },
+  [331] = {
+    [anon_sym_LBRACK] = ACTIONS(834),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(834),
+    [sym_begin_group] = ACTIONS(834),
+    [sym_alignment_tab] = ACTIONS(834),
+    [sym_parameter_char] = ACTIONS(834),
+    [sym_superscript] = ACTIONS(834),
+    [sym_subscript] = ACTIONS(834),
+    [sym_active_char] = ACTIONS(834),
+    [sym_text] = ACTIONS(834),
+  },
+  [332] = {
+    [sym_text_group_at] = STATE(344),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(582),
+    [sym__end_of_line] = ACTIONS(836),
+  },
+  [333] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(836),
+  },
+  [334] = {
+    [anon_sym_LBRACK] = ACTIONS(838),
+    [anon_sym_RBRACK] = ACTIONS(838),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(838),
+    [sym_begin_group] = ACTIONS(838),
+    [sym_end_group] = ACTIONS(838),
+    [sym_math_shift] = ACTIONS(838),
+    [sym_alignment_tab] = ACTIONS(838),
+    [sym_parameter_char] = ACTIONS(838),
+    [sym_superscript] = ACTIONS(838),
+    [sym_subscript] = ACTIONS(838),
+    [sym_active_char] = ACTIONS(838),
+    [sym_text] = ACTIONS(838),
+  },
+  [335] = {
+    [sym__whitespace] = ACTIONS(789),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym_begin_group] = ACTIONS(789),
+    [sym__end_of_line] = ACTIONS(789),
+  },
+  [336] = {
+    [anon_sym_LBRACK] = ACTIONS(840),
+    [anon_sym_RBRACK] = ACTIONS(840),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(840),
+    [sym_begin_group] = ACTIONS(840),
+    [sym_end_group] = ACTIONS(840),
+    [sym_math_shift] = ACTIONS(840),
+    [sym_alignment_tab] = ACTIONS(840),
+    [sym_parameter_char] = ACTIONS(840),
+    [sym_superscript] = ACTIONS(840),
+    [sym_subscript] = ACTIONS(840),
+    [sym_active_char] = ACTIONS(840),
+    [sym_text] = ACTIONS(840),
+  },
+  [337] = {
+    [ts_builtin_sym_end] = ACTIONS(682),
+    [anon_sym_LBRACK] = ACTIONS(682),
+    [anon_sym_RBRACK] = ACTIONS(682),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(682),
+    [sym_begin_group] = ACTIONS(682),
+    [sym_end_group] = ACTIONS(682),
+    [sym_math_shift] = ACTIONS(682),
+    [sym_alignment_tab] = ACTIONS(682),
+    [sym_parameter_char] = ACTIONS(682),
+    [sym_superscript] = ACTIONS(682),
+    [sym_subscript] = ACTIONS(682),
+    [sym_active_char] = ACTIONS(682),
+    [sym_text] = ACTIONS(682),
+  },
+  [338] = {
+    [anon_sym_LBRACK] = ACTIONS(842),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(842),
+    [sym_begin_group] = ACTIONS(842),
+    [sym_alignment_tab] = ACTIONS(842),
+    [sym_parameter_char] = ACTIONS(842),
+    [sym_superscript] = ACTIONS(842),
+    [sym_subscript] = ACTIONS(842),
+    [sym_active_char] = ACTIONS(842),
+    [sym_text] = ACTIONS(842),
+  },
+  [339] = {
+    [aux_sym_SLASH_DOT_SLASH] = ACTIONS(844),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(846),
+    [sym__end_of_line] = ACTIONS(846),
+  },
+  [340] = {
+    [anon_sym_LBRACK] = ACTIONS(848),
+    [anon_sym_RBRACK] = ACTIONS(848),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(848),
+    [sym_begin_group] = ACTIONS(848),
+    [sym_end_group] = ACTIONS(848),
+    [sym_math_shift] = ACTIONS(848),
+    [sym_alignment_tab] = ACTIONS(848),
+    [sym_parameter_char] = ACTIONS(848),
+    [sym_superscript] = ACTIONS(848),
+    [sym_subscript] = ACTIONS(848),
+    [sym_active_char] = ACTIONS(848),
+    [sym_text] = ACTIONS(848),
+  },
+  [341] = {
+    [anon_sym_LBRACK] = ACTIONS(850),
+    [anon_sym_RBRACK] = ACTIONS(850),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(850),
+    [sym_begin_group] = ACTIONS(850),
+    [sym_end_group] = ACTIONS(850),
+    [sym_math_shift] = ACTIONS(850),
+    [sym_alignment_tab] = ACTIONS(850),
+    [sym_parameter_char] = ACTIONS(850),
+    [sym_superscript] = ACTIONS(850),
+    [sym_subscript] = ACTIONS(850),
+    [sym_active_char] = ACTIONS(850),
+    [sym_text] = ACTIONS(850),
+  },
+  [342] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(716),
+  },
+  [343] = {
+    [anon_sym_LBRACK] = ACTIONS(852),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(852),
+    [sym_begin_group] = ACTIONS(852),
+    [sym_alignment_tab] = ACTIONS(852),
+    [sym_parameter_char] = ACTIONS(852),
+    [sym_superscript] = ACTIONS(852),
+    [sym_subscript] = ACTIONS(852),
+    [sym_active_char] = ACTIONS(852),
+    [sym_text] = ACTIONS(852),
+  },
+  [344] = {
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__end_of_line] = ACTIONS(854),
+  },
+  [345] = {
+    [anon_sym_LBRACK] = ACTIONS(856),
+    [sym_magic_comment] = ACTIONS(9),
+    [sym_comment] = ACTIONS(11),
+    [sym__escape] = ACTIONS(856),
+    [sym_begin_group] = ACTIONS(856),
+    [sym_alignment_tab] = ACTIONS(856),
+    [sym_parameter_char] = ACTIONS(856),
+    [sym_superscript] = ACTIONS(856),
+    [sym_subscript] = ACTIONS(856),
+    [sym_active_char] = ACTIONS(856),
+    [sym_text] = ACTIONS(856),
   },
 };
 
@@ -11724,338 +12538,406 @@ static TSParseActionEntry ts_parse_actions[] = {
   [13] = {.count = 1, .reusable = true}, SHIFT(3),
   [15] = {.count = 1, .reusable = true}, SHIFT(4),
   [17] = {.count = 1, .reusable = true}, SHIFT(5),
-  [19] = {.count = 1, .reusable = true}, SHIFT(30),
-  [21] = {.count = 1, .reusable = true}, SHIFT(31),
+  [19] = {.count = 1, .reusable = true}, SHIFT(31),
+  [21] = {.count = 1, .reusable = true}, SHIFT(32),
   [23] = {.count = 1, .reusable = true}, SHIFT(6),
   [25] = {.count = 1, .reusable = true}, REDUCE(sym_begin_opt, 1),
-  [27] = {.count = 1, .reusable = false}, SHIFT(32),
-  [29] = {.count = 1, .reusable = true}, SHIFT(33),
-  [31] = {.count = 1, .reusable = true}, SHIFT(34),
-  [33] = {.count = 1, .reusable = false}, SHIFT(35),
-  [35] = {.count = 1, .reusable = false}, SHIFT(36),
-  [37] = {.count = 1, .reusable = false}, SHIFT(37),
-  [39] = {.count = 1, .reusable = false}, SHIFT(38),
-  [41] = {.count = 1, .reusable = false}, SHIFT(39),
-  [43] = {.count = 1, .reusable = false}, SHIFT(40),
-  [45] = {.count = 1, .reusable = false}, SHIFT(41),
-  [47] = {.count = 1, .reusable = true}, SHIFT(42),
-  [49] = {.count = 1, .reusable = false}, SHIFT(43),
-  [51] = {.count = 1, .reusable = false}, SHIFT(44),
-  [53] = {.count = 1, .reusable = false}, SHIFT(45),
-  [55] = {.count = 1, .reusable = false}, SHIFT(46),
-  [57] = {.count = 1, .reusable = false}, SHIFT(47),
-  [59] = {.count = 1, .reusable = false}, SHIFT(48),
-  [61] = {.count = 1, .reusable = true}, SHIFT(49),
-  [63] = {.count = 1, .reusable = true}, SHIFT(50),
-  [65] = {.count = 1, .reusable = true}, SHIFT(51),
-  [67] = {.count = 1, .reusable = true}, SHIFT(52),
-  [69] = {.count = 1, .reusable = true}, SHIFT(53),
-  [71] = {.count = 1, .reusable = true}, SHIFT(59),
-  [73] = {.count = 1, .reusable = true}, REDUCE(sym__text_mode_common, 1, .alias_sequence_id = 1),
-  [75] = {.count = 1, .reusable = true}, ACCEPT_INPUT(),
-  [77] = {.count = 1, .reusable = true}, SHIFT(60),
-  [79] = {.count = 1, .reusable = true}, REDUCE(sym_document, 1),
-  [81] = {.count = 1, .reusable = true}, SHIFT(62),
-  [83] = {.count = 1, .reusable = false}, SHIFT(70),
-  [85] = {.count = 1, .reusable = true}, SHIFT(66),
-  [87] = {.count = 1, .reusable = true}, SHIFT(71),
-  [89] = {.count = 1, .reusable = true}, SHIFT(72),
-  [91] = {.count = 1, .reusable = true}, SHIFT(75),
-  [93] = {.count = 1, .reusable = true}, SHIFT(76),
-  [95] = {.count = 1, .reusable = true}, SHIFT(81),
-  [97] = {.count = 1, .reusable = true}, REDUCE(sym_storage, 1),
-  [99] = {.count = 1, .reusable = true}, SHIFT(89),
-  [101] = {.count = 1, .reusable = true}, SHIFT(95),
-  [103] = {.count = 1, .reusable = true}, SHIFT(96),
-  [105] = {.count = 1, .reusable = true}, SHIFT(97),
-  [107] = {.count = 1, .reusable = true}, SHIFT(114),
-  [109] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter, 1),
-  [111] = {.count = 1, .reusable = true}, SHIFT(115),
-  [113] = {.count = 1, .reusable = true}, SHIFT(117),
-  [115] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode, 1),
-  [117] = {.count = 1, .reusable = true}, SHIFT(118),
-  [119] = {.count = 1, .reusable = true}, SHIFT(120),
-  [121] = {.count = 1, .reusable = true}, SHIFT(119),
-  [123] = {.count = 1, .reusable = true}, REDUCE(sym_verb_token, 2),
-  [125] = {.count = 1, .reusable = true}, SHIFT(122),
-  [127] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 2),
-  [129] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 2),
-  [131] = {.count = 1, .reusable = true}, REDUCE(sym_escaped, 2),
-  [133] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 2),
-  [135] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 2),
-  [137] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 2),
-  [139] = {.count = 1, .reusable = true}, REDUCE(sym_include_token, 2),
-  [141] = {.count = 1, .reusable = true}, REDUCE(sym_section_token, 2),
-  [143] = {.count = 1, .reusable = true}, REDUCE(sym_storage_token, 2),
-  [145] = {.count = 1, .reusable = true}, REDUCE(sym_catcode_token, 2),
-  [147] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 2),
-  [149] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 2),
-  [151] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 2),
-  [153] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 2),
-  [155] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 2),
-  [157] = {.count = 1, .reusable = true}, REDUCE(sym_token, 2),
-  [159] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 2),
-  [161] = {.count = 1, .reusable = true}, SHIFT(123),
-  [163] = {.count = 1, .reusable = true}, SHIFT(124),
-  [165] = {.count = 1, .reusable = false}, SHIFT(125),
-  [167] = {.count = 1, .reusable = true}, SHIFT(126),
-  [169] = {.count = 1, .reusable = true}, SHIFT(127),
-  [171] = {.count = 1, .reusable = true}, SHIFT(129),
-  [173] = {.count = 1, .reusable = true}, SHIFT(130),
-  [175] = {.count = 1, .reusable = true}, SHIFT(132),
-  [177] = {.count = 1, .reusable = true}, SHIFT(134),
-  [179] = {.count = 1, .reusable = true}, SHIFT(136),
-  [181] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode, 1),
-  [183] = {.count = 1, .reusable = true}, SHIFT(137),
-  [185] = {.count = 1, .reusable = true}, SHIFT(138),
-  [187] = {.count = 1, .reusable = true}, SHIFT(139),
-  [189] = {.count = 1, .reusable = true}, SHIFT(141),
-  [191] = {.count = 1, .reusable = true}, SHIFT(142),
-  [193] = {.count = 1, .reusable = true}, SHIFT(148),
-  [195] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 2),
-  [197] = {.count = 1, .reusable = true}, SHIFT(150),
-  [199] = {.count = 1, .reusable = false}, SHIFT(153),
-  [201] = {.count = 1, .reusable = true}, SHIFT(152),
-  [203] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_text, 1),
-  [205] = {.count = 1, .reusable = true}, SHIFT(154),
-  [207] = {.count = 1, .reusable = false}, SHIFT(148),
-  [209] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 2),
-  [211] = {.count = 1, .reusable = true}, SHIFT(157),
-  [213] = {.count = 1, .reusable = false}, SHIFT(158),
-  [215] = {.count = 1, .reusable = false}, SHIFT(159),
-  [217] = {.count = 1, .reusable = false}, SHIFT(160),
-  [219] = {.count = 1, .reusable = false}, SHIFT(161),
-  [221] = {.count = 1, .reusable = true}, SHIFT(162),
-  [223] = {.count = 1, .reusable = true}, SHIFT(163),
-  [225] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_begin, 2),
-  [227] = {.count = 1, .reusable = true}, SHIFT(167),
-  [229] = {.count = 1, .reusable = true}, REDUCE(sym_begin, 2, .alias_sequence_id = 2),
-  [231] = {.count = 1, .reusable = true}, SHIFT(161),
-  [233] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 2, .alias_sequence_id = 3),
-  [235] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 2, .alias_sequence_id = 4),
-  [237] = {.count = 1, .reusable = true}, REDUCE(sym_include, 2),
-  [239] = {.count = 1, .reusable = true}, REDUCE(sym_section, 2),
-  [241] = {.count = 1, .reusable = false}, SHIFT(173),
-  [243] = {.count = 1, .reusable = true}, SHIFT(174),
-  [245] = {.count = 1, .reusable = true}, REDUCE(sym_emph, 2),
-  [247] = {.count = 1, .reusable = true}, REDUCE(sym_textbf, 2),
-  [249] = {.count = 1, .reusable = true}, REDUCE(sym_textit, 2),
-  [251] = {.count = 1, .reusable = true}, REDUCE(sym_texttt, 2),
-  [253] = {.count = 1, .reusable = false}, SHIFT(175),
-  [255] = {.count = 1, .reusable = false}, SHIFT(176),
-  [257] = {.count = 1, .reusable = true}, SHIFT(177),
-  [259] = {.count = 1, .reusable = true}, SHIFT(178),
-  [261] = {.count = 1, .reusable = true}, SHIFT(179),
-  [263] = {.count = 1, .reusable = true}, SHIFT(180),
-  [265] = {.count = 1, .reusable = true}, SHIFT(181),
-  [267] = {.count = 1, .reusable = true}, SHIFT(182),
-  [269] = {.count = 1, .reusable = true}, SHIFT(187),
-  [271] = {.count = 1, .reusable = true}, SHIFT(188),
-  [273] = {.count = 1, .reusable = true}, SHIFT(191),
-  [275] = {.count = 1, .reusable = true}, SHIFT(195),
-  [277] = {.count = 1, .reusable = true}, SHIFT(197),
-  [279] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 2),
-  [281] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother, 1),
-  [283] = {.count = 1, .reusable = true}, SHIFT(207),
-  [285] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at, 1),
-  [287] = {.count = 1, .reusable = true}, SHIFT(208),
-  [289] = {.count = 1, .reusable = true}, REDUCE(sym_end_opt, 1),
-  [291] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 2),
-  [293] = {.count = 1, .reusable = true}, SHIFT(210),
-  [295] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2),
-  [297] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(2),
-  [300] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(3),
-  [303] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(4),
-  [306] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(5),
-  [309] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(118),
-  [312] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(31),
-  [315] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(6),
-  [318] = {.count = 1, .reusable = true}, REDUCE(sym_parameter, 2),
-  [320] = {.count = 2, .reusable = true}, REDUCE(aux_sym_parameter_repeat1, 2), SHIFT_REPEAT(120),
-  [323] = {.count = 1, .reusable = true}, REDUCE(aux_sym_parameter_repeat1, 2),
-  [325] = {.count = 1, .reusable = true}, REDUCE(sym_verb_token, 3),
-  [327] = {.count = 1, .reusable = true}, REDUCE(sym__whitespace, 1),
-  [329] = {.count = 1, .reusable = true}, SHIFT(211),
-  [331] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 3),
-  [333] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(124),
-  [336] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 2),
-  [338] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 2),
-  [340] = {.count = 1, .reusable = true}, SHIFT(212),
-  [342] = {.count = 1, .reusable = true}, SHIFT(213),
-  [344] = {.count = 1, .reusable = true}, SHIFT(214),
-  [346] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math, 3),
-  [348] = {.count = 1, .reusable = true}, SHIFT(215),
-  [350] = {.count = 1, .reusable = true}, SHIFT(217),
-  [352] = {.count = 1, .reusable = true}, REDUCE(sym_tag, 2),
-  [354] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 2),
-  [356] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 2),
-  [358] = {.count = 1, .reusable = true}, SHIFT(220),
-  [360] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(2),
-  [363] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(51),
-  [366] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(52),
-  [369] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2),
-  [371] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(137),
-  [374] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(31),
-  [377] = {.count = 1, .reusable = true}, SHIFT(221),
-  [379] = {.count = 1, .reusable = true}, SHIFT(222),
-  [381] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math, 3),
-  [383] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(141),
-  [386] = {.count = 1, .reusable = true}, SHIFT(223),
-  [388] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math, 3),
-  [390] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env, 3),
-  [392] = {.count = 1, .reusable = true}, SHIFT(224),
-  [394] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env, 3),
-  [396] = {.count = 1, .reusable = true}, SHIFT(226),
-  [398] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 2),
-  [400] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 3),
-  [402] = {.count = 1, .reusable = true}, SHIFT(228),
-  [404] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_end, 2),
-  [406] = {.count = 1, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
-  [408] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
-  [410] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat1, 2), SHIFT_REPEAT(153),
-  [413] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat1, 2),
-  [415] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(70),
-  [418] = {.count = 2, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(154),
-  [421] = {.count = 1, .reusable = true}, REDUCE(sym_end, 2, .alias_sequence_id = 2),
-  [423] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 3),
-  [425] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(157),
-  [428] = {.count = 1, .reusable = true}, SHIFT(229),
-  [430] = {.count = 1, .reusable = true}, SHIFT(230),
-  [432] = {.count = 1, .reusable = true}, SHIFT(231),
-  [434] = {.count = 1, .reusable = true}, SHIFT(232),
-  [436] = {.count = 1, .reusable = true}, SHIFT(233),
-  [438] = {.count = 1, .reusable = true}, SHIFT(234),
-  [440] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 3),
-  [442] = {.count = 1, .reusable = true}, SHIFT(235),
-  [444] = {.count = 1, .reusable = true}, SHIFT(237),
-  [446] = {.count = 1, .reusable = true}, SHIFT(239),
-  [448] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 3),
-  [450] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 3),
-  [452] = {.count = 1, .reusable = true}, SHIFT(240),
-  [454] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 3, .alias_sequence_id = 5),
-  [456] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 3, .alias_sequence_id = 6),
-  [458] = {.count = 1, .reusable = true}, REDUCE(sym_section, 3),
-  [460] = {.count = 1, .reusable = true}, SHIFT(242),
-  [462] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 2),
-  [464] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 2),
-  [466] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 2),
-  [468] = {.count = 1, .reusable = true}, SHIFT(243),
-  [470] = {.count = 1, .reusable = true}, SHIFT(244),
-  [472] = {.count = 1, .reusable = true}, SHIFT(245),
-  [474] = {.count = 1, .reusable = true}, SHIFT(246),
-  [476] = {.count = 1, .reusable = true}, SHIFT(248),
-  [478] = {.count = 1, .reusable = true}, SHIFT(249),
-  [480] = {.count = 1, .reusable = true}, SHIFT(251),
-  [482] = {.count = 1, .reusable = true}, SHIFT(253),
-  [484] = {.count = 1, .reusable = true}, SHIFT(255),
-  [486] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode_at, 1),
-  [488] = {.count = 1, .reusable = true}, SHIFT(256),
-  [490] = {.count = 1, .reusable = true}, SHIFT(175),
-  [492] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 3),
-  [494] = {.count = 1, .reusable = true}, SHIFT(258),
-  [496] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 2),
-  [498] = {.count = 1, .reusable = true}, SHIFT(263),
-  [500] = {.count = 1, .reusable = true}, SHIFT(264),
-  [502] = {.count = 1, .reusable = true}, REDUCE(sym_include_at, 2),
-  [504] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 2),
-  [506] = {.count = 1, .reusable = true}, REDUCE(sym_emph_at, 2),
-  [508] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_at, 2),
-  [510] = {.count = 1, .reusable = true}, REDUCE(sym_textit_at, 2),
-  [512] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_at, 2),
-  [514] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 2),
-  [516] = {.count = 1, .reusable = true}, SHIFT(270),
-  [518] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(2),
-  [521] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(177),
-  [524] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(96),
-  [527] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(97),
-  [530] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(208),
-  [533] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(31),
-  [536] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(6),
-  [539] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 3),
-  [541] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(210),
-  [544] = {.count = 1, .reusable = true}, REDUCE(aux_sym__whitespace_repeat1, 2),
-  [546] = {.count = 2, .reusable = true}, REDUCE(aux_sym__whitespace_repeat1, 2), SHIFT_REPEAT(211),
-  [549] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 3),
-  [551] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(213),
-  [554] = {.count = 1, .reusable = true}, SHIFT(271),
-  [556] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 2),
-  [558] = {.count = 1, .reusable = true}, SHIFT(272),
-  [560] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 3),
-  [562] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 3),
-  [564] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(220),
-  [567] = {.count = 1, .reusable = true}, REDUCE(sym_inline_verbatim, 4),
-  [569] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 2),
-  [571] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 2),
-  [573] = {.count = 1, .reusable = true}, SHIFT(273),
-  [575] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_end, 2),
-  [577] = {.count = 1, .reusable = true}, SHIFT(159),
-  [579] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_end, 2),
-  [581] = {.count = 1, .reusable = true}, SHIFT(274),
-  [583] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_group, 3),
-  [585] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_group, 3),
-  [587] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env_group, 3),
-  [589] = {.count = 1, .reusable = true}, REDUCE(sym_simple_text_group, 3),
-  [591] = {.count = 1, .reusable = true}, SHIFT(275),
-  [593] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 4),
-  [595] = {.count = 1, .reusable = true}, SHIFT(276),
-  [597] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 4),
-  [599] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 4),
-  [601] = {.count = 1, .reusable = true}, SHIFT(278),
-  [603] = {.count = 1, .reusable = true}, REDUCE(sym_catcode, 4),
-  [605] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 3),
-  [607] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2),
-  [609] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(244),
-  [612] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 2),
-  [614] = {.count = 1, .reusable = true}, SHIFT(279),
-  [616] = {.count = 1, .reusable = true}, SHIFT(280),
-  [618] = {.count = 1, .reusable = true}, SHIFT(281),
-  [620] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math_at, 3),
-  [622] = {.count = 1, .reusable = true}, SHIFT(282),
-  [624] = {.count = 1, .reusable = true}, SHIFT(284),
-  [626] = {.count = 1, .reusable = true}, REDUCE(sym_tag_at, 2),
-  [628] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 2),
-  [630] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 2),
-  [632] = {.count = 1, .reusable = true}, SHIFT(287),
-  [634] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(2),
-  [637] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(180),
-  [640] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(181),
-  [643] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2),
-  [645] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(256),
-  [648] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(31),
-  [651] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math_at, 3),
-  [653] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(258),
-  [656] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math_at, 3),
-  [658] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_at, 3),
-  [660] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_at, 3),
-  [662] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 3),
-  [664] = {.count = 1, .reusable = true}, SHIFT(288),
-  [666] = {.count = 1, .reusable = true}, SHIFT(289),
-  [668] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 3),
-  [670] = {.count = 1, .reusable = true}, SHIFT(290),
-  [672] = {.count = 1, .reusable = true}, SHIFT(293),
-  [674] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 3),
-  [676] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 3),
-  [678] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(270),
-  [681] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math, 5),
-  [683] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 3),
-  [685] = {.count = 1, .reusable = true}, SHIFT(294),
-  [687] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 5),
-  [689] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 5),
-  [691] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 5),
-  [693] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 3),
-  [695] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(280),
-  [698] = {.count = 1, .reusable = true}, SHIFT(295),
-  [700] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 2),
-  [702] = {.count = 1, .reusable = true}, SHIFT(296),
-  [704] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 3),
-  [706] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 3),
-  [708] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(287),
-  [711] = {.count = 1, .reusable = true}, SHIFT(297),
-  [713] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 4),
-  [715] = {.count = 1, .reusable = true}, SHIFT(298),
-  [717] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math_at, 5),
-  [719] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 3),
-  [721] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 5),
+  [27] = {.count = 1, .reusable = false}, SHIFT(33),
+  [29] = {.count = 1, .reusable = true}, SHIFT(34),
+  [31] = {.count = 1, .reusable = true}, SHIFT(35),
+  [33] = {.count = 1, .reusable = false}, SHIFT(36),
+  [35] = {.count = 1, .reusable = false}, SHIFT(37),
+  [37] = {.count = 1, .reusable = false}, SHIFT(38),
+  [39] = {.count = 1, .reusable = false}, SHIFT(39),
+  [41] = {.count = 1, .reusable = false}, SHIFT(40),
+  [43] = {.count = 1, .reusable = false}, SHIFT(41),
+  [45] = {.count = 1, .reusable = false}, SHIFT(42),
+  [47] = {.count = 1, .reusable = true}, SHIFT(43),
+  [49] = {.count = 1, .reusable = false}, SHIFT(44),
+  [51] = {.count = 1, .reusable = false}, SHIFT(45),
+  [53] = {.count = 1, .reusable = false}, SHIFT(46),
+  [55] = {.count = 1, .reusable = false}, SHIFT(47),
+  [57] = {.count = 1, .reusable = false}, SHIFT(48),
+  [59] = {.count = 1, .reusable = false}, SHIFT(49),
+  [61] = {.count = 1, .reusable = false}, SHIFT(50),
+  [63] = {.count = 1, .reusable = true}, SHIFT(51),
+  [65] = {.count = 1, .reusable = true}, SHIFT(52),
+  [67] = {.count = 1, .reusable = true}, SHIFT(53),
+  [69] = {.count = 1, .reusable = true}, SHIFT(54),
+  [71] = {.count = 1, .reusable = true}, SHIFT(55),
+  [73] = {.count = 1, .reusable = true}, SHIFT(61),
+  [75] = {.count = 1, .reusable = true}, REDUCE(sym__text_mode_common, 1, .alias_sequence_id = 1),
+  [77] = {.count = 1, .reusable = true}, ACCEPT_INPUT(),
+  [79] = {.count = 1, .reusable = true}, SHIFT(62),
+  [81] = {.count = 1, .reusable = true}, REDUCE(sym_document, 1),
+  [83] = {.count = 1, .reusable = true}, SHIFT(64),
+  [85] = {.count = 1, .reusable = false}, SHIFT(72),
+  [87] = {.count = 1, .reusable = true}, SHIFT(68),
+  [89] = {.count = 1, .reusable = true}, SHIFT(73),
+  [91] = {.count = 1, .reusable = true}, SHIFT(74),
+  [93] = {.count = 1, .reusable = true}, SHIFT(77),
+  [95] = {.count = 1, .reusable = true}, SHIFT(78),
+  [97] = {.count = 1, .reusable = true}, SHIFT(83),
+  [99] = {.count = 1, .reusable = true}, REDUCE(sym_storage, 1),
+  [101] = {.count = 1, .reusable = true}, SHIFT(92),
+  [103] = {.count = 1, .reusable = true}, SHIFT(100),
+  [105] = {.count = 1, .reusable = true}, SHIFT(101),
+  [107] = {.count = 1, .reusable = true}, SHIFT(102),
+  [109] = {.count = 1, .reusable = true}, SHIFT(120),
+  [111] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter, 1),
+  [113] = {.count = 1, .reusable = true}, SHIFT(121),
+  [115] = {.count = 1, .reusable = true}, SHIFT(123),
+  [117] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode, 1),
+  [119] = {.count = 1, .reusable = true}, SHIFT(124),
+  [121] = {.count = 1, .reusable = true}, SHIFT(126),
+  [123] = {.count = 1, .reusable = true}, SHIFT(125),
+  [125] = {.count = 1, .reusable = true}, REDUCE(sym_verb_token, 2),
+  [127] = {.count = 1, .reusable = true}, SHIFT(127),
+  [129] = {.count = 1, .reusable = false}, SHIFT(128),
+  [131] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 2),
+  [133] = {.count = 1, .reusable = false}, REDUCE(sym_begin_display_math, 2),
+  [135] = {.count = 1, .reusable = false}, SHIFT(129),
+  [137] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 2),
+  [139] = {.count = 1, .reusable = false}, REDUCE(sym_begin_inline_math, 2),
+  [141] = {.count = 1, .reusable = true}, REDUCE(sym_escaped, 2),
+  [143] = {.count = 1, .reusable = true}, SHIFT(130),
+  [145] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 2),
+  [147] = {.count = 1, .reusable = true}, SHIFT(131),
+  [149] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 2),
+  [151] = {.count = 1, .reusable = true}, SHIFT(132),
+  [153] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 2),
+  [155] = {.count = 1, .reusable = true}, REDUCE(sym_include_token, 2),
+  [157] = {.count = 1, .reusable = true}, REDUCE(sym_section_token, 2),
+  [159] = {.count = 1, .reusable = true}, REDUCE(sym_storage_token, 2),
+  [161] = {.count = 1, .reusable = true}, REDUCE(sym_catcode_token, 2),
+  [163] = {.count = 1, .reusable = true}, SHIFT(133),
+  [165] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 2),
+  [167] = {.count = 1, .reusable = true}, SHIFT(134),
+  [169] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_token, 2),
+  [171] = {.count = 1, .reusable = true}, SHIFT(135),
+  [173] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 2),
+  [175] = {.count = 1, .reusable = true}, SHIFT(136),
+  [177] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 2),
+  [179] = {.count = 1, .reusable = true}, SHIFT(137),
+  [181] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 2),
+  [183] = {.count = 1, .reusable = false}, SHIFT(138),
+  [185] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 2),
+  [187] = {.count = 1, .reusable = false}, REDUCE(sym_makeatletter_token, 2),
+  [189] = {.count = 1, .reusable = true}, REDUCE(sym_token, 2),
+  [191] = {.count = 1, .reusable = false}, SHIFT(139),
+  [193] = {.count = 1, .reusable = false}, REDUCE(sym_token, 2),
+  [195] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 2),
+  [197] = {.count = 1, .reusable = true}, SHIFT(140),
+  [199] = {.count = 1, .reusable = true}, SHIFT(141),
+  [201] = {.count = 1, .reusable = false}, SHIFT(142),
+  [203] = {.count = 1, .reusable = true}, SHIFT(143),
+  [205] = {.count = 1, .reusable = true}, SHIFT(144),
+  [207] = {.count = 1, .reusable = true}, SHIFT(146),
+  [209] = {.count = 1, .reusable = true}, SHIFT(147),
+  [211] = {.count = 1, .reusable = true}, SHIFT(149),
+  [213] = {.count = 1, .reusable = true}, SHIFT(151),
+  [215] = {.count = 1, .reusable = true}, SHIFT(153),
+  [217] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode, 1),
+  [219] = {.count = 1, .reusable = true}, SHIFT(154),
+  [221] = {.count = 1, .reusable = true}, SHIFT(155),
+  [223] = {.count = 1, .reusable = true}, SHIFT(156),
+  [225] = {.count = 1, .reusable = true}, SHIFT(158),
+  [227] = {.count = 1, .reusable = true}, SHIFT(159),
+  [229] = {.count = 1, .reusable = true}, SHIFT(165),
+  [231] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 2),
+  [233] = {.count = 1, .reusable = true}, SHIFT(167),
+  [235] = {.count = 1, .reusable = false}, SHIFT(170),
+  [237] = {.count = 1, .reusable = true}, SHIFT(169),
+  [239] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_text, 1),
+  [241] = {.count = 1, .reusable = true}, SHIFT(171),
+  [243] = {.count = 1, .reusable = false}, SHIFT(165),
+  [245] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 2),
+  [247] = {.count = 1, .reusable = true}, SHIFT(174),
+  [249] = {.count = 1, .reusable = false}, SHIFT(175),
+  [251] = {.count = 1, .reusable = false}, SHIFT(176),
+  [253] = {.count = 1, .reusable = false}, SHIFT(177),
+  [255] = {.count = 1, .reusable = false}, SHIFT(178),
+  [257] = {.count = 1, .reusable = true}, SHIFT(179),
+  [259] = {.count = 1, .reusable = true}, SHIFT(180),
+  [261] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_begin, 2),
+  [263] = {.count = 1, .reusable = true}, SHIFT(183),
+  [265] = {.count = 1, .reusable = true}, REDUCE(sym_begin, 2, .alias_sequence_id = 2),
+  [267] = {.count = 1, .reusable = true}, SHIFT(178),
+  [269] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 2, .alias_sequence_id = 3),
+  [271] = {.count = 1, .reusable = true}, SHIFT(186),
+  [273] = {.count = 1, .reusable = true}, SHIFT(188),
+  [275] = {.count = 1, .reusable = true}, SHIFT(190),
+  [277] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 2, .alias_sequence_id = 4),
+  [279] = {.count = 1, .reusable = true}, SHIFT(191),
+  [281] = {.count = 1, .reusable = true}, REDUCE(sym_include, 2),
+  [283] = {.count = 1, .reusable = true}, REDUCE(sym_section, 2),
+  [285] = {.count = 1, .reusable = true}, SHIFT(193),
+  [287] = {.count = 1, .reusable = false}, SHIFT(195),
+  [289] = {.count = 1, .reusable = true}, SHIFT(196),
+  [291] = {.count = 1, .reusable = true}, REDUCE(sym_emph, 2),
+  [293] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 2),
+  [295] = {.count = 1, .reusable = true}, SHIFT(197),
+  [297] = {.count = 1, .reusable = true}, REDUCE(sym_textbf, 2),
+  [299] = {.count = 1, .reusable = true}, REDUCE(sym_textit, 2),
+  [301] = {.count = 1, .reusable = true}, REDUCE(sym_texttt, 2),
+  [303] = {.count = 1, .reusable = false}, SHIFT(199),
+  [305] = {.count = 1, .reusable = false}, SHIFT(200),
+  [307] = {.count = 1, .reusable = true}, SHIFT(201),
+  [309] = {.count = 1, .reusable = true}, SHIFT(202),
+  [311] = {.count = 1, .reusable = true}, SHIFT(203),
+  [313] = {.count = 1, .reusable = true}, SHIFT(204),
+  [315] = {.count = 1, .reusable = true}, SHIFT(205),
+  [317] = {.count = 1, .reusable = true}, SHIFT(206),
+  [319] = {.count = 1, .reusable = true}, SHIFT(211),
+  [321] = {.count = 1, .reusable = true}, SHIFT(212),
+  [323] = {.count = 1, .reusable = true}, SHIFT(215),
+  [325] = {.count = 1, .reusable = true}, SHIFT(219),
+  [327] = {.count = 1, .reusable = true}, SHIFT(221),
+  [329] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 2),
+  [331] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother, 1),
+  [333] = {.count = 1, .reusable = true}, SHIFT(234),
+  [335] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at, 1),
+  [337] = {.count = 1, .reusable = true}, SHIFT(235),
+  [339] = {.count = 1, .reusable = true}, REDUCE(sym_end_opt, 1),
+  [341] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 2),
+  [343] = {.count = 1, .reusable = true}, SHIFT(237),
+  [345] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2),
+  [347] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(2),
+  [350] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(3),
+  [353] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(4),
+  [356] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(5),
+  [359] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(124),
+  [362] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(32),
+  [365] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(6),
+  [368] = {.count = 1, .reusable = true}, REDUCE(sym_parameter, 2),
+  [370] = {.count = 2, .reusable = true}, REDUCE(aux_sym_parameter_repeat1, 2), SHIFT_REPEAT(126),
+  [373] = {.count = 1, .reusable = true}, REDUCE(aux_sym_parameter_repeat1, 2),
+  [375] = {.count = 1, .reusable = true}, REDUCE(sym_verb_token, 3),
+  [377] = {.count = 1, .reusable = true}, REDUCE(sym_begin_display_math, 3),
+  [379] = {.count = 1, .reusable = true}, REDUCE(sym_begin_inline_math, 3),
+  [381] = {.count = 1, .reusable = true}, REDUCE(sym_begin_token, 3),
+  [383] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass_token, 3),
+  [385] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage_token, 3),
+  [387] = {.count = 1, .reusable = true}, REDUCE(sym_emph_token, 3),
+  [389] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_token, 3),
+  [391] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_token, 3),
+  [393] = {.count = 1, .reusable = true}, REDUCE(sym_textit_token, 3),
+  [395] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_token, 3),
+  [397] = {.count = 1, .reusable = true}, REDUCE(sym_makeatletter_token, 3),
+  [399] = {.count = 1, .reusable = true}, REDUCE(sym_token, 3),
+  [401] = {.count = 1, .reusable = true}, REDUCE(sym_text_group, 3),
+  [403] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(141),
+  [406] = {.count = 1, .reusable = true}, SHIFT(238),
+  [408] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 2),
+  [410] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 2),
+  [412] = {.count = 1, .reusable = true}, SHIFT(239),
+  [414] = {.count = 1, .reusable = true}, SHIFT(240),
+  [416] = {.count = 1, .reusable = true}, SHIFT(241),
+  [418] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math, 3),
+  [420] = {.count = 1, .reusable = true}, SHIFT(242),
+  [422] = {.count = 1, .reusable = true}, SHIFT(244),
+  [424] = {.count = 1, .reusable = true}, REDUCE(sym_tag, 2),
+  [426] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 2),
+  [428] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 2),
+  [430] = {.count = 1, .reusable = true}, SHIFT(247),
+  [432] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(2),
+  [435] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(53),
+  [438] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(54),
+  [441] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2),
+  [443] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(154),
+  [446] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(32),
+  [449] = {.count = 1, .reusable = true}, SHIFT(248),
+  [451] = {.count = 1, .reusable = true}, SHIFT(249),
+  [453] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math, 3),
+  [455] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(158),
+  [458] = {.count = 1, .reusable = true}, SHIFT(250),
+  [460] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math, 3),
+  [462] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env, 3),
+  [464] = {.count = 1, .reusable = true}, SHIFT(251),
+  [466] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env, 3),
+  [468] = {.count = 1, .reusable = true}, SHIFT(253),
+  [470] = {.count = 1, .reusable = true}, SHIFT(255),
+  [472] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 2),
+  [474] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env, 3),
+  [476] = {.count = 1, .reusable = true}, SHIFT(256),
+  [478] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_end, 2),
+  [480] = {.count = 1, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
+  [482] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2),
+  [484] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat1, 2), SHIFT_REPEAT(170),
+  [487] = {.count = 1, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat1, 2),
+  [489] = {.count = 2, .reusable = false}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(72),
+  [492] = {.count = 2, .reusable = true}, REDUCE(aux_sym_verbatim_text_repeat2, 2), SHIFT_REPEAT(171),
+  [495] = {.count = 1, .reusable = true}, REDUCE(sym_end, 2, .alias_sequence_id = 2),
+  [497] = {.count = 1, .reusable = true}, REDUCE(sym_text_env, 3),
+  [499] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(174),
+  [502] = {.count = 1, .reusable = true}, SHIFT(257),
+  [504] = {.count = 1, .reusable = true}, SHIFT(258),
+  [506] = {.count = 1, .reusable = true}, SHIFT(259),
+  [508] = {.count = 1, .reusable = true}, SHIFT(260),
+  [510] = {.count = 1, .reusable = true}, SHIFT(261),
+  [512] = {.count = 1, .reusable = true}, SHIFT(262),
+  [514] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 3),
+  [516] = {.count = 1, .reusable = true}, SHIFT(263),
+  [518] = {.count = 1, .reusable = true}, SHIFT(264),
+  [520] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 3),
+  [522] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 3),
+  [524] = {.count = 1, .reusable = true}, SHIFT(266),
+  [526] = {.count = 1, .reusable = true}, SHIFT(267),
+  [528] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 3, .alias_sequence_id = 5),
+  [530] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 3, .alias_sequence_id = 6),
+  [532] = {.count = 1, .reusable = true}, REDUCE(sym_section, 3),
+  [534] = {.count = 1, .reusable = true}, SHIFT(273),
+  [536] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 3),
+  [538] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 2),
+  [540] = {.count = 1, .reusable = false}, SHIFT(275),
+  [542] = {.count = 1, .reusable = false}, REDUCE(sym_makeatother_token, 2),
+  [544] = {.count = 1, .reusable = false}, SHIFT(276),
+  [546] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 2),
+  [548] = {.count = 1, .reusable = false}, REDUCE(sym_token_at, 2),
+  [550] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 2),
+  [552] = {.count = 1, .reusable = true}, SHIFT(277),
+  [554] = {.count = 1, .reusable = true}, SHIFT(278),
+  [556] = {.count = 1, .reusable = true}, SHIFT(279),
+  [558] = {.count = 1, .reusable = true}, SHIFT(280),
+  [560] = {.count = 1, .reusable = true}, SHIFT(282),
+  [562] = {.count = 1, .reusable = true}, SHIFT(283),
+  [564] = {.count = 1, .reusable = true}, SHIFT(285),
+  [566] = {.count = 1, .reusable = true}, SHIFT(287),
+  [568] = {.count = 1, .reusable = true}, SHIFT(289),
+  [570] = {.count = 1, .reusable = true}, REDUCE(sym_math_mode_at, 1),
+  [572] = {.count = 1, .reusable = true}, SHIFT(290),
+  [574] = {.count = 1, .reusable = true}, SHIFT(199),
+  [576] = {.count = 1, .reusable = true}, REDUCE(sym_text_mode_at_region, 3),
+  [578] = {.count = 1, .reusable = true}, SHIFT(292),
+  [580] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 2),
+  [582] = {.count = 1, .reusable = true}, SHIFT(297),
+  [584] = {.count = 1, .reusable = true}, SHIFT(298),
+  [586] = {.count = 1, .reusable = true}, REDUCE(sym_include_at, 2),
+  [588] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 2),
+  [590] = {.count = 1, .reusable = true}, SHIFT(301),
+  [592] = {.count = 1, .reusable = true}, SHIFT(304),
+  [594] = {.count = 1, .reusable = true}, REDUCE(sym_emph_at, 2),
+  [596] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 2),
+  [598] = {.count = 1, .reusable = true}, SHIFT(305),
+  [600] = {.count = 1, .reusable = true}, REDUCE(sym_textbf_at, 2),
+  [602] = {.count = 1, .reusable = true}, REDUCE(sym_textit_at, 2),
+  [604] = {.count = 1, .reusable = true}, REDUCE(sym_texttt_at, 2),
+  [606] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 2),
+  [608] = {.count = 1, .reusable = true}, SHIFT(308),
+  [610] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(2),
+  [613] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(201),
+  [616] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(101),
+  [619] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(102),
+  [622] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(235),
+  [625] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(32),
+  [628] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(6),
+  [631] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group, 3),
+  [633] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_repeat1, 2), SHIFT_REPEAT(237),
+  [636] = {.count = 1, .reusable = true}, REDUCE(sym_tag_token, 3),
+  [638] = {.count = 1, .reusable = true}, REDUCE(sym_math_group, 3),
+  [640] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(240),
+  [643] = {.count = 1, .reusable = true}, SHIFT(309),
+  [645] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 2),
+  [647] = {.count = 1, .reusable = true}, SHIFT(310),
+  [649] = {.count = 1, .reusable = true}, REDUCE(sym_math_env, 3),
+  [651] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group, 3),
+  [653] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_repeat1, 2), SHIFT_REPEAT(247),
+  [656] = {.count = 1, .reusable = true}, REDUCE(sym_inline_verbatim, 4),
+  [658] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 2),
+  [660] = {.count = 1, .reusable = false}, SHIFT(311),
+  [662] = {.count = 1, .reusable = false}, REDUCE(sym_end_display_math, 2),
+  [664] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 2),
+  [666] = {.count = 1, .reusable = false}, SHIFT(312),
+  [668] = {.count = 1, .reusable = false}, REDUCE(sym_end_inline_math, 2),
+  [670] = {.count = 1, .reusable = true}, SHIFT(313),
+  [672] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_end, 2),
+  [674] = {.count = 1, .reusable = true}, SHIFT(176),
+  [676] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_end, 2),
+  [678] = {.count = 1, .reusable = true}, REDUCE(sym_end_token, 3),
+  [680] = {.count = 1, .reusable = true}, SHIFT(314),
+  [682] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_group, 3),
+  [684] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_group, 3),
+  [686] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_env_group, 3),
+  [688] = {.count = 1, .reusable = true}, REDUCE(sym_simple_text_group, 3),
+  [690] = {.count = 1, .reusable = true}, SHIFT(315),
+  [692] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 4),
+  [694] = {.count = 1, .reusable = true}, SHIFT(316),
+  [696] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 4),
+  [698] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 4),
+  [700] = {.count = 1, .reusable = true}, SHIFT(318),
+  [702] = {.count = 1, .reusable = true}, REDUCE(sym_documentclass, 4, .alias_sequence_id = 7),
+  [704] = {.count = 1, .reusable = true}, REDUCE(sym_usepackage, 4, .alias_sequence_id = 8),
+  [706] = {.count = 1, .reusable = true}, REDUCE(sym_section, 4),
+  [708] = {.count = 1, .reusable = true}, REDUCE(sym_catcode, 4),
+  [710] = {.count = 1, .reusable = true}, REDUCE(sym_footnote, 4),
+  [712] = {.count = 1, .reusable = true}, REDUCE(sym_makeatother_token, 3),
+  [714] = {.count = 1, .reusable = true}, REDUCE(sym_token_at, 3),
+  [716] = {.count = 1, .reusable = true}, REDUCE(sym_text_group_at, 3),
+  [718] = {.count = 1, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2),
+  [720] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(278),
+  [723] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 2),
+  [725] = {.count = 1, .reusable = true}, SHIFT(320),
+  [727] = {.count = 1, .reusable = true}, SHIFT(321),
+  [729] = {.count = 1, .reusable = true}, SHIFT(322),
+  [731] = {.count = 1, .reusable = true}, REDUCE(sym_tex_inline_math_at, 3),
+  [733] = {.count = 1, .reusable = true}, SHIFT(323),
+  [735] = {.count = 1, .reusable = true}, SHIFT(325),
+  [737] = {.count = 1, .reusable = true}, REDUCE(sym_tag_at, 2),
+  [739] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 2),
+  [741] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 2),
+  [743] = {.count = 1, .reusable = true}, SHIFT(328),
+  [745] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(2),
+  [748] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(204),
+  [751] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(205),
+  [754] = {.count = 1, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2),
+  [756] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(290),
+  [759] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(32),
+  [762] = {.count = 1, .reusable = true}, REDUCE(sym_latex_display_math_at, 3),
+  [764] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(292),
+  [767] = {.count = 1, .reusable = true}, REDUCE(sym_latex_inline_math_at, 3),
+  [769] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_env_at, 3),
+  [771] = {.count = 1, .reusable = true}, REDUCE(sym_inline_math_env_at, 3),
+  [773] = {.count = 1, .reusable = true}, REDUCE(sym_text_env_at, 3),
+  [775] = {.count = 1, .reusable = true}, SHIFT(329),
+  [777] = {.count = 1, .reusable = true}, SHIFT(330),
+  [779] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 3),
+  [781] = {.count = 1, .reusable = true}, SHIFT(331),
+  [783] = {.count = 1, .reusable = true}, SHIFT(332),
+  [785] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 3),
+  [787] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 3),
+  [789] = {.count = 1, .reusable = true}, REDUCE(sym_opt_text_group_at, 3),
+  [791] = {.count = 2, .reusable = true}, REDUCE(aux_sym_text_mode_at_repeat1, 2), SHIFT_REPEAT(308),
+  [794] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math, 5),
+  [796] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group, 3),
+  [798] = {.count = 1, .reusable = true}, REDUCE(sym_end_display_math, 3),
+  [800] = {.count = 1, .reusable = true}, REDUCE(sym_end_inline_math, 3),
+  [802] = {.count = 1, .reusable = true}, SHIFT(337),
+  [804] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 5),
+  [806] = {.count = 1, .reusable = true}, SHIFT(338),
+  [808] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 5),
+  [810] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 5),
+  [812] = {.count = 1, .reusable = true}, SHIFT(339),
+  [814] = {.count = 1, .reusable = true}, REDUCE(sym_math_group_at, 3),
+  [816] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(321),
+  [819] = {.count = 1, .reusable = true}, SHIFT(340),
+  [821] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 2),
+  [823] = {.count = 1, .reusable = true}, SHIFT(341),
+  [825] = {.count = 1, .reusable = true}, REDUCE(sym_math_env_at, 3),
+  [827] = {.count = 1, .reusable = true}, REDUCE(sym_opt_math_group_at, 3),
+  [829] = {.count = 2, .reusable = true}, REDUCE(aux_sym_math_mode_at_repeat1, 2), SHIFT_REPEAT(328),
+  [832] = {.count = 1, .reusable = true}, SHIFT(342),
+  [834] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 4),
+  [836] = {.count = 1, .reusable = true}, SHIFT(343),
+  [838] = {.count = 1, .reusable = true}, REDUCE(sym_section_at, 4),
+  [840] = {.count = 1, .reusable = true}, REDUCE(sym_footnote_at, 4),
+  [842] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin, 6),
+  [844] = {.count = 1, .reusable = false}, REDUCE(sym_verbatim_begin, 6),
+  [846] = {.count = 1, .reusable = true}, REDUCE(sym_verbatim_begin, 6),
+  [848] = {.count = 1, .reusable = true}, REDUCE(sym_tex_display_math_at, 5),
+  [850] = {.count = 1, .reusable = true}, REDUCE(sym_math_text_group_at, 3),
+  [852] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 5),
+  [854] = {.count = 1, .reusable = true}, SHIFT(345),
+  [856] = {.count = 1, .reusable = true}, REDUCE(sym_display_math_begin_at, 6),
 };
 
 void *tree_sitter_latex_external_scanner_create();


### PR DESCRIPTION
This PR allows whitespace between command tokens and their arguments; e.g., `\texttt  {foo}`.

To do this, and keep it consistent, I abstracted the common `seq($._escape, 'foo', optional($._whitespace))` into a function `named_command`. So the following are equivalent:
```json
texttt_token: $ => named_command($, 'texttt'),

texttt_token: $ => seq($._escape, 'texttt', optional($._whitespace))
```

I also made a similar one for command options, and synonyms for environment options.

Currently, the `_whitespace` rule looks for just spaces and tabs. I eventually want to make it support any combination of comments, spaces, and newlines, so long as there is no paragraph break. Unfortunately, that's not simple to do.

I also tweaked and enabled the footnotes rule, and added tests for the changes.