### PR TITLE
Fix bug in inline verbatim

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -33,7 +33,7 @@ struct Scanner {
       start_delim = 0;
       return;
     };
-    
+
     start_delim = buffer[0];
   }
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -29,7 +29,11 @@ struct Scanner {
   }
 
   void deserialize(const char *buffer, unsigned length) {
-    if (length == 0) return; // or get a segmentation fault
+    if (length == 0) {
+      start_delim = 0;
+      return;
+    };
+    
     start_delim = buffer[0];
   }
 


### PR DESCRIPTION
It was a weird thing where the `start_delim` value is not initialised correctly, so the very first verbatim command threw an error, but the ones following were fine. Setting the value explicitly when deserialising for the first time seems to have fixed it.

Note `length == 0` represents "junk" data, where the buffer is not actually anything serialised. I'm not sure if this is a bug or feature of TS, but the HTML parser does a similar length check.

Even more weird is that the bug only appears when a different test fails. 