### PR TITLE
Minor cleaning

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -91,10 +91,6 @@ module.exports = grammar({
     $.tag_comment,
   ],
 
-  conflicts: $ => [
-    [$._word, $._word]
-  ],
-
   rules: {
     document: $ => repeat($._text_mode),
 

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -848,8 +848,7 @@ struct Scanner {
     return scan_catcode_commands(lexer, valid_symbols);
   }
 
-  bool scan(TSLexer *lexer, const bool *valid_symbols)
-  {
+  bool scan(TSLexer *lexer, const bool *valid_symbols) {
     switch (mode) {
       case CS_MODE:
         return scan_cs_mode(lexer, valid_symbols);


### PR DESCRIPTION
Just a couple of style and redundant code changes (I imagine there was some reason at one point for declaring a rule to conflict with itself...).

Also, I was wondering the reason for
```
Array.prototype.slice.call(arguments, 2))
```
over
```
arguments.slice(2)
```
(and similar with `seq.apply(null, ...)` vs `seq(...)`. 
