### PR TITLE
Fall back to saved catcodes

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -220,7 +220,13 @@ struct Scanner {
   Category get_catcode(char key) {
     auto it = catcodes.find(key);
 
-    return (it == catcodes.end()) ?
+    if (it != catcodes.end()) {
+      return it->second;
+    }
+
+    it = saved_catcodes.find(key);
+
+    return (it == saved_catcodes.end()) ?
       OTHER_CATEGORY :
       it->second;
   }


### PR DESCRIPTION
If I've understood it right, this should let the `saved_catcodes` do it's job.

Seeing as there are two maps, and the "main" one appears to hold a known set of keys, I think it should be easy to convert it to a switch / array. By this, I'm imagining something like
```cpp
Category catcodes[30] = { FOO, FOO, BAR, ... };

get_catcode(char c) {
  switch (c) {
    case '\\': return catcodes[0];
    case '{': return catcodes[1];
    ...
    default:
     auto it = saved_catcodes.find(c);
     return it->second;
  }
}
```

So we can still change the values of the fixed characters. I also think we can hard code letters as always letters, because 1) I don't think anyone is crazy enough to change that, and 2) if they do change it, what if we don't detect when they reverted it?